### PR TITLE
feat: jan UI with Tool use UX

### DIFF
--- a/core/src/types/inference/inferenceEntity.ts
+++ b/core/src/types/inference/inferenceEntity.ts
@@ -7,6 +7,7 @@ export enum ChatCompletionRole {
   System = 'system',
   Assistant = 'assistant',
   User = 'user',
+  Tool = 'tool',
 }
 
 /**
@@ -18,6 +19,9 @@ export type ChatCompletionMessage = {
   content?: ChatCompletionMessageContent
   /** The role of the author of this message. **/
   role: ChatCompletionRole
+  type?: string
+  output?: string
+  tool_call_id?: string
 }
 
 export type ChatCompletionMessageContent =

--- a/core/src/types/message/messageEntity.ts
+++ b/core/src/types/message/messageEntity.ts
@@ -36,6 +36,8 @@ export type ThreadMessage = {
   type?: string
   /** The error code which explain what error type. Used in conjunction with MessageStatus.Error */
   error_code?: ErrorCode
+
+  tool_call_id?: string
 }
 
 /**

--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -114,7 +114,7 @@ export default function ModelHandler() {
 
   const onNewMessageResponse = useCallback(
     async (message: ThreadMessage) => {
-      if (message.type === MessageRequestType.Thread) {
+      if (message.type !== MessageRequestType.Summary) {
         addNewMessage(message)
       }
     },
@@ -129,35 +129,20 @@ export default function ModelHandler() {
   const updateThreadTitle = useCallback(
     (message: ThreadMessage) => {
       // Update only when it's finished
-      if (message.status !== MessageStatus.Ready) {
-        return
-      }
+      if (message.status !== MessageStatus.Ready) return
 
       const thread = threadsRef.current?.find((e) => e.id == message.thread_id)
-      if (!thread) {
-        console.warn(
-          `Failed to update title for thread ${message.thread_id}: Thread not found!`
-        )
-        return
-      }
-
       let messageContent = message.content[0]?.text?.value
-      if (!messageContent) {
-        console.warn(
-          `Failed to update title for thread ${message.thread_id}: Responded content is null!`
-        )
-        return
-      }
+      if (!thread || !messageContent) return
 
       // No new line character is presented in the title
       // And non-alphanumeric characters should be removed
-      if (messageContent.includes('\n')) {
+      if (messageContent.includes('\n'))
         messageContent = messageContent.replace(/\n/g, ' ')
-      }
+
       const match = messageContent.match(/<\/think>(.*)$/)
-      if (match) {
-        messageContent = match[1]
-      }
+      if (match) messageContent = match[1]
+
       // Remove non-alphanumeric characters
       const cleanedMessageContent = messageContent
         .replace(/[^\p{L}\s]+/gu, '')
@@ -193,18 +178,13 @@ export default function ModelHandler() {
 
   const updateThreadMessage = useCallback(
     (message: ThreadMessage) => {
-      if (
-        messageGenerationSubscriber.current &&
-        message.thread_id === activeThreadRef.current?.id &&
-        !messageGenerationSubscriber.current!.thread_id
-      ) {
-        updateMessage(
-          message.id,
-          message.thread_id,
-          message.content,
-          message.status
-        )
-      }
+      updateMessage(
+        message.id,
+        message.thread_id,
+        message.content,
+        message.metadata,
+        message.status
+      )
 
       if (message.status === MessageStatus.Pending) {
         if (message.content.length) {
@@ -243,16 +223,19 @@ export default function ModelHandler() {
         engines &&
         isLocalEngine(engines, activeModelRef.current.engine)
       ) {
-        ;(async () => {
-          if (
-            !(await extensionManager
-              .get<ModelExtension>(ExtensionTypeEnum.Model)
-              ?.isModelLoaded(activeModelRef.current?.id as string))
-          ) {
-            setActiveModel(undefined)
-            setStateModel({ state: 'start', loading: false, model: undefined })
-          }
-        })()
+        extensionManager
+          .get<ModelExtension>(ExtensionTypeEnum.Model)
+          ?.isModelLoaded(activeModelRef.current?.id as string)
+          .then((isLoaded) => {
+            if (!isLoaded) {
+              setActiveModel(undefined)
+              setStateModel({
+                state: 'start',
+                loading: false,
+                model: undefined,
+              })
+            }
+          })
       }
       // Mark the thread as not waiting for response
       updateThreadWaiting(message.thread_id, false)
@@ -296,19 +279,10 @@ export default function ModelHandler() {
           error_code: message.error_code,
         }
       }
-      ;(async () => {
-        const updatedMessage = await extensionManager
-          .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
-          ?.createMessage(message)
-          .catch(() => undefined)
-        if (updatedMessage) {
-          deleteMessage(message.id)
-          addNewMessage(updatedMessage)
-          setTokenSpeed((prev) =>
-            prev ? { ...prev, message: updatedMessage.id } : undefined
-          )
-        }
-      })()
+
+      extensionManager
+        .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
+        ?.createMessage(message)
 
       // Attempt to generate the title of the Thread when needed
       generateThreadTitle(message, thread)
@@ -319,24 +293,20 @@ export default function ModelHandler() {
 
   const onMessageResponseUpdate = useCallback(
     (message: ThreadMessage) => {
-      switch (message.type) {
-        case MessageRequestType.Summary:
-          updateThreadTitle(message)
-          break
-        default:
-          updateThreadMessage(message)
-          break
-      }
+      if (message.type === MessageRequestType.Summary)
+        updateThreadTitle(message)
+      else updateThreadMessage(message)
     },
     [updateThreadMessage, updateThreadTitle]
   )
 
   const generateThreadTitle = (message: ThreadMessage, thread: Thread) => {
     // If this is the first ever prompt in the thread
-    if ((thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle)
+    if (
+      !activeModelRef.current ||
+      (thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle
+    )
       return
-
-    if (!activeModelRef.current) return
 
     // Check model engine; we don't want to generate a title when it's not a local engine. remote model using first promp
     if (

--- a/web/helpers/atoms/ChatMessage.atom.ts
+++ b/web/helpers/atoms/ChatMessage.atom.ts
@@ -165,6 +165,7 @@ export const updateMessageAtom = atom(
     id: string,
     conversationId: string,
     text: ThreadContent[],
+    metadata: Record<string, unknown> | undefined,
     status: MessageStatus
   ) => {
     const messages = get(chatMessages)[conversationId] ?? []
@@ -172,6 +173,7 @@ export const updateMessageAtom = atom(
     if (message) {
       message.content = text
       message.status = status
+      message.metadata = metadata
       const updatedMessages = [...messages]
 
       const newData: Record<string, ThreadMessage[]> = {
@@ -192,6 +194,7 @@ export const updateMessageAtom = atom(
         created_at: Date.now() / 1000,
         completed_at: Date.now() / 1000,
         object: 'thread.message',
+        metadata: metadata,
       })
     }
   }

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -26,6 +26,7 @@ import {
   ChatCompletionTool,
 } from 'openai/resources/chat'
 
+import { Stream } from 'openai/streaming'
 import { ulid } from 'ulidx'
 
 import { modelDropdownStateAtom } from '@/containers/ModelDropdown'
@@ -259,110 +260,53 @@ export default function useSendChatMessage() {
         dangerouslyAllowBrowser: true,
       })
       while (!isDone) {
+        const messageId = ulid()
         const data = requestBuilder.build()
+        const message: ThreadMessage = {
+          id: messageId,
+          object: 'message',
+          thread_id: activeThreadRef.current.id,
+          assistant_id: activeAssistantRef.current.assistant_id,
+          role: ChatCompletionRole.Assistant,
+          content: [],
+          metadata: {},
+          status: MessageStatus.Pending,
+          created_at: Date.now() / 1000,
+          completed_at: Date.now() / 1000,
+        }
+        events.emit(MessageEvent.OnMessageResponse, message)
         const response = await openai.chat.completions.create({
-          messages: (data.messages ?? []).map((e) => {
-            return {
-              role: e.role as OpenAIChatCompletionRole,
-              content: e.content,
-            }
-          }) as ChatCompletionMessageParam[],
+          messages: requestBuilder.messages as ChatCompletionMessageParam[],
           model: data.model?.id ?? '',
           tools: data.tools as ChatCompletionTool[],
-          stream: false,
+          stream: data.model?.parameters?.stream ?? false,
+          tool_choice: 'auto',
         })
-        if (response.choices[0]?.message.content) {
-          const newMessage: ThreadMessage = {
-            id: ulid(),
-            object: 'message',
-            thread_id: activeThreadRef.current.id,
-            assistant_id: activeAssistantRef.current.assistant_id,
-            attachments: [],
-            role: response.choices[0].message.role as ChatCompletionRole,
-            content: [
-              {
-                type: ContentType.Text,
-                text: {
-                  value: response.choices[0].message.content
-                    ? response.choices[0].message.content
-                    : '',
-                  annotations: [],
-                },
+        // Variables to track and accumulate streaming content
+        if (!message.content.length) {
+          message.content = [
+            {
+              type: ContentType.Text,
+              text: {
+                value: '',
+                annotations: [],
               },
-            ],
-            status: MessageStatus.Ready,
-            created_at: Date.now(),
-            completed_at: Date.now(),
-          }
-          requestBuilder.pushAssistantMessage(
-            response.choices[0].message.content ?? ''
+            },
+          ]
+        }
+        if (data.model?.parameters?.stream)
+          isDone = await processStreamingResponse(
+            response as Stream<OpenAI.Chat.Completions.ChatCompletionChunk>,
+            requestBuilder,
+            message
           )
-          events.emit(MessageEvent.OnMessageUpdate, newMessage)
+        else {
+          isDone = await processNonStreamingResponse(
+            response as OpenAI.Chat.Completions.ChatCompletion,
+            requestBuilder,
+            message
+          )
         }
-
-        if (response.choices[0]?.message.tool_calls) {
-          for (const toolCall of response.choices[0].message.tool_calls) {
-            const id = ulid()
-            const toolMessage: ThreadMessage = {
-              id: id,
-              object: 'message',
-              thread_id: activeThreadRef.current.id,
-              assistant_id: activeAssistantRef.current.assistant_id,
-              attachments: [],
-              role: ChatCompletionRole.Assistant,
-              content: [
-                {
-                  type: ContentType.Text,
-                  text: {
-                    value: `<think>Executing Tool ${toolCall.function.name} with arguments ${toolCall.function.arguments}`,
-                    annotations: [],
-                  },
-                },
-              ],
-              status: MessageStatus.Pending,
-              created_at: Date.now(),
-              completed_at: Date.now(),
-            }
-            events.emit(MessageEvent.OnMessageUpdate, toolMessage)
-            const result = await window.core.api.callTool({
-              toolName: toolCall.function.name,
-              arguments: JSON.parse(toolCall.function.arguments),
-            })
-            if (result.error) {
-              console.error(result.error)
-              break
-            }
-            const message: ThreadMessage = {
-              id: id,
-              object: 'message',
-              thread_id: activeThreadRef.current.id,
-              assistant_id: activeAssistantRef.current.assistant_id,
-              attachments: [],
-              role: ChatCompletionRole.Assistant,
-              content: [
-                {
-                  type: ContentType.Text,
-                  text: {
-                    value:
-                      `<think>Executing Tool ${toolCall.function.name} with arguments ${toolCall.function.arguments}</think>` +
-                      (result.content[0]?.text ?? ''),
-                    annotations: [],
-                  },
-                },
-              ],
-              status: MessageStatus.Ready,
-              created_at: Date.now(),
-              completed_at: Date.now(),
-            }
-            requestBuilder.pushAssistantMessage(result.content[0]?.text ?? '')
-            requestBuilder.pushMessage('Go for the next step')
-            events.emit(MessageEvent.OnMessageUpdate, message)
-          }
-        }
-
-        isDone =
-          !response.choices[0]?.message.tool_calls ||
-          !response.choices[0]?.message.tool_calls.length
       }
     } else {
       // Request for inference
@@ -374,6 +318,165 @@ export default function useSendChatMessage() {
     // Reset states
     setReloadModel(false)
     setEngineParamsUpdate(false)
+  }
+
+  const processNonStreamingResponse = async (
+    response: OpenAI.Chat.Completions.ChatCompletion,
+    requestBuilder: MessageRequestBuilder,
+    message: ThreadMessage
+  ): Promise<boolean> => {
+    // Handle tool calls in the response
+    const toolCalls = response.choices[0]?.message?.tool_calls
+    const content = response.choices[0].message?.content
+    message.content = [
+      {
+        type: ContentType.Text,
+        text: {
+          value: content ?? '',
+          annotations: [],
+        },
+      },
+    ]
+    events.emit(MessageEvent.OnMessageUpdate, message)
+    await postMessageProcessing(
+      toolCalls ?? [],
+      requestBuilder,
+      message,
+      content ?? ''
+    )
+    return !toolCalls || !toolCalls.length
+  }
+
+  const processStreamingResponse = async (
+    response: Stream<OpenAI.Chat.Completions.ChatCompletionChunk>,
+    requestBuilder: MessageRequestBuilder,
+    message: ThreadMessage
+  ): Promise<boolean> => {
+    // Variables to track and accumulate streaming content
+    let currentToolCall: {
+      id: string
+      function: { name: string; arguments: string }
+    } | null = null
+    let accumulatedContent = ''
+    const toolCalls = []
+    // Process the streaming chunks
+    for await (const chunk of response) {
+      // Handle tool calls in the chunk
+      if (chunk.choices[0]?.delta?.tool_calls) {
+        const deltaToolCalls = chunk.choices[0].delta.tool_calls
+
+        // Handle the beginning of a new tool call
+        if (
+          deltaToolCalls[0]?.index !== undefined &&
+          deltaToolCalls[0]?.function
+        ) {
+          const index = deltaToolCalls[0].index
+
+          // Create new tool call if this is the first chunk for it
+          if (!toolCalls[index]) {
+            toolCalls[index] = {
+              id: deltaToolCalls[0]?.id || '',
+              function: {
+                name: deltaToolCalls[0]?.function?.name || '',
+                arguments: deltaToolCalls[0]?.function?.arguments || '',
+              },
+            }
+            currentToolCall = toolCalls[index]
+          } else {
+            // Continuation of existing tool call
+            currentToolCall = toolCalls[index]
+
+            // Append to function name or arguments if they exist in this chunk
+            if (deltaToolCalls[0]?.function?.name) {
+              currentToolCall!.function.name += deltaToolCalls[0].function.name
+            }
+
+            if (deltaToolCalls[0]?.function?.arguments) {
+              currentToolCall!.function.arguments +=
+                deltaToolCalls[0].function.arguments
+            }
+          }
+        }
+      }
+
+      // Handle regular content in the chunk
+      if (chunk.choices[0]?.delta?.content) {
+        const content = chunk.choices[0].delta.content
+        accumulatedContent += content
+
+        message.content = [
+          {
+            type: ContentType.Text,
+            text: {
+              value: accumulatedContent,
+              annotations: [],
+            },
+          },
+        ]
+        events.emit(MessageEvent.OnMessageUpdate, message)
+      }
+    }
+
+    await postMessageProcessing(
+      toolCalls ?? [],
+      requestBuilder,
+      message,
+      accumulatedContent ?? ''
+    )
+    return !toolCalls || !toolCalls.length
+  }
+
+  const postMessageProcessing = async (
+    toolCalls: any[],
+    requestBuilder: MessageRequestBuilder,
+    message: ThreadMessage,
+    content: string
+  ) => {
+    requestBuilder.pushAssistantMessage({
+      content,
+      role: 'assistant',
+      refusal: null,
+      tool_calls: toolCalls.map((e) => ({
+        ...e,
+        type: 'function',
+      })),
+    })
+
+    // Handle completed tool calls
+    if (toolCalls.length > 0) {
+      for (const toolCall of toolCalls) {
+        const result = await window.core.api.callTool({
+          toolName: toolCall.function.name,
+          arguments: JSON.parse(toolCall.function.arguments),
+        })
+        if (result.error) break
+
+        message.metadata = {
+          ...(message.metadata ?? {}),
+          tool_calls: [
+            ...(message.metadata?.tool_calls &&
+            Array.isArray(message.metadata?.tool_calls)
+              ? message.metadata?.tool_calls
+              : []),
+            {
+              tool: {
+                ...toolCall,
+                id: ulid(),
+              },
+              response: result,
+            },
+          ],
+        }
+
+        requestBuilder.pushToolMessage(
+          result.content[0]?.text ?? '',
+          toolCall.id
+        )
+        events.emit(MessageEvent.OnMessageUpdate, message)
+      }
+    }
+    message.status = MessageStatus.Ready
+    events.emit(MessageEvent.OnMessageUpdate, message)
   }
 
   return {

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -335,7 +335,8 @@ export default function useSendChatMessage() {
     message: ThreadMessage
   ): Promise<boolean> => {
     // Handle tool calls in the response
-    const toolCalls = response.choices[0]?.message?.tool_calls
+    const toolCalls: ChatCompletionMessageToolCall[] =
+      response.choices[0]?.message?.tool_calls ?? []
     const content = response.choices[0].message?.content
     message.content = [
       {
@@ -367,7 +368,7 @@ export default function useSendChatMessage() {
       function: { name: string; arguments: string }
     } | null = null
     let accumulatedContent = ''
-    const toolCalls = []
+    const toolCalls: ChatCompletionMessageToolCall[] = []
     // Process the streaming chunks
     for await (const chunk of response) {
       // Handle tool calls in the chunk
@@ -389,6 +390,7 @@ export default function useSendChatMessage() {
                 name: deltaToolCalls[0]?.function?.name || '',
                 arguments: deltaToolCalls[0]?.function?.arguments || '',
               },
+              type: 'function',
             }
             currentToolCall = toolCalls[index]
           } else {
@@ -436,7 +438,7 @@ export default function useSendChatMessage() {
   }
 
   const postMessageProcessing = async (
-    toolCalls: any[],
+    toolCalls: ChatCompletionMessageToolCall[],
     requestBuilder: MessageRequestBuilder,
     message: ThreadMessage,
     content: string
@@ -445,10 +447,7 @@ export default function useSendChatMessage() {
       content,
       role: 'assistant',
       refusal: null,
-      tool_calls: toolCalls.map((e) => ({
-        ...e,
-        type: 'function',
-      })),
+      tool_calls: toolCalls,
     })
 
     // Handle completed tool calls

--- a/web/hooks/useSendChatMessage.ts
+++ b/web/hooks/useSendChatMessage.ts
@@ -307,7 +307,7 @@ export default function useSendChatMessage() {
           isDone = await processStreamingResponse(
             response as Stream<OpenAI.Chat.Completions.ChatCompletionChunk>,
             requestBuilder,
-            message,
+            message
           )
         else {
           isDone = await processNonStreamingResponse(

--- a/web/screens/Hub/ModelFilter/ModelSize/index.tsx
+++ b/web/screens/Hub/ModelFilter/ModelSize/index.tsx
@@ -1,9 +1,8 @@
-import { useRef, useState } from 'react'
+import { useState } from 'react'
 
-import { Slider, Input, Tooltip } from '@janhq/joi'
+import { Slider, Input } from '@janhq/joi'
 
 import { atom, useAtom } from 'jotai'
-import { InfoIcon } from 'lucide-react'
 
 export const hubModelSizeMinAtom = atom(0)
 export const hubModelSizeMaxAtom = atom(100)

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -410,7 +410,7 @@ const ChatInput = () => {
                   size={16}
                   className="flex-shrink-0 cursor-pointer text-[hsla(var(--text-secondary))]"
                 />
-                <span className='text-xs'>{tools.length}</span>
+                <span className="text-xs">{tools.length}</span>
               </Badge>
             )}
           </div>

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -13,6 +13,7 @@ import {
   SettingsIcon,
   ChevronUpIcon,
   Settings2Icon,
+  WrenchIcon,
 } from 'lucide-react'
 
 import { twMerge } from 'tailwind-merge'
@@ -45,6 +46,7 @@ import {
   isBlockingSendAtom,
 } from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
+import { ModelTool } from '@/types/model'
 
 const ChatInput = () => {
   const activeThread = useAtomValue(activeThreadAtom)
@@ -69,6 +71,7 @@ const ChatInput = () => {
   const isBlockingSend = useAtomValue(isBlockingSendAtom)
   const activeAssistant = useAtomValue(activeAssistantAtom)
   const { stopInference } = useActiveModel()
+  const [tools, setTools] = useState<any>([])
 
   const upload = uploader()
   const [activeTabThreadRightPanel, setActiveTabThreadRightPanel] = useAtom(
@@ -91,6 +94,12 @@ const ChatInput = () => {
       setActiveSettingInputBox(true)
     }
   }, [activeSettingInputBox, selectedModel, setActiveSettingInputBox])
+
+  useEffect(() => {
+    window.core?.api?.getTools().then((data: ModelTool[]) => {
+      setTools(data)
+    })
+  }, [])
 
   const onStopInferenceClick = async () => {
     stopInference()
@@ -385,6 +394,25 @@ const ChatInput = () => {
                 className="flex-shrink-0 cursor-pointer text-[hsla(var(--text-secondary))]"
               />
             </Badge>
+            {tools && tools.length > 0 && (
+              <Badge
+                theme="secondary"
+                className={twMerge(
+                  'flex cursor-pointer items-center gap-x-1',
+                  activeTabThreadRightPanel === 'model' &&
+                    'border border-transparent'
+                )}
+                variant={
+                  activeTabThreadRightPanel === 'model' ? 'solid' : 'outline'
+                }
+              >
+                <WrenchIcon
+                  size={16}
+                  className="flex-shrink-0 cursor-pointer text-[hsla(var(--text-secondary))]"
+                />
+                <span className='text-xs'>{tools.length}</span>
+              </Badge>
+            )}
           </div>
           {selectedModel && (
             <Button

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -427,10 +427,10 @@ const ChatInput = () => {
                   onOpenChange={setShowToolsModal}
                   title="Available MCP Tools"
                   content={
-                    <div className="">
+                    <div className="overflow-y-auto">
                       <div className="mb-2 py-2 text-sm text-[hsla(var(--text-secondary))]">
-                        Jan can can use tools provided by specialized servers
-                        using Model Context Protocol.{' '}
+                        Jan can use tools provided by specialized servers using
+                        Model Context Protocol.{' '}
                         <a
                           href="https://modelcontextprotocol.io/introduction"
                           target="_blank"

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -3,7 +3,15 @@ import { useEffect, useRef, useState } from 'react'
 
 import { InferenceEngine } from '@janhq/core'
 
-import { TextArea, Button, Tooltip, useClickOutside, Badge } from '@janhq/joi'
+import {
+  TextArea,
+  Button,
+  Tooltip,
+  useClickOutside,
+  Badge,
+  Modal,
+  ModalClose,
+} from '@janhq/joi'
 import { useAtom, useAtomValue } from 'jotai'
 import {
   FileTextIcon,
@@ -72,6 +80,7 @@ const ChatInput = () => {
   const activeAssistant = useAtomValue(activeAssistantAtom)
   const { stopInference } = useActiveModel()
   const [tools, setTools] = useState<any>([])
+  const [showToolsModal, setShowToolsModal] = useState(false)
 
   const upload = uploader()
   const [activeTabThreadRightPanel, setActiveTabThreadRightPanel] = useAtom(
@@ -144,6 +153,8 @@ const ChatInput = () => {
       }
     }
   }
+
+  console.log(tools)
 
   return (
     <div className="relative p-4 pb-2">
@@ -395,17 +406,60 @@ const ChatInput = () => {
               />
             </Badge>
             {tools && tools.length > 0 && (
-              <Badge
-                theme="secondary"
-                className={twMerge('flex cursor-pointer items-center gap-x-1')}
-                variant={'outline'}
-              >
-                <WrenchIcon
-                  size={16}
-                  className="flex-shrink-0 cursor-pointer text-[hsla(var(--text-secondary))]"
+              <>
+                <Badge
+                  theme="secondary"
+                  className={twMerge(
+                    'flex cursor-pointer items-center gap-x-1'
+                  )}
+                  variant={'outline'}
+                  onClick={() => setShowToolsModal(true)}
+                >
+                  <WrenchIcon
+                    size={16}
+                    className="flex-shrink-0 cursor-pointer text-[hsla(var(--text-secondary))]"
+                  />
+                  <span className="text-xs">{tools.length}</span>
+                </Badge>
+
+                <Modal
+                  open={showToolsModal}
+                  onOpenChange={setShowToolsModal}
+                  title="Available MCP Tools"
+                  content={
+                    <div className="">
+                      <div className="mb-2 py-2 text-sm text-[hsla(var(--text-secondary))]">
+                        Jan can can use tools provided by specialized servers
+                        using Model Context Protocol.{' '}
+                        <a
+                          href="https://modelcontextprotocol.io/introduction"
+                          target="_blank"
+                          className="text-[hsla(var(--app-link))]"
+                        >
+                          Learn more about MCP
+                        </a>
+                      </div>
+                      {tools.map((tool: any) => (
+                        <div
+                          key={tool.name}
+                          className="flex items-center gap-x-3 px-4 py-3 hover:bg-[hsla(var(--dropdown-menu-hover-bg))]"
+                        >
+                          <WrenchIcon
+                            size={16}
+                            className="flex-shrink-0 text-[hsla(var(--text-secondary))]"
+                          />
+                          <div>
+                            <div className="font-medium">{tool.name}</div>
+                            <div className="text-sm text-[hsla(var(--text-secondary))]">
+                              {tool.description}
+                            </div>
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  }
                 />
-                <span className="text-xs">{tools.length}</span>
-              </Badge>
+              </>
             )}
           </div>
           {selectedModel && (

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -397,14 +397,8 @@ const ChatInput = () => {
             {tools && tools.length > 0 && (
               <Badge
                 theme="secondary"
-                className={twMerge(
-                  'flex cursor-pointer items-center gap-x-1',
-                  activeTabThreadRightPanel === 'model' &&
-                    'border border-transparent'
-                )}
-                variant={
-                  activeTabThreadRightPanel === 'model' ? 'solid' : 'outline'
-                }
+                className={twMerge('flex cursor-pointer items-center gap-x-1')}
+                variant={'outline'}
               >
                 <WrenchIcon
                   size={16}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
@@ -1,0 +1,54 @@
+import React from 'react'
+
+import { atom, useAtom } from 'jotai'
+import { ChevronDown, ChevronUp } from 'lucide-react'
+
+import { MarkdownTextMessage } from './MarkdownTextMessage'
+
+interface Props {
+  result: string
+  name: string
+  id: number
+}
+
+const toolCallBlockStateAtom = atom<{ [id: number]: boolean }>({})
+
+const ToolCallBlock = ({ id, name, result }: Props) => {
+  const [collapseState, setCollapseState] = useAtom(toolCallBlockStateAtom)
+
+  const isExpanded = collapseState[id] ?? false
+
+  const handleClick = () => {
+    setCollapseState((prev) => ({ ...prev, [id]: !isExpanded }))
+  }
+  return (
+    <div className="mx-auto w-full">
+      <div className="mb-4 rounded-lg border border-dashed border-[hsla(var(--app-border))] p-2">
+        <div
+          className="flex cursor-pointer items-center gap-3"
+          onClick={handleClick}
+        >
+          <button className="flex items-center gap-2 focus:outline-none">
+            {isExpanded ? (
+              <ChevronUp className="h-4 w-4" />
+            ) : (
+              <ChevronDown className="h-4 w-4" />
+            )}
+            <span className="font-medium">
+              {' '}
+              View result from <span className="font-bold">{name}</span>
+            </span>
+          </button>
+        </div>
+
+        {isExpanded && (
+          <div className="mt-2 overflow-x-hidden pl-6 text-[hsla(var(--text-secondary))]">
+            <MarkdownTextMessage text={result.trim()} />
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+
+export default ToolCallBlock

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 import { atom, useAtom } from 'jotai'
-import { ChevronDown, ChevronUp } from 'lucide-react'
+import { ChevronDown, ChevronUp, Loader } from 'lucide-react'
 
 import { MarkdownTextMessage } from './MarkdownTextMessage'
 
@@ -9,15 +9,15 @@ interface Props {
   result: string
   name: string
   id: number
+  loading: boolean
 }
 
 const toolCallBlockStateAtom = atom<{ [id: number]: boolean }>({})
 
-const ToolCallBlock = ({ id, name, result }: Props) => {
+const ToolCallBlock = ({ id, name, result, loading }: Props) => {
   const [collapseState, setCollapseState] = useAtom(toolCallBlockStateAtom)
 
   const isExpanded = collapseState[id] ?? false
-
   const handleClick = () => {
     setCollapseState((prev) => ({ ...prev, [id]: !isExpanded }))
   }
@@ -28,6 +28,9 @@ const ToolCallBlock = ({ id, name, result }: Props) => {
           className="flex cursor-pointer items-center gap-3"
           onClick={handleClick}
         >
+          {loading && (
+            <Loader className="h-4 w-4 animate-spin text-[hsla(var(--primary-bg))]" />
+          )}
           <button className="flex items-center gap-2 focus:outline-none">
             {isExpanded ? (
               <ChevronUp className="h-4 w-4" />
@@ -43,7 +46,7 @@ const ToolCallBlock = ({ id, name, result }: Props) => {
 
         {isExpanded && (
           <div className="mt-2 overflow-x-hidden pl-6 text-[hsla(var(--text-secondary))]">
-            <MarkdownTextMessage text={result.trim()} />
+            <span>{result.trim()} </span>
           </div>
         )}
       </div>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -75,41 +75,44 @@ const MessageContainer: React.FC<
   return (
     <div
       className={twMerge(
-        'group relative mx-auto px-4 py-2',
+        'group relative mx-auto px-4',
+        !(props.metadata && 'parent_id' in props.metadata) && 'py-2',
         chatWidth === 'compact' && 'max-w-[700px]',
         isUser && 'pb-4 pt-0'
       )}
     >
-      <div
-        className={twMerge(
-          'mb-2 flex items-center justify-start',
-          !isUser && 'mt-2 gap-x-2'
-        )}
-      >
-        {!isUser && !isSystem && <LogoMark width={28} />}
-
+      {!(props.metadata && 'parent_id' in props.metadata) && (
         <div
           className={twMerge(
-            'font-extrabold capitalize',
-            isUser && 'text-gray-500'
+            'mb-2 flex items-center justify-start',
+            !isUser && 'mt-2 gap-x-2'
           )}
         >
-          {!isUser && (
-            <>
-              {props.metadata && 'model' in props.metadata
-                ? (props.metadata?.model as string)
-                : props.isCurrentMessage
-                  ? selectedModel?.name
-                  : (activeAssistant?.assistant_name ?? props.role)}
-            </>
-          )}
-        </div>
+          {!isUser && !isSystem && <LogoMark width={28} />}
 
-        <p className="text-xs font-medium text-gray-400">
-          {props.created_at &&
-            displayDate(props.created_at ?? Date.now() / 1000)}
-        </p>
-      </div>
+          <div
+            className={twMerge(
+              'font-extrabold capitalize',
+              isUser && 'text-gray-500'
+            )}
+          >
+            {!isUser && (
+              <>
+                {props.metadata && 'model' in props.metadata
+                  ? (props.metadata?.model as string)
+                  : props.isCurrentMessage
+                    ? selectedModel?.name
+                    : (activeAssistant?.assistant_name ?? props.role)}
+              </>
+            )}
+          </div>
+
+          <p className="text-xs font-medium text-gray-400">
+            {props.created_at &&
+              displayDate(props.created_at ?? Date.now() / 1000)}
+          </p>
+        </div>
+      )}
 
       <div className="flex w-full flex-col ">
         <div

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -197,6 +197,7 @@ const MessageContainer: React.FC<
                       name={toolCall.tool?.function?.name ?? ''}
                       key={toolCall.tool?.id}
                       result={JSON.stringify(toolCall.response)}
+                      loading={toolCall.state === 'pending'}
                     />
                   ))}
                 </>

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -114,12 +114,12 @@ const MessageContainer: React.FC<
         </div>
       )}
 
-      <div className="flex w-full flex-col ">
+      <div className="flex w-full flex-col">
         <div
           className={twMerge(
             'absolute right-0 order-1 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
             twMerge(
-              'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:z-50 group-hover:flex',
+              'hidden group-hover:absolute group-hover:-bottom-4 group-hover:right-4 group-hover:z-50 group-hover:flex',
               image && 'group-hover:-top-2'
             ),
 

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -18,6 +18,8 @@ import ImageMessage from './ImageMessage'
 import { MarkdownTextMessage } from './MarkdownTextMessage'
 import ThinkingBlock from './ThinkingBlock'
 
+import ToolCallBlock from './ToolCallBlock'
+
 import { activeAssistantAtom } from '@/helpers/atoms/Assistant.atom'
 import {
   editMessageAtom,
@@ -65,7 +67,10 @@ const MessageContainer: React.FC<
     [props.content]
   )
 
-  const attachedFile = useMemo(() => 'attachments' in props, [props])
+  const attachedFile = useMemo(
+    () => 'attachments' in props && props.attachments?.length,
+    [props]
+  )
 
   return (
     <div
@@ -110,12 +115,11 @@ const MessageContainer: React.FC<
         <div
           className={twMerge(
             'absolute right-0 order-1 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
-            isUser
-              ? twMerge(
-                  'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:z-50 group-hover:flex',
-                  image && 'group-hover:-top-2'
-                )
-              : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100',
+            twMerge(
+              'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:z-50 group-hover:flex',
+              image && 'group-hover:-top-2'
+            ),
+
             props.isCurrentMessage && 'opacity-100'
           )}
         >
@@ -179,6 +183,21 @@ const MessageContainer: React.FC<
                 />
               </div>
             )}
+            {props.metadata &&
+              'tool_calls' in props.metadata &&
+              Array.isArray(props.metadata.tool_calls) &&
+              props.metadata.tool_calls.length && (
+                <>
+                  {props.metadata.tool_calls.map((toolCall) => (
+                    <ToolCallBlock
+                      id={toolCall.tool?.id}
+                      name={toolCall.tool?.function?.name ?? ''}
+                      key={toolCall.tool?.id}
+                      result={JSON.stringify(toolCall.response)}
+                    />
+                  ))}
+                </>
+              )}
           </>
         </div>
       </div>


### PR DESCRIPTION
This pull request includes significant updates to the chat message handling and tool call processing within the application. The changes enhance the functionality and simplify the codebase by adding new properties, improving message handling, and introducing a new UI component for tool call results.

## Changes
- Add new ToolCallMessage type.
- Message's metadata now has tool_calls persisted (pending moving threads to Jan - cortex.cpp could not save metadata with key - object type).
- Using OpenAI client sdk to parse response from cortex.cpp for now (soon move back to Jan with model proviers as extensions)

## Screenshots

![CleanShot 2025-04-13 at 21 50 53@2x](https://github.com/user-attachments/assets/abdcb2bf-6654-4018-bac0-4fbd4600e18a)

![CleanShot 2025-04-14 at 14 55 11@2x](https://github.com/user-attachments/assets/15d91c01-fb0e-421d-98d2-31322b259a42)


## GitHub issues
#4862

### Enhancements to chat message handling:

* [`core/src/types/inference/inferenceEntity.ts`](diffhunk://#diff-c3667eaa51fed6cc102a698812611ed0518c93e79623b0416cb0e9e6c84b8a59R10): Added `Tool` to `ChatCompletionRole` enum and new optional properties `type`, `output`, and `tool_call_id` to `ChatCompletionMessage` type. [[1]](diffhunk://#diff-c3667eaa51fed6cc102a698812611ed0518c93e79623b0416cb0e9e6c84b8a59R10) [[2]](diffhunk://#diff-c3667eaa51fed6cc102a698812611ed0518c93e79623b0416cb0e9e6c84b8a59R22-R24)
* [`core/src/types/message/messageEntity.ts`](diffhunk://#diff-d5052ab0bf661b4f3d0a79c9b3d69d6e36ddc8bf85cd8b64ff7af9c0c99bde77R39-R40): Added optional `tool_call_id` property to `ThreadMessage` type.
* [`web/containers/Providers/ModelHandler.tsx`](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL117-R117): Updated multiple functions to handle new message types and statuses, and refactored code for better readability and efficiency. [[1]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL117-R117) [[2]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL132-R145) [[3]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL196-L207) [[4]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL246-R238) [[5]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL299-L311) [[6]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dL322-L340)

### Introduction of new UI component:

* [`web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx`](diffhunk://#diff-dccceadf748958b80f27c7ded6e6dda6b6151d496dfe08dec5495283fd11916aR1-R54): Introduced a new `ToolCallBlock` component to display tool call results with expandable/collapsible functionality.
* [`web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx`](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccR21-R22): Integrated the `ToolCallBlock` component into the message display logic. [[1]](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccR21-R22) [[2]](diffhunk://#diff-efce7749ad34c34cc3f189aea671b9975208995580033b9de787c3c96c878cccL68-R73)

### Additional updates:

* [`web/helpers/atoms/ChatMessage.atom.ts`](diffhunk://#diff-e850ebdf2270ad76344cabdfd3caa7629e6206a3a317f9eab2bff6a5e6cdfebcR168-R176): Updated `updateMessageAtom` to handle new `metadata` property. [[1]](diffhunk://#diff-e850ebdf2270ad76344cabdfd3caa7629e6206a3a317f9eab2bff6a5e6cdfebcR168-R176) [[2]](diffhunk://#diff-e850ebdf2270ad76344cabdfd3caa7629e6206a3a317f9eab2bff6a5e6cdfebcR197)
* [`web/hooks/useSendChatMessage.ts`](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R29): Refactored the `useSendChatMessage` hook to include new message handling logic and tool call processing. [[1]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R29) [[2]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R263-R479)
* [`web/screens/Hub/ModelFilter/ModelSize/index.tsx`](diffhunk://#diff-71cf48a7bdabc4bde4ee85c923975806bd88e33a73e34f382b2aa4e77d448d37L1-L6): Removed unused imports to clean up the code.