### PR TITLE
enhancement: automatically update MCP tool list UI on server change

### DIFF
--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -6,7 +6,7 @@ use std::{
     sync::{Arc, Mutex},
 };
 use tar::Archive;
-use tauri::{App, Listener, Manager};
+use tauri::{App, Emitter, Listener, Manager};
 use tauri_plugin_shell::process::CommandEvent;
 use tauri_plugin_shell::ShellExt;
 use tauri_plugin_store::StoreExt;
@@ -185,10 +185,12 @@ pub fn setup_mcp(app: &App) {
     let state = app.state::<AppState>().inner();
     let app_path_str = app_path.to_str().unwrap().to_string();
     let servers = state.mcp_servers.clone();
+    let app_handle = app.handle().clone();
     tauri::async_runtime::spawn(async move {
         if let Err(e) = run_mcp_commands(app_path_str, servers).await {
             log::error!("Failed to run mcp commands: {}", e);
         }
+        app_handle.emit("mcp-update", "MCP servers updated").unwrap();
     });
 }
 

--- a/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
+++ b/web/screens/Thread/ThreadCenterPanel/ChatInput/index.tsx
@@ -12,6 +12,7 @@ import {
   Modal,
   Switch,
 } from '@janhq/joi'
+import { listen } from '@tauri-apps/api/event'
 import { useAtom, useAtomValue } from 'jotai'
 import {
   FileTextIcon,
@@ -115,6 +116,12 @@ const ChatInput = () => {
   useEffect(() => {
     window.core?.api?.getTools().then((data: ModelTool[]) => {
       setTools(data)
+    })
+
+    listen('mcp-update', (event) => {
+      window.core?.api?.getTools().then((data: ModelTool[]) => {
+        setTools(data)
+      })
     })
   }, [])
 


### PR DESCRIPTION
## Describe Your Changes
This PR enhances the MCP tool by enabling the tool list UI to automatically refresh when changes occur on the server. Previously, users had to manually refresh or navigate away to see updates, which could lead to confusion or outdated information being displayed.

https://github.com/user-attachments/assets/9d8c7c6b-709c-4814-8393-ecb0503a3440

- Implemented a listener for server-side changes relevant to the tool list.
- Integrated automatic UI update logic to reflect real-time changes.

## Testing
- [ ] Verified that UI updates occur automatically when:
- [ ] Tools are added or removed from the server.
