### PR TITLE
ci(workflow): add condition pr labelling job for forked repo

### DIFF
--- a/.github/workflows/auto-label-conventional-commits.yaml
+++ b/.github/workflows/auto-label-conventional-commits.yaml
@@ -6,6 +6,7 @@ on:
       - opened
 jobs:
   label_prs:
+    if: github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
This pull request introduces a small but significant change to the `.github/workflows/auto-label-conventional-commits.yaml` file. The change adds a conditional statement to ensure that the workflow only runs when the pull request originates from the same repository.

* [`.github/workflows/auto-label-conventional-commits.yaml`](diffhunk://#diff-a394f880f50eb3772ae5a74c2a03140168abffbc204db8945f133da68d312784R9): Added an `if` condition to the `label_prs` job to check that `github.event.pull_request.head.repo.full_name` matches `github.repository`.