### PR TITLE
fix: clean up threads persistence and fix assistant update issue

### DIFF
--- a/src-tauri/src/core/threads.rs
+++ b/src-tauri/src/core/threads.rs
@@ -465,7 +465,7 @@ pub async fn modify_thread_assistant<R: Runtime>(
     {
         if let Some(index) = assistants
             .iter()
-            .position(|a| a.get("id").and_then(|v| v.as_str()) == Some(assistant_id))
+            .position(|a| a.get("assistant_id").and_then(|v| v.as_str()) == Some(assistant_id))
         {
             assistants[index] = assistant.clone();
             let data = serde_json::to_string_pretty(&thread).map_err(|e| e.to_string())?;

--- a/web/containers/ModelDropdown/index.tsx
+++ b/web/containers/ModelDropdown/index.tsx
@@ -232,26 +232,6 @@ const ModelDropdown = ({
       stopModel()
 
       if (activeThread) {
-        // Change assistand tools based on model support RAG
-        updateThreadMetadata({
-          ...activeThread,
-          assistants: [
-            {
-              ...activeAssistant,
-              tools: [
-                {
-                  type: 'retrieval',
-                  enabled: model?.engine === InferenceEngine.cortex,
-                  settings: {
-                    ...(activeAssistant.tools &&
-                      activeAssistant.tools[0]?.settings),
-                  },
-                },
-              ],
-            },
-          ],
-        })
-
         const contextLength = model?.settings.ctx_len
           ? Math.min(8192, model?.settings.ctx_len ?? 8192)
           : undefined
@@ -273,11 +253,25 @@ const ModelDropdown = ({
 
         // Update model parameter to the thread file
         if (model)
-          updateModelParameter(activeThread, {
-            params: modelParams,
-            modelId: model.id,
-            engine: model.engine,
-          })
+          updateModelParameter(
+            activeThread,
+            {
+              params: modelParams,
+              modelId: model.id,
+              engine: model.engine,
+            },
+            // Update tools
+            [
+              {
+                type: 'retrieval',
+                enabled: model?.engine === InferenceEngine.cortex,
+                settings: {
+                  ...(activeAssistant.tools &&
+                    activeAssistant.tools[0]?.settings),
+                },
+              },
+            ]
+          )
       }
     },
     [

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -180,7 +180,7 @@ export const useCreateNewThread = () => {
       updateThreadCallback(thread)
       if (thread.assistants && thread.assistants?.length > 0) {
         setActiveAssistant(thread.assistants[0])
-        updateAssistantCallback(thread.id, thread.assistants[0])
+        return updateAssistantCallback(thread.id, thread.assistants[0])
       }
     },
     [

--- a/web/hooks/useUpdateModelParameters.ts
+++ b/web/hooks/useUpdateModelParameters.ts
@@ -1,6 +1,7 @@
 import { useCallback } from 'react'
 
 import {
+  AssistantTool,
   ConversationalExtension,
   ExtensionTypeEnum,
   InferenceEngine,
@@ -51,7 +52,11 @@ export default function useUpdateModelParameters() {
   )
 
   const updateModelParameter = useCallback(
-    async (thread: Thread, settings: UpdateModelParameter) => {
+    async (
+      thread: Thread,
+      settings: UpdateModelParameter,
+      tools?: AssistantTool[]
+    ) => {
       if (!activeAssistant) return
 
       const toUpdateSettings = processStopWords(settings.params ?? {})
@@ -70,6 +75,7 @@ export default function useUpdateModelParameters() {
       const settingParams = extractModelLoadParams(updatedModelParams)
       const assistantInfo = {
         ...activeAssistant,
+        tools: tools ?? activeAssistant.tools,
         model: {
           ...activeAssistant?.model,
           parameters: runtimeParams,


### PR DESCRIPTION
This pull request includes several updates to improve thread and assistant management in both backend and frontend code. The changes focus on enhancing assistant identification, updating model parameters, and refining assistant tools. Below is a summary of the most important changes:

### Backend Improvements:
* **Assistant Identification Update**: Modified the key used to identify assistants in the `modify_thread_assistant` function from `"id"` to `"assistant_id"` for better clarity and consistency (`src-tauri/src/core/threads.rs`).

### Frontend Enhancements:
* **Assistant Tools Management**:
  - Removed outdated logic for updating assistant tools in the `ModelDropdown` component, simplifying the code (`web/containers/ModelDropdown/index.tsx`).
  - Added support for updating assistant tools when model parameters are updated, ensuring proper synchronization (`web/containers/ModelDropdown/index.tsx`).

* **Model Parameter Updates**:
  - Extended the `updateModelParameter` function to accept an optional `tools` parameter, allowing dynamic updates to assistant tools (`web/hooks/useUpdateModelParameters.ts`). [[1]](diffhunk://#diff-27428f860fc847e657e4dccc6693e209c622ea926aa68bde2035bc048dd81acfL54-R59) [[2]](diffhunk://#diff-27428f860fc847e657e4dccc6693e209c622ea926aa68bde2035bc048dd81acfR78)

* **Thread Creation Behavior**:
  - Updated the `useCreateNewThread` hook to return the result of `updateAssistantCallback`, improving the handling of assistant updates during thread creation (`web/hooks/useCreateNewThread.ts`).