### PR TITLE
feat: allow users to enable and disable tools

### DIFF
--- a/web/containers/ToolCallApprovalModal/index.tsx
+++ b/web/containers/ToolCallApprovalModal/index.tsx
@@ -63,7 +63,8 @@ export function useTollCallPromiseModal() {
             <div className="mt-4 flex justify-end gap-x-2">
               <ModalClose asChild>
                 <Button
-                  theme="ghost" variant="outline"
+                  theme="ghost"
+                  variant="outline"
                   onClick={() => {
                     setApprovedToolsAtom((prev) => {
                       const newState = { ...prev }
@@ -87,7 +88,12 @@ export function useTollCallPromiseModal() {
                 </Button>
               </ModalClose>
               <ModalClose asChild>
-                <Button theme="ghost" variant="outline" onClick={handleConfirm} autoFocus>
+                <Button
+                  theme="ghost"
+                  variant="outline"
+                  onClick={handleConfirm}
+                  autoFocus
+                >
                   Allow once
                 </Button>
               </ModalClose>

--- a/web/helpers/atoms/Thread.atom.ts
+++ b/web/helpers/atoms/Thread.atom.ts
@@ -24,6 +24,7 @@ enum ThreadStorageAtomKeys {
   ThreadStates = 'threadStates',
   ThreadList = 'threadList',
   ThreadListReady = 'threadListReady',
+  DisabledTools = 'disabledTools',
 }
 
 //// Threads Atom
@@ -73,9 +74,17 @@ export const threadDataReadyAtom = atomWithStorage<boolean>(
 export const threadModelParamsAtom = atom<Record<string, ModelParams>>({})
 
 /**
- * Store the tool call approval thread id
+ * Store the tool call approval for thread id
  */
 export const approvedThreadToolsAtom = atom<Record<string, string[]>>({})
+
+/**
+ * Store the tool call disabled for thread id
+ */
+export const disabledThreadToolsAtom = atomWithStorage<string[]>(
+  ThreadStorageAtomKeys.DisabledTools,
+  []
+)
 
 //// End Thread Atom
 


### PR DESCRIPTION
This PR introduces the ability to enable or disable individual tools within the MCP tools list. Users can now toggle tool availability through the updated interface, allowing for more flexible and customizable workflows.

https://github.com/user-attachments/assets/c6ab577c-d38f-4328-8726-c4b2aa91a03b

- Added support for tracking tool state (enabled/disabled)
- Updated MCP tools list UI to reflect tool states
- Implemented logic to persist and respect tool states across sessions

## How to test this?
- [ ] Go to settings and add any MCP servers.
- [ ] Back to the chat screen and disable some tools from the MCP tool list.
- [ ] Check if the tool is still being used.