### PR TITLE
enhancement: cache MCP Server search results to enhance UX

### DIFF
--- a/web/screens/Settings/MCP/search.tsx
+++ b/web/screens/Settings/MCP/search.tsx
@@ -1,6 +1,8 @@
 import React, { useState, useEffect, useCallback } from 'react'
 
 import { Button, Input } from '@janhq/joi'
+import { useAtom } from 'jotai'
+import { atomWithStorage } from 'jotai/utils'
 import { PlusIcon } from 'lucide-react'
 import { npxFinder, NPMPackage } from 'npx-scope-finder'
 
@@ -16,12 +18,13 @@ interface MCPConfig {
   }
 }
 
+const mcpPackagesAtom = atomWithStorage<NPMPackage[]>('mcpPackages', [])
 const MCPSearch = () => {
   const [showToast, setShowToast] = useState(false)
   const [toastMessage, setToastMessage] = useState('')
   const [toastType, setToastType] = useState<'success' | 'error'>('success')
   const [orgName, setOrgName] = useState('@modelcontextprotocol')
-  const [packages, setPackages] = useState<NPMPackage[]>([])
+  const [packages, setPackages] = useAtom(mcpPackagesAtom)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
 

--- a/web/screens/Settings/MCP/search.tsx
+++ b/web/screens/Settings/MCP/search.tsx
@@ -173,7 +173,7 @@ const MCPSearch = () => {
       // Check if this server already exists
       if (config.mcpServers[serverName]) {
         toaster({
-          title: `Add ${serverName} success`,
+          title: `Add ${serverName}`,
           description: `Server ${serverName} already exists in configuration`,
           type: 'error',
         })
@@ -194,7 +194,7 @@ const MCPSearch = () => {
       await window.core?.api?.restartMcpServers()
 
       toaster({
-        title: `Add ${serverName} success`,
+        title: `Add ${serverName}`,
         description: `Added ${serverName} to MCP configuration`,
         type: 'success',
       })


### PR DESCRIPTION
## Describe Your Changes

This PR adds caching for MCP server search results during the initial page load to eliminate the blank state for first-time users. Previously, users visiting the page for the first time would experience a brief blank screen while search results were fetched from the server. With this update, initial data is fetched and cached early in the lifecycle, allowing the UI to render meaningful content immediately.

https://github.com/user-attachments/assets/2d6d2b30-584a-47b5-adfe-3dba109b7436


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
