### PR TITLE
feat: restart MCP servers to reflect config updates

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -44,6 +44,7 @@ pub fn run() {
             // MCP commands
             core::cmd::get_tools,
             core::cmd::call_tool,
+            core::mcp::restart_mcp_servers,
             // Threads
             core::threads::list_threads,
             core::threads::create_thread,

--- a/web/screens/Settings/MCP/configuration.tsx
+++ b/web/screens/Settings/MCP/configuration.tsx
@@ -46,6 +46,7 @@ const MCPConfiguration = () => {
         return
       }
       await window.core?.api?.saveMcpConfigs({ configs: configContent })
+      await window.core?.api?.restartMcpServers()
 
       setSuccess('Config saved successfully')
       setIsSaving(false)

--- a/web/screens/Settings/MCP/search.tsx
+++ b/web/screens/Settings/MCP/search.tsx
@@ -188,6 +188,7 @@ const MCPSearch = () => {
       await window.core?.api?.saveMcpConfigs({
         configs: JSON.stringify(config, null, 2),
       })
+      await window.core?.api?.restartMcpServers()
 
       toaster({
         title: `Add ${serverName} success`,

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -154,8 +154,6 @@ const ChatInput = () => {
     }
   }
 
-  console.log(tools)
-
   return (
     <div className="relative p-4 pb-2">
       {renderPreview(fileUpload)}

--- a/web/services/tauriService.ts
+++ b/web/services/tauriService.ts
@@ -21,6 +21,7 @@ export const Routes = [
   'modifyThreadAssistant',
   'saveMcpConfigs',
   'getMcpConfigs',
+  'restartMcpServers',
 ].map((r) => ({
   path: `app`,
   route: r,


### PR DESCRIPTION
This pull request introduces a new feature to restart MCP servers programmatically, along with minor cleanup in the codebase. Key changes include adding a new Tauri command for restarting MCP servers, integrating this functionality into the frontend, and updating the routing configuration. Additionally, an unused `console.log` statement was removed.

AC: When I add or update a server, the tools should reflect the change.

![CleanShot 2025-04-17 at 14 53 37](https://github.com/user-attachments/assets/f6a297d7-253b-40e3-8c6d-e6a69d943e2e)

### Backend Changes:
* Added a new Tauri command `restart_mcp_servers` in `src-tauri/src/core/mcp.rs`. This command stops and restarts MCP servers by interacting with the application's state and MCP server configurations.
* Updated the Tauri command registration in `src-tauri/src/lib.rs` to include the new `restart_mcp_servers` command.

### Frontend Changes:
* Integrated the `restartMcpServers` API call into the MCP configuration and search screens (`web/screens/Settings/MCP/configuration.tsx` and `web/screens/Settings/MCP/search.tsx`) to restart servers after saving configurations. [[1]](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322R49) [[2]](diffhunk://#diff-6f613aef692a9ac0069237b2edc5ebce294e39bf2cb201ce46f27eee98204fb7R191)
* Added `restartMcpServers` to the Tauri service routes in `web/services/tauriService.ts`.

### Code Cleanup:
* Removed an unused `console.log` statement from `web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx`.