### PR TITLE
chore: should get hardware information on launch

### DIFF
--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -15,6 +15,7 @@ import { useDebouncedCallback } from 'use-debounce'
 import useAssistants from '@/hooks/useAssistants'
 import { useGetEngines } from '@/hooks/useEngineManagement'
 import useGetSystemResources from '@/hooks/useGetSystemResources'
+import { useGetHardwareInfo } from '@/hooks/useHardwareManagement'
 import useModels from '@/hooks/useModels'
 import useThreads from '@/hooks/useThreads'
 
@@ -34,6 +35,7 @@ const DataLoader: React.FC = () => {
   const setJanSettingScreen = useSetAtom(janSettingScreenAtom)
   const { getData: loadModels } = useModels()
   const { mutate } = useGetEngines()
+  const { mutate: getHardwareInfo } = useGetHardwareInfo()
 
   useThreads()
   useAssistants()
@@ -42,6 +44,7 @@ const DataLoader: React.FC = () => {
   useEffect(() => {
     // Load data once
     loadModels()
+    getHardwareInfo()
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
   const reloadData = useDebouncedCallback(() => {


### PR DESCRIPTION
This pull request includes changes to the `web/containers/Providers/DataLoader.tsx` file to incorporate hardware information loading functionality. The most important changes include importing the `useGetHardwareInfo` hook, adding a new `mutate` function for hardware information, and calling this function within a `useEffect` hook to load hardware information once the component is mounted.

Improvements to data loading:

* [`web/containers/Providers/DataLoader.tsx`](diffhunk://#diff-b3a10000ff3b8316a1062f61e4286a582ea6d78628f749d3df61204553101797R18): Imported `useGetHardwareInfo` from `useHardwareManagement` to enable hardware information retrieval.
* [`web/containers/Providers/DataLoader.tsx`](diffhunk://#diff-b3a10000ff3b8316a1062f61e4286a582ea6d78628f749d3df61204553101797R38): Added `getHardwareInfo` function from `useGetHardwareInfo` to the component state.
* [`web/containers/Providers/DataLoader.tsx`](diffhunk://#diff-b3a10000ff3b8316a1062f61e4286a582ea6d78628f749d3df61204553101797R47): Called `getHardwareInfo` within a `useEffect` hook to load hardware information when the component mounts.