### PR TITLE
chore: fix jan about doc

### DIFF
--- a/docs/src/pages/about/index.mdx
+++ b/docs/src/pages/about/index.mdx
@@ -81,7 +81,7 @@ Our products are designed with [Extension APIs](/docs/extensions), and we do our
 
 We are part of a larger open-source community and are committed to being a good jigsaw puzzle piece. We credit and actively contribute to upstream projects. 
 
-We adopt a public-by-default approach to [Project Management](https://github.com/orgs/menloresearch/projects/5), [Roadmaps](https://github.com/orgs/menloresearch/projects/5/views/31), and Helpdesk for our products. 
+We adopt a public-by-default approach to [Project Management](https://github.com/orgs/menloresearch/projects/30/views/1), [Roadmaps](https://github.com/orgs/menloresearch/projects/30/views/4), and Helpdesk for our products. 
 
 ## Inspirations
 

--- a/docs/src/pages/about/team.mdx
+++ b/docs/src/pages/about/team.mdx
@@ -18,39 +18,12 @@ import { Cards, Card } from 'nextra/components'
 
 # Team
 
-We're a small, fully-remote team, mostly based in Southeast Asia. 
+We're a small, fully-remote team, mostly based in Southeast Asia.
 
 We are committed to become a global company. You can check our [Careers page](https://menlo.bamboohr.com/careers) if you'd like to join us on our adventure.
+
+You can find our full team members on the [Menlo handbook](https://menlo.ai/handbook/team#jan).
 
 <Callout emoji="🌏">
 Ping us in [Discord](https://discord.gg/AAGQNpJQtH) if you're keen to talk to us!
 </Callout>
-
-## Core Team
-
-<Cards>
-    <Card title="Nicole Zhu" href="#" />
-    <Card title="Daniel Ong" href="#" />
-    <Card title="Louis Le" href="#" />
-    <Card title="Diane Le" href="#" />
-    <Card title="Alan Dao" href="#" />
-    <Card title="Hien To" href="#" />
-    <Card title="James Nguyen" href="#" />
-    <Card title="Ong Yeowhua" href="#" />
-    <Card title="Hiro Vuong" href="#" />
-    <Card title="Faisal Amir" href="#" />
-    <Card title="Rex Ha" href="#" />
-    <Card title="Ashley Tran" href="#" />
-    <Card title="Van Pham" href="#" />
-    <Card title="Ed Chessman" href="#" />
-    <Card title="Emre Can Kartal" href="#" />
-    <Card title="Cameron Nguyen" href="#" />
-    <Card title="Sang Nguyen" href="#" />
-</Cards>
-
-## Board Members
-
-<Cards>
-    <Card title="Dobby" href="#" />
-    <Card title="Mama Cat" href="#" />
-</Cards>


### PR DESCRIPTION
This pull request makes updates to the "About" section of the documentation, focusing on improving clarity and simplifying team member information. The most important changes include updating project management and roadmap links, and replacing individual team member cards with a link to the Menlo handbook.

### Updates to project and team information:

* **Updated project management and roadmap links**: The links to the public project management and roadmap views were updated to reflect the correct URLs for better accessibility. (`docs/src/pages/about/index.mdx`)

* **Simplified team member section**: Removed individual team member and board member cards and replaced them with a single link to the Menlo handbook, which provides comprehensive team information. (`docs/src/pages/about/team.mdx`)