### PR TITLE
enhancement: tool call block should be wrapped in a collapsible scroll area

### DIFF
--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -202,6 +202,7 @@ const ChatBody = memo(
                       isCurrentMessage={
                         virtualRow.index === messages?.length - 1
                       }
+                      isLast={virtualRow.index === messages?.length - 1}
                       onExpand={(props) =>
                         preserveScrollOnExpand(() => {
                           setToolCallExpanded((prev) => ({

--- a/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatBody/index.tsx
@@ -4,13 +4,15 @@ import { ThreadMessage } from '@janhq/core'
 import { ScrollArea } from '@janhq/joi'
 import { useVirtualizer } from '@tanstack/react-virtual'
 
-import { useAtomValue } from 'jotai'
+import { useAtomValue, useSetAtom } from 'jotai'
 
 import { loadModelErrorAtom } from '@/hooks/useActiveModel'
 
 import ChatItem from '../ChatItem'
 
 import LoadModelError from '../LoadModelError'
+
+import { toolCallBlockStateAtom } from '../TextMessage/ToolCallBlock'
 
 import EmptyThread from './EmptyThread'
 
@@ -65,9 +67,11 @@ const ChatBody = memo(
     const parentRef = useRef<HTMLDivElement>(null)
     const prevScrollTop = useRef(0)
     const isUserManuallyScrollingUp = useRef(false)
+    const isNestedScrollviewExpanding = useRef(false)
     const currentThread = useAtomValue(activeThreadAtom)
     const isBlockingSend = useAtomValue(isBlockingSendAtom)
     const showScrollBar = useAtomValue(showScrollBarAtom)
+    const setToolCallExpanded = useSetAtom(toolCallBlockStateAtom)
 
     const count = useMemo(
       () => (messages?.length ?? 0) + (loadModelError ? 1 : 0),
@@ -97,7 +101,10 @@ const ChatBody = memo(
       _,
       instance
     ) => {
-      if (isUserManuallyScrollingUp.current === true && isBlockingSend)
+      if (
+        isNestedScrollviewExpanding ||
+        (isUserManuallyScrollingUp.current === true && isBlockingSend)
+      )
         return false
       return (
         // item.start < (instance.scrollOffset ?? 0) &&
@@ -129,6 +136,22 @@ const ChatBody = memo(
       },
       [isBlockingSend]
     )
+
+    const preserveScrollOnExpand = (callback: () => void) => {
+      isNestedScrollviewExpanding.current = true
+      const scrollEl = parentRef.current
+      const prevScrollTop = scrollEl?.scrollTop ?? 0
+      const prevScrollHeight = scrollEl?.scrollHeight ?? 0
+
+      callback() // Expand content (e.g. setIsExpanded(true))
+
+      if (scrollEl)
+        requestAnimationFrame(() => {
+          const newScrollHeight = scrollEl?.scrollHeight ?? 0
+          scrollEl.scrollTop =
+            prevScrollTop + (newScrollHeight - prevScrollHeight)
+        })
+    }
 
     return (
       <div className="flex h-full w-full flex-col overflow-x-hidden">
@@ -178,6 +201,14 @@ const ChatBody = memo(
                       index={virtualRow.index}
                       isCurrentMessage={
                         virtualRow.index === messages?.length - 1
+                      }
+                      onExpand={(props) =>
+                        preserveScrollOnExpand(() => {
+                          setToolCallExpanded((prev) => ({
+                            ...prev,
+                            ...props,
+                          }))
+                        })
                       }
                     />
                   )}

--- a/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
@@ -22,6 +22,7 @@ type Props = {
   loadModelError?: string
   isCurrentMessage?: boolean
   index: number
+  isLast: boolean
   onExpand: (props: { [id: number]: boolean }) => void
 } & ThreadMessage
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatItem/index.tsx
@@ -22,6 +22,7 @@ type Props = {
   loadModelError?: string
   isCurrentMessage?: boolean
   index: number
+  onExpand: (props: { [id: number]: boolean }) => void
 } & ThreadMessage
 
 const ChatItem = forwardRef<Ref, Props>((message, ref) => {
@@ -81,6 +82,7 @@ const ChatItem = forwardRef<Ref, Props>((message, ref) => {
               status={status}
               index={message.index}
               isCurrentMessage={message.isCurrentMessage ?? false}
+              onExpand={message.onExpand}
             />
           </div>
         )}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
@@ -1,7 +1,10 @@
 import React from 'react'
 
+import { ScrollArea } from '@janhq/joi'
 import { atom, useAtom } from 'jotai'
 import { ChevronDown, ChevronUp, Loader } from 'lucide-react'
+
+import { twMerge } from 'tailwind-merge'
 
 import { MarkdownTextMessage } from './MarkdownTextMessage'
 
@@ -10,16 +13,18 @@ interface Props {
   name: string
   id: number
   loading: boolean
+  onExpand: (props: { [id: number]: boolean }) => void
 }
 
-const toolCallBlockStateAtom = atom<{ [id: number]: boolean }>({})
+export const toolCallBlockStateAtom = atom<{ [id: number]: boolean }>({})
 
-const ToolCallBlock = ({ id, name, result, loading }: Props) => {
+const ToolCallBlock = ({ id, name, result, loading, onExpand }: Props) => {
   const [collapseState, setCollapseState] = useAtom(toolCallBlockStateAtom)
 
   const isExpanded = collapseState[id] ?? false
   const handleClick = () => {
-    setCollapseState((prev) => ({ ...prev, [id]: !isExpanded }))
+    onExpand({ [id]: !isExpanded })
+    // setCollapseState((prev) => ({ ...prev, [id]: !isExpanded }))
   }
   return (
     <div className="mx-auto w-full">
@@ -38,17 +43,21 @@ const ToolCallBlock = ({ id, name, result, loading }: Props) => {
               <ChevronDown className="h-4 w-4" />
             )}
             <span className="font-medium">
-              {' '}
               View result from <span className="font-bold">{name}</span>
             </span>
           </button>
         </div>
 
-        {isExpanded && (
+        <ScrollArea
+          className={twMerge(
+            'w-full overflow-hidden transition-all duration-300',
+            isExpanded ? 'max-h-96' : 'max-h-0'
+          )}
+        >
           <div className="mt-2 overflow-x-hidden pl-6 text-[hsla(var(--text-secondary))]">
             <span>{result ?? ''} </span>
           </div>
-        )}
+        </ScrollArea>
       </div>
     </div>
   )

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/ToolCallBlock.tsx
@@ -24,7 +24,6 @@ const ToolCallBlock = ({ id, name, result, loading, onExpand }: Props) => {
   const isExpanded = collapseState[id] ?? false
   const handleClick = () => {
     onExpand({ [id]: !isExpanded })
-    // setCollapseState((prev) => ({ ...prev, [id]: !isExpanded }))
   }
   return (
     <div className="mx-auto w-full">

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -103,15 +103,7 @@ const MessageContainer: React.FC<
               isUser && 'text-gray-500'
             )}
           >
-            {!isUser && (
-              <>
-                {props.metadata && 'model' in props.metadata
-                  ? (props.metadata?.model as string)
-                  : props.isCurrentMessage
-                    ? selectedModel?.name
-                    : (activeAssistant?.assistant_name ?? props.role)}
-              </>
-            )}
+            {!isUser && <>{props.role}</>}
           </div>
 
           <p className="text-xs font-medium text-gray-400">

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -33,6 +33,7 @@ const MessageContainer: React.FC<
   ThreadMessage & {
     isCurrentMessage: boolean
     index: number
+    isLast: boolean
     onExpand: (props: { [id: number]: boolean }) => void
   }
 > = (props) => {
@@ -124,10 +125,12 @@ const MessageContainer: React.FC<
         <div
           className={twMerge(
             'absolute right-0 order-1 flex cursor-pointer items-center justify-start gap-x-2 transition-all',
-            twMerge(
-              'hidden group-hover:absolute group-hover:-bottom-4 group-hover:right-4 group-hover:z-50 group-hover:flex',
-              image && 'group-hover:-top-2'
-            ),
+            !props.isLast
+              ? twMerge(
+                  'hidden group-hover:absolute group-hover:right-4 group-hover:top-4 group-hover:z-50 group-hover:flex',
+                  image && 'group-hover:-top-2'
+                )
+              : 'relative left-0 order-2 flex w-full justify-between opacity-0 group-hover:opacity-100',
 
             props.isCurrentMessage && 'opacity-100'
           )}

--- a/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/TextMessage/index.tsx
@@ -30,7 +30,11 @@ import { selectedModelAtom } from '@/helpers/atoms/Model.atom'
 import { chatWidthAtom } from '@/helpers/atoms/Setting.atom'
 
 const MessageContainer: React.FC<
-  ThreadMessage & { isCurrentMessage: boolean; index: number }
+  ThreadMessage & {
+    isCurrentMessage: boolean
+    index: number
+    onExpand: (props: { [id: number]: boolean }) => void
+  }
 > = (props) => {
   const isUser = props.role === ChatCompletionRole.User
   const isSystem = props.role === ChatCompletionRole.System
@@ -195,6 +199,7 @@ const MessageContainer: React.FC<
                 <>
                   {props.metadata.tool_calls.map((toolCall) => (
                     <ToolCallBlock
+                      onExpand={props.onExpand}
                       id={toolCall.tool?.id}
                       name={toolCall.tool?.function?.name ?? ''}
                       key={toolCall.tool?.id}


### PR DESCRIPTION
## Describe Your Changes

Improved the UI by wrapping the tool call block in a collapsible container with scroll support. This keeps the interface clean and more manageable, especially when tool calls produce long or verbose outputs.
This also fixes the glitchy issue when users hover over the bottommost message.

https://github.com/user-attachments/assets/2e495823-05ab-4f68-8eb5-8f8cb078d5cd

No UI glitch issue when reaching the bottommost message

https://github.com/user-attachments/assets/a10b2d72-f4f2-4713-8619-5c53bb183ef4

Simplify assistant display name until the new UI/UX arrived.
![CleanShot 2025-04-23 at 22 51 26@2x](https://github.com/user-attachments/assets/8e2e21cf-7fb9-4062-9007-b3dd25e4c706)


- Cleaner UI for large tool call outputs
- Easier navigation and focus on relevant content
- Optional visibility via collapsible section

## How to test?
- [ ] Send a tool call message that produce long response (e.g. fetch)
- [ ] Click to expand tool call response output
- [ ] See it expandes and do not push the content to top
