### PR TITLE
fix: tool outputs are gone after switching to another thread

### DIFF
--- a/src-tauri/src/core/threads.rs
+++ b/src-tauri/src/core/threads.rs
@@ -278,8 +278,10 @@ pub async fn create_message<R: Runtime>(
     ensure_thread_dir_exists(app_handle.clone(), &thread_id)?;
     let path = get_messages_path(app_handle.clone(), &thread_id);
 
-    let uuid = Uuid::new_v4().to_string();
-    message["id"] = serde_json::Value::String(uuid);
+    if message.get("id").is_none() {
+        let uuid = Uuid::new_v4().to_string();
+        message["id"] = serde_json::Value::String(uuid);
+    }
 
     // Acquire per-thread lock before writing
     {
@@ -292,7 +294,7 @@ pub async fn create_message<R: Runtime>(
 
         let _guard = lock.lock().await;
 
-        let mut file = fs::OpenOptions::new()
+        let mut file: File = fs::OpenOptions::new()
             .create(true)
             .append(true)
             .open(path)
@@ -354,21 +356,34 @@ pub async fn modify_message<R: Runtime>(
 
 /// Deletes a message from a thread's messages.jsonl file by message ID.
 /// Rewrites the entire messages.jsonl file for the thread.
+/// Uses a per-thread async lock to prevent race conditions and ensure file consistency.
 #[command]
 pub async fn delete_message<R: Runtime>(
     app_handle: tauri::AppHandle<R>,
     thread_id: String,
     message_id: String,
 ) -> Result<(), String> {
-    let mut messages = list_messages(app_handle.clone(), thread_id.clone()).await?;
-    messages.retain(|m| m.get("id").and_then(|v| v.as_str()) != Some(message_id.as_str()));
+    // Acquire per-thread lock before modifying
+    {
+        let mut locks = MESSAGE_LOCKS.lock().await;
+        let lock = locks
+            .entry(thread_id.to_string())
+            .or_insert_with(|| Arc::new(Mutex::new(())))
+            .clone();
+        drop(locks); // Release the map lock before awaiting the file lock
 
-    // Rewrite remaining messages
-    let path = get_messages_path(app_handle.clone(), &thread_id);
-    let mut file = File::create(path).map_err(|e| e.to_string())?;
-    for msg in messages {
-        let data = serde_json::to_string(&msg).map_err(|e| e.to_string())?;
-        writeln!(file, "{}", data).map_err(|e| e.to_string())?;
+        let _guard = lock.lock().await;
+
+        let mut messages = list_messages(app_handle.clone(), thread_id.clone()).await?;
+        messages.retain(|m| m.get("id").and_then(|v| v.as_str()) != Some(message_id.as_str()));
+
+        // Rewrite remaining messages
+        let path = get_messages_path(app_handle.clone(), &thread_id);
+        let mut file = File::create(path).map_err(|e| e.to_string())?;
+        for msg in messages {
+            let data = serde_json::to_string(&msg).map_err(|e| e.to_string())?;
+            writeln!(file, "{}", data).map_err(|e| e.to_string())?;
+        }
     }
 
     Ok(())
@@ -441,7 +456,7 @@ pub async fn modify_thread_assistant<R: Runtime>(
         serde_json::from_str(&data).map_err(|e| e.to_string())?
     };
     let assistant_id = assistant
-        .get("id")
+        .get("assistant_id")
         .and_then(|v| v.as_str())
         .ok_or("Missing assistant_id")?;
     if let Some(assistants) = thread

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -38,12 +38,13 @@ export default function useDeleteThread() {
         ?.listMessages(threadId)
         .catch(console.error)
       if (messages) {
-        messages.forEach((message) => {
-          extensionManager
+        for (const message of messages) {
+          await extensionManager
             .get<ConversationalExtension>(ExtensionTypeEnum.Conversational)
             ?.deleteMessage(threadId, message.id)
             .catch(console.error)
-        })
+        }
+       
         const thread = threads.find((e) => e.id === threadId)
         if (thread) {
           const updatedThread = {

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
@@ -46,7 +46,7 @@ const ToolCallBlock = ({ id, name, result, loading }: Props) => {
 
         {isExpanded && (
           <div className="mt-2 overflow-x-hidden pl-6 text-[hsla(var(--text-secondary))]">
-            <span>{result.trim()} </span>
+            <span>{result ?? ''} </span>
           </div>
         )}
       </div>


### PR DESCRIPTION
This PR resolved an issue where thread outputs disappear if users switch to another thread while generating content.

![CleanShot 2025-04-17 at 21 09 01](https://github.com/user-attachments/assets/ebf8cab3-bf38-4e14-816b-5590dd11d5e5)

### Backend Improvements:
* **Thread-level locking for file operations**: Introduced per-thread async locks to prevent race conditions in `delete_message` and `modify_message` functions, ensuring file consistency during concurrent operations. [[1]](diffhunk://#diff-9a1f54bb36894668e9646ace7f7bcd05533588c833e2dedcc783ab9c67a617f4R359-R376) [[2]](diffhunk://#diff-9a1f54bb36894668e9646ace7f7bcd05533588c833e2dedcc783ab9c67a617f4R387)
* **Message ID assignment**: Added logic to auto-generate a unique ID for messages if not provided, ensuring all messages have an identifier.
* **Variable type clarity**: Explicitly defined the type for file operations to improve code readability and maintainability.
* **Field name correction**: Updated `modify_thread_assistant` to use `assistant_id` instead of `id` for better clarity and alignment with data structure expectations.

### Frontend Enhancements:
* **State management for models**: Improved handling of active models by unifying references and ensuring consistent state updates across `ModelHandler` and `useSendChatMessage`. [[1]](diffhunk://#diff-c52744b512485151ef69f9c9e8b58535cc47dc550c4caf152cb52ec103ea898dR263-R269) [[2]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860L138-R147)
* **Error handling improvements**: Enhanced error handling in `useDeleteThread` by switching to `for...of` with `await` for sequential message deletions, ensuring proper execution flow.
* **Thread and message updates**: Refactored thread updates to use current references for better consistency and added status updates for messages. [[1]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860L214-R220) [[2]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R322-R323)
* **UI fixes**: Adjusted `ToolCallBlock` to handle null or undefined results gracefully, preventing potential rendering issues.