### PR TITLE
feat: Jan - MCP Client Host

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,10 @@ tauri-build = { version = "2.0.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.1.0", features = [ "protocol-asset",'macos-private-api'] }
+tauri = { version = "2.1.0", features = [
+    "protocol-asset",
+    'macos-private-api',
+] }
 tauri-plugin-log = "2.0.0-rc"
 tauri-plugin-shell = "2.2.0"
 flate2 = "1.0"
@@ -33,3 +36,10 @@ hyper = { version = "0.14", features = ["server"] }
 reqwest = { version = "0.11", features = ["json"] }
 tokio = { version = "1", features = ["full"] }
 tracing = "0.1.41"
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+    "client",
+    "transport-sse",
+    "transport-child-process",
+    "tower",
+] }
+schemars = { version = "0.8.22", features = ["derive"] }

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,7 @@ log = "0.4"
 tauri = { version = "2.1.0", features = [
     "protocol-asset",
     'macos-private-api',
+    "test"
 ] }
 tauri-plugin-log = "2.0.0-rc"
 tauri-plugin-shell = "2.2.0"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,7 +24,7 @@ log = "0.4"
 tauri = { version = "2.1.0", features = [
     "protocol-asset",
     'macos-private-api',
-    "test"
+    "test",
 ] }
 tauri-plugin-log = "2.0.0-rc"
 tauri-plugin-shell = "2.2.0"
@@ -43,4 +43,3 @@ rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "mai
     "transport-child-process",
     "tower",
 ] }
-schemars = { version = "0.8.22", features = ["derive"] }

--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -1,11 +1,8 @@
-use rmcp::{
-    model::{CallToolRequestParam, CallToolResult, Tool},
-    object,
-};
+use rmcp::model::{CallToolRequestParam, CallToolResult, Tool};
 use serde::{Deserialize, Serialize};
 use serde_json::{Map, Value};
 use std::{fs, path::PathBuf};
-use tauri::{AppHandle, Manager, State};
+use tauri::{AppHandle, Manager, Runtime, State};
 
 use super::{server, setup, state::AppState};
 
@@ -26,7 +23,7 @@ impl AppConfiguration {
 }
 
 #[tauri::command]
