### PR TITLE
chore: should have an option to not revalidate hardware information

### DIFF
--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -95,7 +95,7 @@ export default class JanModelExtension extends ModelExtension {
      */
     return this.queue.add(() =>
       this.api
-        .post('v1/models/pull', { json: { model, id, name } })
+        .post('v1/models/pull', { json: { model, id, name }, timeout: false })
         .json()
         .catch(async (e) => {
           throw (await e.response?.json()) ?? e
@@ -232,7 +232,10 @@ export default class JanModelExtension extends ModelExtension {
     return this.queue
       .add(() =>
         this.api
-          .patch(`v1/models/${model.id}`, { json: { ...model } })
+          .patch(`v1/models/${model.id}`, {
+            json: { ...model },
+            timeout: false,
+          })
           .json()
           .then()
       )
@@ -267,6 +270,7 @@ export default class JanModelExtension extends ModelExtension {
       this.api
         .post('v1/models/import', {
           json: { model, modelPath, name, option },
+          timeout: false,
         })
         .json()
         .catch((e) => console.debug(e)) // Ignore error
@@ -313,6 +317,7 @@ export default class JanModelExtension extends ModelExtension {
         json: {
           source,
         },
+        timeout: false,
       })
     )
   }
@@ -382,11 +387,7 @@ export default class JanModelExtension extends ModelExtension {
     [key: string]: any
   }): Promise<void> {
     return this.queue
-      .add(() =>
-        this.api
-          .patch('v1/configs', { json: body })
-          .then(() => {})
-      )
+      .add(() => this.api.patch('v1/configs', { json: body }).then(() => {}))
       .catch((e) => console.debug(e))
   }
 

--- a/web/containers/Providers/DataLoader.tsx
+++ b/web/containers/Providers/DataLoader.tsx
@@ -35,7 +35,7 @@ const DataLoader: React.FC = () => {
   const setJanSettingScreen = useSetAtom(janSettingScreenAtom)
   const { getData: loadModels } = useModels()
   const { mutate } = useGetEngines()
-  const { mutate: getHardwareInfo } = useGetHardwareInfo()
+  const { mutate: getHardwareInfo } = useGetHardwareInfo(false)
 
   useThreads()
   useAssistants()

--- a/web/hooks/useHardwareManagement.ts
+++ b/web/hooks/useHardwareManagement.ts
@@ -32,7 +32,7 @@ const getExtension = () =>
 /**
  * @returns A Promise that resolves to an object of list engines.
  */
-export function useGetHardwareInfo() {
+export function useGetHardwareInfo(updatePeriodically: boolean = true) {
   const setCpuUsage = useSetAtom(cpuUsageAtom)
   const setUsedRam = useSetAtom(usedRamAtom)
   const setTotalRam = useSetAtom(totalRamAtom)
@@ -56,7 +56,7 @@ export function useGetHardwareInfo() {
     {
       revalidateOnFocus: false,
       revalidateOnReconnect: false,
-      refreshInterval: 2000,
+      refreshInterval: updatePeriodically ? 2000 : undefined,
     }
   )
 


### PR DESCRIPTION
This pull request includes several changes to the `extensions/hardware-management-extension` and `extensions/model-extension` codebases, as well as some updates to the `web` module. The most important changes involve refactoring the API instance handling in the `JSONHardwareManagementExtension` class, adding timeout configurations to API requests in the `JanModelExtension` class, and modifying the `useGetHardwareInfo` hook to support conditional periodic updates.

Refactoring API instance handling:

* [`extensions/hardware-management-extension/src/index.ts`](diffhunk://#diff-62746e863ccfaef934a7929aa607a6ba7dd5bc8b2a8eb8d7655ad4134b0fa93bL12-L29): Refactored the `JSONHardwareManagementExtension` class to replace direct API access with an `apiInstance` method, ensuring API instances are fetched dynamically. [[1]](diffhunk://#diff-62746e863ccfaef934a7929aa607a6ba7dd5bc8b2a8eb8d7655ad4134b0fa93bL12-L29) [[2]](diffhunk://#diff-62746e863ccfaef934a7929aa607a6ba7dd5bc8b2a8eb8d7655ad4134b0fa93bL42-R63) [[3]](diffhunk://#diff-62746e863ccfaef934a7929aa607a6ba7dd5bc8b2a8eb8d7655ad4134b0fa93bL69-R77)

Adding timeout configurations:

* [`extensions/model-extension/src/index.ts`](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61L98-R98): Updated the `JanModelExtension` class to include a `timeout: false` configuration in various API request methods, allowing for requests without timeouts. [[1]](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61L98-R98) [[2]](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61L235-R238) [[3]](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61R273) [[4]](diffhunk://#diff-455462e3e0df5d294c62fe6a5c5913754f97422be9e8c47380907766ab6c9c61R320)

Supporting conditional periodic updates:

* [`web/hooks/useHardwareManagement.ts`](diffhunk://#diff-67ba4bc8171caa0a2230dc2826225b9ce27a5a468beb7b83c700bd28eac6df06L35-R35): Modified the `useGetHardwareInfo` hook to accept an `updatePeriodically` parameter, allowing the refresh interval to be conditionally set based on the parameter value. [[1]](diffhunk://#diff-67ba4bc8171caa0a2230dc2826225b9ce27a5a468beb7b83c700bd28eac6df06L35-R35) [[2]](diffhunk://#diff-67ba4bc8171caa0a2230dc2826225b9ce27a5a468beb7b83c700bd28eac6df06L59-R59)
* [`web/containers/Providers/DataLoader.tsx`](diffhunk://#diff-b3a10000ff3b8316a1062f61e4286a582ea6d78628f749d3df61204553101797L38-R38): Updated the `useGetHardwareInfo` hook usage to pass `false` for the `updatePeriodically` parameter, disabling periodic updates in this context.