### PR TITLE
feat: permission dialog for tool call requests

### DIFF
--- a/web/containers/ToolCallApprovalModal/index.tsx
+++ b/web/containers/ToolCallApprovalModal/index.tsx
@@ -2,6 +2,7 @@ import { memo, useCallback, useState } from 'react'
 
 import { Button, Modal, ModalClose } from '@janhq/joi'
 import { useSetAtom } from 'jotai'
+
 import { approvedThreadToolsAtom } from '@/helpers/atoms/Thread.atom'
 
 export function useTollCallPromiseModal() {
@@ -50,8 +51,7 @@ export function useTollCallPromiseModal() {
         open={isOpen}
         onOpenChange={(open) => {
           setIsOpen(!isOpen)
-          if(!open)
-            handleCancel()
+          if (!open) handleCancel()
         }}
         content={
           <div>
@@ -63,7 +63,7 @@ export function useTollCallPromiseModal() {
             <div className="mt-4 flex justify-end gap-x-2">
               <ModalClose asChild>
                 <Button
-                  theme="primary"
+                  theme="ghost" variant="outline"
                   onClick={() => {
                     setApprovedToolsAtom((prev) => {
                       const newState = { ...prev }
@@ -87,12 +87,12 @@ export function useTollCallPromiseModal() {
                 </Button>
               </ModalClose>
               <ModalClose asChild>
-                <Button theme="primary" onClick={handleConfirm} autoFocus>
+                <Button theme="ghost" variant="outline" onClick={handleConfirm} autoFocus>
                   Allow once
                 </Button>
               </ModalClose>
               <ModalClose asChild onClick={handleCancel}>
-                <Button theme="ghost">Deny</Button>
+                <Button theme="destructive">Deny</Button>
               </ModalClose>
             </div>
           </div>

--- a/web/containers/ToolCallApprovalModal/index.tsx
+++ b/web/containers/ToolCallApprovalModal/index.tsx
@@ -1,0 +1,104 @@
+import { memo, useCallback, useState } from 'react'
+
+import { Button, Modal, ModalClose } from '@janhq/joi'
+import { useSetAtom } from 'jotai'
+import { approvedThreadToolsAtom } from '@/helpers/atoms/Thread.atom'
+
+export function useTollCallPromiseModal() {
+  const [isOpen, setIsOpen] = useState(false)
+  const setApprovedToolsAtom = useSetAtom(approvedThreadToolsAtom)
+  const [modalProps, setModalProps] = useState<{
+    toolName: string
+    threadId: string
+    resolveRef: ((value: unknown) => void) | null
+  }>({
+    toolName: '',
+    threadId: '',
+    resolveRef: null,
+  })
+
+  // Function to open the modal and return a Promise
+  const showModal = useCallback((toolName: string, threadId: string) => {
+    return new Promise((resolve) => {
+      setModalProps({
+        toolName,
+        threadId,
+        resolveRef: resolve,
+      })
+      setIsOpen(true)
+    })
+  }, [])
+
+  const PromiseModal = useCallback(() => {
+    const handleConfirm = () => {
+      setIsOpen(false)
+      if (modalProps.resolveRef) {
+        modalProps.resolveRef(true)
+      }
+    }
+
+    const handleCancel = () => {
+      setIsOpen(false)
+      if (modalProps.resolveRef) {
+        modalProps.resolveRef(false)
+      }
+    }
+
+    return (
+      <Modal
+        title={<span>Allow tool from {modalProps.toolName} (local)?</span>}
+        open={isOpen}
+        onOpenChange={(open) => {
+          setIsOpen(!isOpen)
+          if(!open)
+            handleCancel()
+        }}
+        content={
+          <div>
+            <p className="text-[hsla(var(--text-secondary))]">
+              Malicious MCP servers or conversation content could potentially
+              trick Jan into attempting harmful actions through your installed
+              tools. Review each action carefully before approving.
+            </p>
+            <div className="mt-4 flex justify-end gap-x-2">
+              <ModalClose asChild>
+                <Button
+                  theme="primary"
+                  onClick={() => {
+                    setApprovedToolsAtom((prev) => {
+                      const newState = { ...prev }
+                      if (!newState[modalProps.threadId]) {
+                        newState[modalProps.threadId] = []
+                      }
+                      if (
+                        !newState[modalProps.threadId].includes(
+                          modalProps.toolName
+                        )
+                      ) {
+                        newState[modalProps.threadId].push(modalProps.toolName)
+                      }
+                      return newState
+                    })
+                    handleConfirm()
+                  }}
+                  autoFocus
+                >
+                  Allow for this chat
+                </Button>
+              </ModalClose>
+              <ModalClose asChild>
+                <Button theme="primary" onClick={handleConfirm} autoFocus>
+                  Allow once
+                </Button>
+              </ModalClose>
+              <ModalClose asChild onClick={handleCancel}>
+                <Button theme="ghost">Deny</Button>
+              </ModalClose>
+            </div>
+          </div>
+        }
+      />
+    )
+  }, [isOpen, modalProps])
+  return { showModal, PromiseModal }
+}

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -72,6 +72,11 @@ export const threadDataReadyAtom = atomWithStorage<boolean>(
  */
 export const threadModelParamsAtom = atom<Record<string, ModelParams>>({})
 
+/**
+ * Store the tool call approval thread id
+ */
+export const approvedThreadToolsAtom = atom<Record<string, string[]>>({})
+
 //// End Thread Atom
 
 /// Active Thread Atom

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useCallback, useEffect, useMemo, useRef, ClipboardEvent } from 'react'
+import { useCallback, useEffect, useMemo, useRef, ClipboardEvent, useContext } from 'react'
 
 import { MessageStatus } from '@janhq/core'
 import { useAtom, useAtomValue } from 'jotai'
@@ -28,6 +28,7 @@ import {
   getActiveThreadIdAtom,
   activeSettingInputBoxAtom,
 } from '@/helpers/atoms/Thread.atom'
+import { ChatContext } from '../../ThreadCenterPanel'
 
 type CustomElement = {
   type: 'paragraph' | 'code' | null
@@ -77,7 +78,8 @@ const RichTextEditor = ({
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)
   const activeSettingInputBox = useAtomValue(activeSettingInputBoxAtom)
   const messages = useAtomValue(getCurrentChatMessagesAtom)
-  const { sendChatMessage } = useSendChatMessage()
+  const { showApprovalModal } = useContext(ChatContext)
+  const { sendChatMessage } = useSendChatMessage(showApprovalModal)
   const { stopInference } = useActiveModel()
   const selectedModel = useAtomValue(selectedModelAtom)
   const largeContentThreshold = 1000

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/RichTextEditor.tsx
@@ -1,5 +1,12 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useCallback, useEffect, useMemo, useRef, ClipboardEvent, useContext } from 'react'
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  ClipboardEvent,
+  useContext,
+} from 'react'
 
 import { MessageStatus } from '@janhq/core'
 import { useAtom, useAtomValue } from 'jotai'
@@ -21,6 +28,8 @@ import { currentPromptAtom } from '@/containers/Providers/Jotai'
 import { useActiveModel } from '@/hooks/useActiveModel'
 import useSendChatMessage from '@/hooks/useSendChatMessage'
 
+import { ChatContext } from '../../ThreadCenterPanel'
+
 import { getCurrentChatMessagesAtom } from '@/helpers/atoms/ChatMessage.atom'
 
 import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
@@ -28,7 +37,6 @@ import {
   getActiveThreadIdAtom,
   activeSettingInputBoxAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { ChatContext } from '../../ThreadCenterPanel'
 
 type CustomElement = {
   type: 'paragraph' | 'code' | null

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 
 import { InferenceEngine } from '@janhq/core'
 
@@ -10,7 +10,6 @@ import {
   useClickOutside,
   Badge,
   Modal,
-  ModalClose,
 } from '@janhq/joi'
 import { useAtom, useAtomValue } from 'jotai'
 import {
@@ -55,6 +54,7 @@ import {
 } from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
 import { ModelTool } from '@/types/model'
+import { ChatContext } from '../../ThreadCenterPanel'
 
 const ChatInput = () => {
   const activeThread = useAtomValue(activeThreadAtom)
@@ -65,7 +65,8 @@ const ChatInput = () => {
   const [activeSettingInputBox, setActiveSettingInputBox] = useAtom(
     activeSettingInputBoxAtom
   )
-  const { sendChatMessage } = useSendChatMessage()
+  const { showApprovalModal } = useContext(ChatContext)
+  const { sendChatMessage } = useSendChatMessage(showApprovalModal)
   const selectedModel = useAtomValue(selectedModelAtom)
 
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -36,6 +36,7 @@ import useSendChatMessage from '@/hooks/useSendChatMessage'
 import { uploader } from '@/utils/file'
 import { isLocalEngine } from '@/utils/modelEngine'
 
+import { ChatContext } from '../../ThreadCenterPanel'
 import FileUploadPreview from '../FileUploadPreview'
 import ImageUploadPreview from '../ImageUploadPreview'
 
@@ -54,7 +55,6 @@ import {
 } from '@/helpers/atoms/Thread.atom'
 import { activeTabThreadRightPanelAtom } from '@/helpers/atoms/ThreadRightPanel.atom'
 import { ModelTool } from '@/types/model'
-import { ChatContext } from '../../ThreadCenterPanel'
 
 const ChatInput = () => {
   const activeThread = useAtomValue(activeThreadAtom)

--- a/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/no-explicit-any */
-import { useEffect, useRef, useState } from 'react'
+import { useContext, useEffect, useRef, useState } from 'react'
 
 import {
   ConversationalExtension,
@@ -31,6 +31,7 @@ import {
   activeThreadAtom,
   getActiveThreadIdAtom,
 } from '@/helpers/atoms/Thread.atom'
+import { ChatContext } from '../../ThreadCenterPanel'
 
 type Props = {
   message: ThreadMessage
@@ -42,7 +43,8 @@ const EditChatInput: React.FC<Props> = ({ message }) => {
   const messages = useAtomValue(getCurrentChatMessagesAtom)
 
   const [editPrompt, setEditPrompt] = useAtom(editPromptAtom)
-  const { sendChatMessage } = useSendChatMessage()
+  const { showApprovalModal } = useContext(ChatContext)
+  const { sendChatMessage } = useSendChatMessage(showApprovalModal)
   const setMessages = useSetAtom(setConvoMessagesAtom)
   const activeThreadId = useAtomValue(getActiveThreadIdAtom)
   const spellCheck = useAtomValue(spellCheckAtom)

--- a/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/EditChatInput/index.tsx
@@ -19,6 +19,8 @@ import { useActiveModel } from '@/hooks/useActiveModel'
 
 import useSendChatMessage from '@/hooks/useSendChatMessage'
 
+import { ChatContext } from '../../ThreadCenterPanel'
+
 import { extensionManager } from '@/extension'
 
 import {
@@ -31,7 +33,6 @@ import {
   activeThreadAtom,
   getActiveThreadIdAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { ChatContext } from '../../ThreadCenterPanel'
 
 type Props = {
   message: ThreadMessage

--- a/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
@@ -1,4 +1,4 @@
-import { useCallback } from 'react'
+import { useCallback, useContext } from 'react'
 
 import {
   MessageStatus,
@@ -34,13 +34,15 @@ import {
   updateThreadAtom,
   updateThreadStateLastMessageAtom,
 } from '@/helpers/atoms/Thread.atom'
+import { ChatContext } from '../../ThreadCenterPanel'
 
 const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
   const deleteMessage = useSetAtom(deleteMessageAtom)
   const setEditMessage = useSetAtom(editMessageAtom)
   const thread = useAtomValue(activeThreadAtom)
   const messages = useAtomValue(getCurrentChatMessagesAtom)
-  const { resendChatMessage } = useSendChatMessage()
+  const { showApprovalModal } = useContext(ChatContext)
+  const { resendChatMessage } = useSendChatMessage(showApprovalModal)
   const clipboard = useClipboard({ timeout: 1000 })
   const updateThreadLastMessage = useSetAtom(updateThreadStateLastMessageAtom)
   const updateThread = useSetAtom(updateThreadAtom)

--- a/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/MessageToolbar/index.tsx
@@ -22,6 +22,8 @@ import {
 import { useClipboard } from '@/hooks/useClipboard'
 import useSendChatMessage from '@/hooks/useSendChatMessage'
 
+import { ChatContext } from '../../ThreadCenterPanel'
+
 import { extensionManager } from '@/extension'
 import {
   deleteMessageAtom,
@@ -34,7 +36,6 @@ import {
   updateThreadAtom,
   updateThreadStateLastMessageAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { ChatContext } from '../../ThreadCenterPanel'
 
 const MessageToolbar = ({ message }: { message: ThreadMessage }) => {
   const deleteMessage = useSetAtom(deleteMessageAtom)

--- a/web/screens/Thread/ThreadCenterPanel/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/index.tsx
@@ -17,6 +17,8 @@ import ModelStart from '@/containers/Loader/ModelStart'
 import { fileUploadAtom } from '@/containers/Providers/Jotai'
 import { snackbar } from '@/containers/Toast'
 
+import { useTollCallPromiseModal } from '@/containers/ToolCallApprovalModal'
+
 import { activeModelAtom } from '@/hooks/useActiveModel'
 import { reloadModelAtom } from '@/hooks/useSendChatMessage'
 
@@ -36,7 +38,6 @@ import {
   engineParamsUpdateAtom,
   isGeneratingResponseAtom,
 } from '@/helpers/atoms/Thread.atom'
-import { useTollCallPromiseModal } from '@/containers/ToolCallApprovalModal'
 
 const renderError = (code: string) => {
   switch (code) {

--- a/web/screens/Thread/ThreadCenterPanel/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/index.tsx
@@ -1,6 +1,6 @@
 /* eslint-disable @typescript-eslint/naming-convention */
 
-import { memo, useEffect, useState } from 'react'
+import { createContext, memo, useEffect, useState } from 'react'
 
 import { Accept, useDropzone } from 'react-dropzone'
 
@@ -36,6 +36,7 @@ import {
   engineParamsUpdateAtom,
   isGeneratingResponseAtom,
 } from '@/helpers/atoms/Thread.atom'
+import { useTollCallPromiseModal } from '@/containers/ToolCallApprovalModal'
 
 const renderError = (code: string) => {
   switch (code) {
@@ -52,6 +53,16 @@ const renderError = (code: string) => {
       return 'Oops, something error, please try again.'
   }
 }
+
+interface ChatContextType {
+  showApprovalModal:
+    | ((toolName: string, threadId: string) => Promise<unknown>)
+    | undefined
+}
+
+export const ChatContext = createContext<ChatContextType>({
+  showApprovalModal: undefined,
+})
 
 const ThreadCenterPanel = () => {
   const [dragRejected, setDragRejected] = useState({ code: '' })
@@ -71,6 +82,7 @@ const ThreadCenterPanel = () => {
     : {
         'application/pdf': ['.pdf'],
       }
+  const { showModal, PromiseModal } = useTollCallPromiseModal()
 
   const { getRootProps, isDragReject } = useDropzone({
     noClick: true,
@@ -158,73 +170,82 @@ const ThreadCenterPanel = () => {
   const isGeneratingResponse = useAtomValue(isGeneratingResponseAtom)
 
   return (
-    <CenterPanelContainer>
-      <div
-        className="relative flex h-full w-full flex-col outline-none"
-        {...getRootProps()}
-      >
-        {dragOver && (
-          <div className="absolute z-50 mx-auto h-full w-full p-8 backdrop-blur-lg">
-            <div
-              className={twMerge(
-                'flex h-full w-full items-center justify-center rounded-lg border border-dashed border-[hsla(var(--primary-bg))]',
-                isDragReject && 'border-[hsla(var(--destructive-bg))]'
-              )}
-            >
-              <div className="mx-auto w-1/2 text-center">
-                <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full">
-                  <UploadCloudIcon
-                    size={24}
-                    className="text-[hsla(var(--primary-bg))]"
-                  />
-                </div>
-                <div className="mt-4 text-[hsla(var(--primary-bg))]">
-                  <h6 className="font-bold">
-                    {isDragReject
-                      ? `Currently, we only support 1 attachment at the same time with ${
-                          activeAssistant?.model.settings?.mmproj
-                            ? 'PDF, JPEG, JPG, PNG'
-                            : 'PDF'
-                        } format`
-                      : 'Drop file here'}
-                  </h6>
-                  {!isDragReject && (
-                    <p className="mt-2">
-                      {activeAssistant?.model.settings?.mmproj
-                        ? 'PDF, JPEG, JPG, PNG'
-                        : 'PDF'}
-                    </p>
-                  )}
+    <ChatContext.Provider
+      value={{
+        showApprovalModal: showModal,
+      }}
+    >
+      <CenterPanelContainer>
+        <div
+          className="relative flex h-full w-full flex-col outline-none"
+          {...getRootProps()}
+        >
+          {dragOver && (
+            <div className="absolute z-50 mx-auto h-full w-full p-8 backdrop-blur-lg">
+              <div
+                className={twMerge(
+                  'flex h-full w-full items-center justify-center rounded-lg border border-dashed border-[hsla(var(--primary-bg))]',
+                  isDragReject && 'border-[hsla(var(--destructive-bg))]'
+                )}
+              >
+                <div className="mx-auto w-1/2 text-center">
+                  <div className="mx-auto inline-flex h-12 w-12 items-center justify-center rounded-full">
+                    <UploadCloudIcon
+                      size={24}
+                      className="text-[hsla(var(--primary-bg))]"
+                    />
+                  </div>
+                  <div className="mt-4 text-[hsla(var(--primary-bg))]">
+                    <h6 className="font-bold">
+                      {isDragReject
+                        ? `Currently, we only support 1 attachment at the same time with ${
+                            activeAssistant?.model.settings?.mmproj
+                              ? 'PDF, JPEG, JPG, PNG'
+                              : 'PDF'
+                          } format`
+                        : 'Drop file here'}
+                    </h6>
+                    {!isDragReject && (
+                      <p className="mt-2">
+                        {activeAssistant?.model.settings?.mmproj
+                          ? 'PDF, JPEG, JPG, PNG'
+                          : 'PDF'}
+                      </p>
+                    )}
+                  </div>
                 </div>
               </div>
             </div>
-          </div>
-        )}
-        <div className={twMerge('flex h-full w-full flex-col justify-between')}>
-          {activeThread ? (
-            <div className="flex h-full w-full overflow-x-hidden">
-              <ChatBody />
-            </div>
-          ) : (
-            <RequestDownloadModel />
           )}
-
-          {!engineParamsUpdate && <ModelStart />}
-
-          {reloadModel && <ModelReload />}
-
-          {activeModel && isGeneratingResponse && <GenerateResponse />}
           <div
-            className={twMerge(
-              'mx-auto w-full',
-              chatWidth === 'compact' && 'max-w-[700px]'
-            )}
+            className={twMerge('flex h-full w-full flex-col justify-between')}
           >
-            <ChatInput />
+            {activeThread ? (
+              <div className="flex h-full w-full overflow-x-hidden">
+                <ChatBody />
+              </div>
+            ) : (
+              <RequestDownloadModel />
+            )}
+
+            {!engineParamsUpdate && <ModelStart />}
+
+            {reloadModel && <ModelReload />}
+
+            {activeModel && isGeneratingResponse && <GenerateResponse />}
+            <div
+              className={twMerge(
+                'mx-auto w-full',
+                chatWidth === 'compact' && 'max-w-[700px]'
+              )}
+            >
+              <ChatInput />
+            </div>
           </div>
         </div>
-      </div>
-    </CenterPanelContainer>
+      </CenterPanelContainer>
+      <PromiseModal />
+    </ChatContext.Provider>
   )
 }
 


### PR DESCRIPTION
This pull request introduces a tool call approval modal, enhancing user control over tool usage in chat threads. It includes the creation of a modal component to approve or deny tool calls, integration of this modal into various parts of the application, and the introduction of a new atom to track approved tools.

![CleanShot 2025-04-22 at 23 07 31@2x](https://github.com/user-attachments/assets/c891f0a1-b817-451b-9cac-9cee8fbfee98)


https://github.com/user-attachments/assets/af75ff39-7a33-4553-ac6b-0a6bd4f53993



### New Feature: Tool Call Approval Modal
* **Modal Component**: Added `useTollCallPromiseModal` in `web/containers/ToolCallApprovalModal/index.tsx` to create a reusable modal for approving or denying tool calls. The modal supports both one-time and thread-specific approvals.

### State Management Updates
* **New Atom**: Introduced `approvedThreadToolsAtom` in `web/helpers/atoms/Thread.atom.ts` to store thread-specific tool approvals.

### Integration with Existing Components
* **Chat Message Handling**: Updated `useSendChatMessage` in `web/hooks/useSendChatMessage.ts` to check for tool approval using the new modal and atom. If a tool call is not pre-approved, the modal is displayed to the user. [[1]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860R58) [[2]](diffhunk://#diff-4bcabf86358832bf98408dfb9dc4ef66ba0d94bd74dc5281e8ba8a2586668860L483-R505)
* **Rich Text Editor, Chat Input, Edit Chat Input, and Message Toolbar**: Integrated the tool approval modal into these components by passing the `showApprovalModal` function from the newly created `ChatContext`. [[1]](diffhunk://#diff-3a47c34cdde40a71d284d97ee2e3d6235eced5ed23322b02be7569348c070d58L80-R82) [[2]](diffhunk://#diff-6939e74c6339668f085c4edb1a90987fea21a6e5679fa3ff95495629ba249b4aL68-R69) [[3]](diffhunk://#diff-76d00976c1356798136c0a7a790d72bae5603018e9db5a42167f015ef0c5300aL45-R47) [[4]](diffhunk://#diff-07bea7d15d67880f331f5ffb1c2debfce463d3057b4caa1e85575031f0bf78ceR37-R45)

### Context Provider
* **Chat Context**: Introduced `ChatContext` in `web/screens/Thread/ThreadCenterPanel/index.tsx` to provide the `showApprovalModal` function to child components, ensuring consistent access to the modal functionality. [[1]](diffhunk://#diff-cb76c7ab06366b4233689217aed26f81c523a8c2f490dd28e021385bb3ad0eb6R57-R66) [[2]](diffhunk://#diff-cb76c7ab06366b4233689217aed26f81c523a8c2f490dd28e021385bb3ad0eb6R173-R177) [[3]](diffhunk://#diff-cb76c7ab06366b4233689217aed26f81c523a8c2f490dd28e021385bb3ad0eb6R247-R248)