### PR TITLE
chore: allow draggable window app

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -8,6 +8,7 @@
   },
   "permissions": [
     "core:default",
+    "core:window:allow-start-dragging",
     "shell:allow-spawn",
     "shell:allow-open",
     "log:default",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -14,8 +14,8 @@
     "windows": [
       {
         "title": "Jan",
-        "width": 1000,
-        "height": 700,
+        "width": 1024,
+        "height": 768,
         "resizable": true,
         "fullscreen": false,
         "hiddenTitle": true,

--- a/web/containers/Layout/TopPanel/index.tsx
+++ b/web/containers/Layout/TopPanel/index.tsx
@@ -70,9 +70,13 @@ const TopPanel = () => {
         reduceTransparent &&
           'border-b border-[hsla(var(--app-border))] bg-[hsla(var(--top-panel-bg))]'
       )}
+      data-tauri-drag-region
     >
       {!isMac && <LogoMark width={24} height={24} className="-ml-1 mr-2" />}
-      <div className="flex w-full items-center justify-between text-[hsla(var(--text-secondary))]">
+      <div
+        className="flex w-full items-center justify-between text-[hsla(var(--text-secondary))]"
+        data-tauri-drag-region
+      >
         <div className="unset-drag flex cursor-pointer gap-x-0.5">
           {!isMac && (
             <Button


### PR DESCRIPTION
## Describe Your Changes

This pull request includes several changes to improve the functionality and appearance of the application. The most important changes include updating permissions, modifying window dimensions, and enhancing the drag region for better user interaction.

### Permissions Update:
* [`src-tauri/capabilities/default.json`](diffhunk://#diff-8fe2bbfebcddedcaa718510825d2a4bd04f59d2826a6848ea55fa086c5bb4213R11): Added the permission `core:window:allow-start-dragging` to the capabilities.

### Window Configuration:
* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L17-R18): Changed the default window dimensions from 1000x700 to 1024x768.

### User Interface Enhancements:
* [`web/containers/Layout/TopPanel/index.tsx`](diffhunk://#diff-144fb1f3592881414cfc6860d959d7b0fb1ffc1a4f427f005a9da3e61523ccd7R73-R79): Added `data-tauri-drag-region` attribute to improve drag functionality in the `TopPanel` component.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
