### PR TITLE
fix: added border for search textfield

### DIFF
--- a/web/containers/ModelSearch/index.tsx
+++ b/web/containers/ModelSearch/index.tsx
@@ -83,7 +83,7 @@ const ModelSearch = ({ onSearchLocal }: Props) => {
       value={searchText}
       clearable={searchText.length > 0}
       onClear={onClear}
-      className="border-0 bg-[hsla(var(--app-bg))]"
+      className="bg-[hsla(var(--app-bg))]"
       onClick={() => {
         onSearchLocal?.(inputRef.current?.value ?? '')
       }}


### PR DESCRIPTION
This pull request includes a small change to the `ModelSearch` component in the `web/containers/ModelSearch/index.tsx` file. The change involves modifying the class name of an element to remove the `border-0` class, simplifying the styling.

* [`web/containers/ModelSearch/index.tsx`](diffhunk://#diff-246b4b85fb7409a40822b732441e9c9aa329d2f950ce0d87b882e98887bf75f2L86-R86): Removed the `border-0` class from the element's className property to simplify the styling.

## Describe Your Changes
- Added border for the search text field

<img width="1016" alt="image" src="https://github.com/user-attachments/assets/c8e2afff-c3a4-4ac0-8bcd-863891278fc3" />
