### PR TITLE
fix: prevent curly quotes from MCP config

### DIFF
--- a/web/screens/Settings/MCP/configuration.tsx
+++ b/web/screens/Settings/MCP/configuration.tsx
@@ -1,4 +1,4 @@
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 
 import { Button, TextArea } from '@janhq/joi'
 import { useAtomValue } from 'jotai'
@@ -11,6 +11,8 @@ const MCPConfiguration = () => {
   const [isSaving, setIsSaving] = useState(false)
   const [error, setError] = useState('')
   const [success, setSuccess] = useState('')
+
+  const textAreaRef = useRef<HTMLTextAreaElement>(null)
 
   const readConfigFile = useCallback(async () => {
     try {
@@ -76,14 +78,37 @@ const MCPConfiguration = () => {
           Configuration File (JSON)
         </label>
         <TextArea
-          // className="h-80 w-full rounded border border-gray-800 p-2 font-mono text-sm"
+          ref={textAreaRef}
           className="font-mono text-xs"
           value={configContent}
           rows={20}
           onChange={(e) => {
-            setConfigContent(e.target.value)
+            const input = e.target
+            const start = input.selectionStart
+            const end = input.selectionEnd
+
+            // Sanitize quotes
+            const originalValue = input.value
+            const sanitizedValue = originalValue
+              .replace(/[“”]/g, '"')
+              .replace(/[‘’]/g, "'")
+
+            // Update content
+            setConfigContent(sanitizedValue)
             setSuccess('')
+
+            // Restore cursor after DOM updates
+            requestAnimationFrame(() => {
+              if (textAreaRef.current) {
+                const offset = sanitizedValue.length - originalValue.length
+                textAreaRef.current.selectionStart = start + offset
+                textAreaRef.current.selectionEnd = end + offset
+              }
+            })
           }}
+          autoComplete="off"
+          autoCorrect="off"
+          spellCheck={false}
         />
       </div>
 


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces enhancements to the `MCPConfiguration` component in the `web/screens/Settings/MCP/configuration.tsx` file. The changes focus on improving the user experience when editing configuration files, particularly by sanitizing input and maintaining cursor position during updates.

### Enhancements to input handling and user experience:

* **Added `useRef` for TextArea reference**: Introduced a `textAreaRef` using `useRef` to manage the cursor position during updates. (`[[1]](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322L1-R1)`, `[[2]](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322R15-R16)`)
* **Sanitized quotes in input**: Implemented logic to replace curly quotes (`“”` and `‘’`) with straight quotes (`"` and `'`) to ensure consistent formatting of the configuration content. (`[web/screens/Settings/MCP/configuration.tsxL79-R111](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322L79-R111)`)
* **Restored cursor position**: Used `requestAnimationFrame` to restore the cursor position after DOM updates caused by sanitization. This ensures a seamless editing experience for the user. (`[web/screens/Settings/MCP/configuration.tsxL79-R111](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322L79-R111)`)

### Accessibility and usability improvements:

* **Disabled browser auto-features**: Added `autoComplete="off"`, `autoCorrect="off"`, and `spellCheck={false}` to the `TextArea` to prevent unwanted browser interventions while editing JSON configuration files. (`[web/screens/Settings/MCP/configuration.tsxL79-R111](diffhunk://#diff-32acd7247a078095f811607a2902c02bc7070611281ad58c813cb49e1813c322L79-R111)`)


## Fixes Issues

![Screenshot 2025-04-21 at 09 42 06](https://github.com/user-attachments/assets/dbccf74f-5422-421f-8c4e-d33330d273df)

- Closes # https://discord.com/channels/1107178041848909847/1362449620239909167
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