-pub fn get_app_configurations(app_handle: tauri::AppHandle) -> AppConfiguration {
+pub fn get_app_configurations<R: Runtime>(app_handle: tauri::AppHandle<R>) -> AppConfiguration {
     let mut app_default_configuration = AppConfiguration::default();
 
     if std::env::var("CI").unwrap_or_default() == "e2e" {
@@ -95,7 +92,7 @@ pub fn update_app_configuration(
 }
 
 #[tauri::command]
-pub fn get_jan_data_folder_path(app_handle: tauri::AppHandle) -> PathBuf {
+pub fn get_jan_data_folder_path<R: Runtime>(app_handle: tauri::AppHandle<R>) -> PathBuf {
     let app_configurations = get_app_configurations(app_handle);
     PathBuf::from(app_configurations.data_folder)
 }
@@ -137,7 +134,7 @@ pub fn read_theme(app_handle: tauri::AppHandle, theme_name: String) -> Result<St
 }
 
 #[tauri::command]
-pub fn get_configuration_file_path(app_handle: tauri::AppHandle) -> PathBuf {
+pub fn get_configuration_file_path<R: Runtime>(app_handle: tauri::AppHandle<R>) -> PathBuf {
     let app_path = app_handle.path().app_data_dir().unwrap_or_else(|err| {
         eprintln!(
             "Failed to get app data directory: {}. Using home directory instead.",
@@ -158,7 +155,7 @@ pub fn get_configuration_file_path(app_handle: tauri::AppHandle) -> PathBuf {
 }
 
 #[tauri::command]
-pub fn default_data_folder_path(app_handle: tauri::AppHandle) -> String {
+pub fn default_data_folder_path<R: Runtime>(app_handle: tauri::AppHandle<R>) -> String {
     return app_handle
         .path()
         .app_data_dir()

--- a/src-tauri/src/core/fs.rs
+++ b/src-tauri/src/core/fs.rs
@@ -1,3 +1,5 @@
+// WARNING: These APIs will be deprecated soon due to removing FS API access from frontend.
+// It's added to ensure the legacy implementation from frontend still functions before removal.
 use crate::core::cmd::get_jan_data_folder_path;
 use std::fs;
 use std::path::PathBuf;

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -22,15 +22,11 @@ pub async fn run_mcp_commands(
         app_path.clone() + "/mcp_config.json"
     );
     // let mut client_list = HashMap::new();
-    let config_content = match std::fs::read_to_string(app_path.clone() + "/mcp_config.json") {
-        Ok(content) => content,
-        Err(e) => return Err(format!("Failed to read config file: {}", e)),
-    };
+    let config_content = std::fs::read_to_string(app_path.clone() + "/mcp_config.json")
+        .map_err(|e| format!("Failed to read config file: {}", e))?;
 
-    let mcp_servers: serde_json::Value = match serde_json::from_str(&config_content) {
-        Ok(v) => v,
-        Err(e) => return Err(format!("Failed to parse config: {}", e)),
-    };
+    let mcp_servers: serde_json::Value = serde_json::from_str(&config_content)
+        .map_err(|e| format!("Failed to parse config: {}", e))?;
 
     if let Some(server_map) = mcp_servers.get("mcpServers").and_then(Value::as_object) {
         println!("MCP Servers: {server_map:#?}");

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -1,11 +1,6 @@
 use std::{collections::HashMap, sync::Arc};
 
-use rmcp::{
-    model::{CallToolRequestParam, GetPromptRequestParam, ReadResourceRequestParam},
-    service::RunningService,
-    transport::TokioChildProcess,
-    RoleClient, ServiceExt,
-};
+use rmcp::{service::RunningService, transport::TokioChildProcess, RoleClient, ServiceExt};
 use tokio::{process::Command, sync::Mutex};
 
 pub async fn run_mcp_commands(
@@ -70,4 +65,35 @@ pub async fn run_mcp_commands(
         println!("Tools: {_tools:#?}");
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+    use std::fs::File;
+    use std::io::Write;
+    use std::sync::Arc;
+    use tokio::sync::Mutex;
+
+    #[tokio::test]
+    async fn test_run_mcp_commands() {
+        // Create a mock mcp_config.json file
+        let config_path = "mcp_config.json";
+        let mut file = File::create(config_path).expect("Failed to create config file");
+        file.write_all(b"{\"mcpServers\":{}}")
+            .expect("Failed to write to config file");
+
+        // Call the run_mcp_commands function
+        let app_path = ".".to_string();
+        let servers_state: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>> =
+            Arc::new(Mutex::new(HashMap::new()));
+        let result = run_mcp_commands(app_path, servers_state).await;
+
+        // Assert that the function returns Ok(())
+        assert!(result.is_ok());
+
+        // Clean up the mock config file
+        std::fs::remove_file(config_path).expect("Failed to remove config file");
+    }
 }

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -3,6 +3,15 @@ use std::{collections::HashMap, sync::Arc};
 use rmcp::{service::RunningService, transport::TokioChildProcess, RoleClient, ServiceExt};
 use tokio::{process::Command, sync::Mutex};
 
+/// Runs MCP commands by reading configuration from a JSON file and initializing servers
+///
+/// # Arguments
+/// * `app_path` - Path to the application directory containing mcp_config.json
+/// * `servers_state` - Shared state containing running MCP services
+///
+/// # Returns
+/// * `Ok(())` if servers were initialized successfully
+/// * `Err(String)` if there was an error reading config or starting servers
 pub async fn run_mcp_commands(
     app_path: String,
     servers_state: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>>,
@@ -26,7 +35,6 @@ pub async fn run_mcp_commands(
         println!("MCP Servers: {servers:#?}");
         if let Some(server_map) = servers.as_object() {
             for (name, config) in server_map {
-                println!("Server Name: {}", name);
                 if let Some(config_obj) = config.as_object() {
                     if let (Some(command), Some(args)) = (
                         config_obj.get("command").and_then(|v| v.as_str()),
@@ -59,10 +67,6 @@ pub async fn run_mcp_commands(
         // Initialize
         let _server_info = service.peer_info();
         println!("Connected to server: {_server_info:#?}");
-        // List tools
-        let _tools = service.list_all_tools().await.map_err(|e| e.to_string())?;
-
-        println!("Tools: {_tools:#?}");
     }
     Ok(())
 }

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -1,0 +1,73 @@
+use std::{collections::HashMap, sync::Arc};
+
+use rmcp::{
+    model::{CallToolRequestParam, GetPromptRequestParam, ReadResourceRequestParam},
+    service::RunningService,
+    transport::TokioChildProcess,
+    RoleClient, ServiceExt,
+};
+use tokio::{process::Command, sync::Mutex};
+
+pub async fn run_mcp_commands(
+    app_path: String,
+    servers_state: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>>,
+) -> Result<(), String> {
+    println!(
+        "Load MCP configs from {}",
+        app_path.clone() + "/mcp_config.json"
+    );
+    // let mut client_list = HashMap::new();
+    let config_content = match std::fs::read_to_string(app_path.clone() + "/mcp_config.json") {
+        Ok(content) => content,
+        Err(e) => return Err(format!("Failed to read config file: {}", e)),
+    };
+
+    let mcp_servers: serde_json::Value = match serde_json::from_str(&config_content) {
+        Ok(v) => v,
+        Err(e) => return Err(format!("Failed to parse config: {}", e)),
+    };
+
+    if let Some(servers) = mcp_servers.get("mcpServers") {
+        println!("MCP Servers: {servers:#?}");
+        if let Some(server_map) = servers.as_object() {
+            for (name, config) in server_map {
+                println!("Server Name: {}", name);
+                if let Some(config_obj) = config.as_object() {
+                    if let (Some(command), Some(args)) = (
+                        config_obj.get("command").and_then(|v| v.as_str()),
+                        config_obj.get("args").and_then(|v| v.as_array()),
+                    ) {
+                        let mut cmd = Command::new(command);
+                        for arg in args {
+                            if let Some(arg_str) = arg.as_str() {
+                                cmd.arg(arg_str);
+                            }
+                        }
+
+                        let service =
+                            ().serve(TokioChildProcess::new(&mut cmd).map_err(|e| e.to_string())?)
+                                .await
+                                .map_err(|e| e.to_string())?;
+                        {
+                            let mut servers_map = servers_state.lock().await;
+                            servers_map.insert(name.clone(), service);
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    // Collect servers into a Vec to avoid holding the RwLockReadGuard across await points
+    let servers_map = servers_state.lock().await;
+    for (_, service) in servers_map.iter() {
+        // Initialize
+        let _server_info = service.peer_info();
+        println!("Connected to server: {_server_info:#?}");
+        // List tools
+        let _tools = service.list_all_tools().await.map_err(|e| e.to_string())?;
+
+        println!("Tools: {_tools:#?}");
+    }
+    Ok(())
+}

--- a/src-tauri/src/core/mod.rs
+++ b/src-tauri/src/core/mod.rs
@@ -3,3 +3,4 @@ pub mod fs;
 pub mod setup;
 pub mod state;
 pub mod server;
+pub mod mcp;

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::{Arc}};
+use std::{collections::HashMap, sync::Arc};
 
 use rand::{distributions::Alphanumeric, Rng};
 use rmcp::{service::RunningService, RoleClient};

--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -1,9 +1,14 @@
-use rand::{distributions::Alphanumeric, Rng};
+use std::{collections::HashMap, sync::{Arc}};
 
+use rand::{distributions::Alphanumeric, Rng};
+use rmcp::{service::RunningService, RoleClient};
+use tokio::sync::Mutex;
+
+#[derive(Default)]
 pub struct AppState {
     pub app_token: Option<String>,
+    pub mcp_servers: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>>
 }
-
 pub fn generate_app_token() -> String {
     rand::thread_rng()
         .sample_iter(&Alphanumeric)

--- a/web/containers/Providers/CoreConfigurator.tsx
+++ b/web/containers/Providers/CoreConfigurator.tsx
@@ -24,7 +24,9 @@ export const CoreConfigurator = ({ children }: PropsWithChildren) => {
     setTimeout(async () => {
       if (!isCoreExtensionInstalled()) {
         setSettingUp(true)
-        await setupBaseExtensions()
+
+        await new Promise((resolve) => setTimeout(resolve, 500))
+        setupBaseExtensions()
         return
       }
 

--- a/web/services/tauriService.ts
+++ b/web/services/tauriService.ts
@@ -2,12 +2,16 @@ import { CoreRoutes, APIRoutes } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
 
 // Define API routes based on different route types
-export const Routes = [...CoreRoutes, ...APIRoutes, 'installExtensions'].map(
-  (r) => ({
-    path: `app`,
-    route: r,
-  })
-)
+export const Routes = [
+  ...CoreRoutes,
+  ...APIRoutes,
+  'installExtensions',
+  'getTools',
+  'callTool',
+].map((r) => ({
+  path: `app`,
+  route: r,
+}))
 
 // Function to open an external URL in a new browser window
 export function openExternalUrl(url: string) {


### PR DESCRIPTION
This PR introduces MCP Host functionality to Jan, enabling users to utilize any existing mcp_config.json that is compatible with other MCP Hosts, such as Claude Desktop.

There will be another PR to update the Jan Chat UI to display the steps involved in using the tool. For now, this PR is to expose all the necessary APIs to the frontend, so that it can use these as parameters for OpenAI's tool use.

## Changes
- Implemented MCP Host support in Jan.
- Ensured compatibility with mcp_config.json to allow seamless integration with various MCP Servers.
- Added connection handling for multiple MCP Servers.
- Improved request routing between Jan (as an MCP Host) and configured MCP Servers.

## Why
This enhancement allows Jan to function as a flexible MCP Host, making it interoperable with existing MCP-compatible servers, providing users with more options for AI model hosting and inference.

## Architecture draft

![CleanShot 2025-03-30 at 17 41 35@2x](https://github.com/user-attachments/assets/50670755-620c-4853-a96e-90bc6c167cd2)


```mermaid
graph TD;
    Jan[Jan MCP Host] <-->|MCP Protocol| ServerA[MCP Server A];
    Jan <-->|MCP Protocol| ServerB[MCP Server B];
    ServerA <-->|Data Flow| DataResourceA[Data Resource A];
    ServerB <-->|Data Flow| DataResourceB[Data Resource B];
```

## Out of scope
Currently, the most popular standard stdio protocol is added only, but it will soon support SSE and WebSocket protocols (When these protocols are stable and supported by numerous servers)

## Screenshots
- List all available Tools
![CleanShot 2025-03-30 at 15 36 08@2x](https://github.com/user-attachments/assets/eddce2d2-3f99-456f-912c-ae4be5f21687)

- Call a tool use
![CleanShot 2025-03-30 at 15 35 59@2x](https://github.com/user-attachments/assets/47e5f225-80c0-4d09-b126-bd9efbf3f587)

![CleanShot 2025-03-30 at 15 38 54](https://github.com/user-attachments/assets/fe1633b3-9c05-43f4-97ef-b8b5e46c06b5)

## How to use

1. Obtain an mcp_config.json file from the Claude Desktop application or create one yourself. 
2. Place it in app data folder.
3. Launch Jan and see available tools.

## Action Items
- Implement Jan Tool Use UI

## Issues
#4824
#4861

## MCP example config file
[mcp_config.json](https://github.com/user-attachments/files/19525299/mcp_config.json)

