### PR TITLE
chore: enable window effect blur

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,7 +20,11 @@
         "fullscreen": false,
         "hiddenTitle": true,
         "transparent": true,
-        "titleBarStyle": "Overlay"
+        "titleBarStyle": "Overlay",
+        "windowEffects": {
+          "effects": ["fullScreenUI", "mica", "blur", "acrylic"],
+          "state": "active"
+        }
       }
     ],
     "security": {


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a change to the `src-tauri/tauri.conf.json` file to enhance the window effects configuration. The most important change is the addition of new window effects options.

Enhancements to window effects configuration:

* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L23-R27): Added the `windowEffects` property with options for `fullScreenUI`, `mica`, `blur`, and `acrylic`, and set the state to `active`.

## Fixes Issues

![Screenshot 2025-04-09 at 18 29 50](https://github.com/user-attachments/assets/ccce933b-9bb4-4219-9f4c-8e3618ebfc80)

![Screenshot 2025-04-09 at 18 29 35](https://github.com/user-attachments/assets/8eb4432f-896b-409c-9b7a-4d1f2f3d9447)


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
