### PR TITLE
fix: thread title does not set on remote models

### DIFF
--- a/web/containers/Providers/ModelHandler.tsx
+++ b/web/containers/Providers/ModelHandler.tsx
@@ -16,16 +16,11 @@ import {
   EngineManager,
   InferenceEngine,
   extractInferenceParams,
-  ModelExtension,
 } from '@janhq/core'
 import { useAtom, useAtomValue, useSetAtom } from 'jotai'
 import { ulid } from 'ulidx'
 
 import { activeModelAtom, stateModelAtom } from '@/hooks/useActiveModel'
-
-import { useGetEngines } from '@/hooks/useEngineManagement'
-
-import { isLocalEngine } from '@/utils/modelEngine'
 
 import { extensionManager } from '@/extension'
 import {
@@ -33,7 +28,6 @@ import {
   addNewMessageAtom,
   updateMessageAtom,
   tokenSpeedAtom,
-  deleteMessageAtom,
   subscribedGeneratingMessageAtom,
 } from '@/helpers/atoms/ChatMessage.atom'
 import { downloadedModelsAtom } from '@/helpers/atoms/Model.atom'
@@ -54,7 +48,6 @@ export default function ModelHandler() {
   const addNewMessage = useSetAtom(addNewMessageAtom)
   const updateMessage = useSetAtom(updateMessageAtom)
   const downloadedModels = useAtomValue(downloadedModelsAtom)
-  const deleteMessage = useSetAtom(deleteMessageAtom)
   const activeModel = useAtomValue(activeModelAtom)
   const setActiveModel = useSetAtom(activeModelAtom)
   const setStateModel = useSetAtom(stateModelAtom)
@@ -77,7 +70,6 @@ export default function ModelHandler() {
   const activeModelParamsRef = useRef(activeModelParams)
 
   const [tokenSpeed, setTokenSpeed] = useAtom(tokenSpeedAtom)
-  const { engines } = useGetEngines()
   const tokenSpeedRef = useRef(tokenSpeed)
 
   useEffect(() => {
@@ -292,16 +284,14 @@ export default function ModelHandler() {
 
   const generateThreadTitle = (message: ThreadMessage, thread: Thread) => {
     // If this is the first ever prompt in the thread
-    if (
-      !activeModelRef.current ||
-      (thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle
-    )
+    if ((thread.title ?? thread.metadata?.title)?.trim() !== defaultThreadTitle)
       return
 
     // Check model engine; we don't want to generate a title when it's not a local engine. remote model using first promp
     if (
-      activeModelRef.current?.engine !== InferenceEngine.cortex &&
-      activeModelRef.current?.engine !== InferenceEngine.cortex_llamacpp
+      !activeModelRef.current ||
+      (activeModelRef.current?.engine !== InferenceEngine.cortex &&
+        activeModelRef.current?.engine !== InferenceEngine.cortex_llamacpp)
     ) {
       const updatedThread: Thread = {
         ...thread,

--- a/web/hooks/useCreateNewThread.ts
+++ b/web/hooks/useCreateNewThread.ts
@@ -59,21 +59,6 @@ export const useCreateNewThread = () => {
   ) => {
     const defaultModel = model || selectedModel || recommendedModel
 
-    if (!model) {
-      // if we have model, which means user wants to create new thread from Model hub. Allow them.
-
-      // check last thread message, if there empty last message use can not create thread
-      const lastMessage = threads[0]?.metadata?.lastMessage
-
-      if (!lastMessage && threads.length) {
-        return toaster({
-          title: 'No new thread created.',
-          description: `To avoid piling up empty threads, please reuse previous one before creating new.`,
-          type: 'warning',
-        })
-      }
-    }
-
     // modify assistant tools when experimental on, retieval toggle enabled in default
     const assistantTools: AssistantTool = {
       type: 'retrieval',
@@ -146,7 +131,7 @@ export const useCreateNewThread = () => {
     } catch (ex) {
       return toaster({
         title: 'Thread created failed.',
-        description: `To avoid piling up empty threads, please reuse previous one before creating new.`,
+        description: `Could not create a new thread. Please try again.`,
         type: 'error',
       })
     }

--- a/web/hooks/useDeleteThread.ts
+++ b/web/hooks/useDeleteThread.ts
@@ -44,7 +44,7 @@ export default function useDeleteThread() {
             ?.deleteMessage(threadId, message.id)
             .catch(console.error)
         }
-       
+
         const thread = threads.find((e) => e.id === threadId)
         if (thread) {
           const updatedThread = {


### PR DESCRIPTION
This pull request fixed an issue where remote model threads do not have title set properly. Since this PR, there's no thread creation gate because users would want to create multiple threads (with different prompts) beforehand.

![CleanShot 2025-04-20 at 15 50 28](https://github.com/user-attachments/assets/3c06a9db-1125-42f3-81e4-3ad4686605ee)

The refactoring of the `ModelHandler` component in `web/containers/Providers/ModelHandler.tsx` aims to clean up unused imports and streamline its logic.

### Code cleanup and removal of unused imports:

* Removed unused imports such as `ModelExtension`, `useGetEngines`, and `isLocalEngine` from `@janhq/core` and other modules. This helps declutter the file and ensures only necessary dependencies are included.

* Removed the `deleteMessageAtom` and its associated `useSetAtom` call, as it was not being used in the component.

* Removed the `useGetEngines` hook and its destructured `engines` property, as it was not utilized in the component logic.

### Logic simplification:

* Simplified the `generateThreadTitle` function by reorganizing conditions to make the logic more concise and easier to read. This change ensures that the function checks for the presence of an active model and specific engine types in a more streamlined manner.