### PR TITLE
chore: pull binaries windows, linux

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -67,9 +67,8 @@
     "resources": [
       "binaries/engines/**/*",
       "resources/themes/**/*",
-      "resources/pre-install/**/*",
-      "resources/bin/**/*"
+      "resources/pre-install/**/*"
     ],
-    "externalBin": ["binaries/cortex-server"]
+    "externalBin": ["binaries/cortex-server", "resources/bin/bun", "resources/bin/uv"]
   }
 }


### PR DESCRIPTION
## Describe Your Changes
MacOS code sign will be updated in another PR because the Tauri CI/CD PR is not merged yet
Still have some issue with `appimage` build that it can not bundle `bun`

This pull request introduces platform-specific improvements and error handling in the `scripts/download-bin.js` script, along with updates to the Tauri configuration file to include new binaries. The changes enhance compatibility across operating systems, improve error resilience, and ensure proper handling of platform-specific binaries.

### Platform-Specific Improvements:
* Updated `getPlatformArch` function to refine platform and architecture mappings for Linux and Windows, ensuring accurate binary selection (`scripts/download-bin.js`).
* Added platform-specific logic for handling `.zip` and `.tar.gz` files, ensuring compatibility with Windows (`scripts/download-bin.js`).

### Error Handling Enhancements:
* Introduced `try-catch` blocks to handle potential errors during directory creation, file copying, and permission changes, improving script robustness (`scripts/download-bin.js`).

### Configuration Updates:
* Modified `tauri.conf.json` to include `bun` and `uv` binaries in the `externalBin` array, ensuring they are bundled correctly for the application (`src-tauri/tauri.conf.json`).

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
