### PR TITLE
chore: fix headers

### DIFF
--- a/.github/workflows/jan-docs-new-release.yaml
+++ b/.github/workflows/jan-docs-new-release.yaml
@@ -49,7 +49,7 @@ jobs:
         run: yarn install
       - name: Build website
         working-directory: docs
-        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects
+        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects && cp _headers out/_headers
 
       - name: Publish to Cloudflare Pages Production
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/jan-docs.yml
+++ b/.github/workflows/jan-docs.yml
@@ -55,7 +55,7 @@ jobs:
         run: yarn install
       - name: Build website
         working-directory: docs
-        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects
+        run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects && cp _headers out/_headers
 
       - name: Publish to Cloudflare Pages PR Preview and Staging
         if: github.event_name == 'pull_request'

--- a/docs/_headers
+++ b/docs/_headers
@@ -1,0 +1,4 @@
+/*
+  X-Frame-Options: SAMEORIGIN
+  Permissions-Policy: interest-cohort=()
+  Strict-Transport-Security: max-age=31536000; includeSubDomains; preload


### PR DESCRIPTION
This pull request includes updates to the documentation build process and introduces a new `_headers` file to enhance security configurations for the deployed website. The key changes involve modifying the GitHub Actions workflows to include the `_headers` file during the build process and adding security-related headers.

### Updates to GitHub Actions workflows:

* [`.github/workflows/jan-docs-new-release.yaml`](diffhunk://#diff-78078ebad586cc9fb54bc959e437dc3411e688a9bc8fdcc5faebac85d9b2ad62L52-R52): Updated the `Build website` step to copy the `_headers` file into the `out` directory during the build process.
* [`.github/workflows/jan-docs.yml`](diffhunk://#diff-307479c4bef1f0bb90238fcfe3f7df26d8a15312aab6233edf9e1c43fd3fa5a4L58-R58): Updated the `Build website` step to copy the `_headers` file into the `out` directory during the build process.

### Security enhancements:

* [`docs/_headers`](diffhunk://#diff-38853761b9fea0b81b350df3121b1bbd01542fa427cecc4510206e9f5980d749R1-R4): Added a new `_headers` file with security headers, including `X-Frame-Options: SAMEORIGIN`, `Permissions-Policy: interest-cohort=()`, and `Strict-Transport-Security: max-age=31536000; includeSubDomains; preload`.