### PR TITLE
fix: qwen3 - weird token output  - reasoning content should not be in completion request

### DIFF
--- a/extensions/engine-management-extension/rolldown.config.mjs
+++ b/extensions/engine-management-extension/rolldown.config.mjs
@@ -15,7 +15,7 @@ export default defineConfig([
         `http://127.0.0.1:${process.env.CORTEX_API_PORT ?? '39291'}`
       ),
       PLATFORM: JSON.stringify(process.platform),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.55'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.56'),
       DEFAULT_REMOTE_ENGINES: JSON.stringify(engines),
       DEFAULT_REMOTE_MODELS: JSON.stringify(models),
       DEFAULT_REQUEST_PAYLOAD_TRANSFORM: JSON.stringify(
@@ -38,7 +38,7 @@ export default defineConfig([
       file: 'dist/node/index.cjs.js',
     },
     define: {
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.55'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.56'),
     },
   },
 ])

--- a/extensions/inference-cortex-extension/download.bat
+++ b/extensions/inference-cortex-extension/download.bat
@@ -2,7 +2,7 @@
 set BIN_PATH=./bin
 set SHARED_PATH=./../../electron/shared
 set /p CORTEX_VERSION=<./bin/version.txt
-set ENGINE_VERSION=0.1.55
+set ENGINE_VERSION=0.1.56
 
 @REM Download cortex.llamacpp binaries
 set DOWNLOAD_URL=https://github.com/menloresearch/cortex.llamacpp/releases/download/v%ENGINE_VERSION%/cortex.llamacpp-%ENGINE_VERSION%-windows-amd64

--- a/extensions/inference-cortex-extension/download.sh
+++ b/extensions/inference-cortex-extension/download.sh
@@ -2,7 +2,7 @@
 
 # Read CORTEX_VERSION
 CORTEX_VERSION=$(cat ./bin/version.txt)
-ENGINE_VERSION=0.1.55
+ENGINE_VERSION=0.1.56
 CORTEX_RELEASE_URL="https://github.com/menloresearch/cortex.cpp/releases/download"
 ENGINE_DOWNLOAD_URL="https://github.com/menloresearch/cortex.llamacpp/releases/download/v${ENGINE_VERSION}/cortex.llamacpp-${ENGINE_VERSION}"
 CUDA_DOWNLOAD_URL="https://github.com/menloresearch/cortex.llamacpp/releases/download/v${ENGINE_VERSION}"

--- a/extensions/inference-cortex-extension/rolldown.config.mjs
+++ b/extensions/inference-cortex-extension/rolldown.config.mjs
@@ -19,7 +19,7 @@ export default defineConfig([
       CORTEX_SOCKET_URL: JSON.stringify(
         `ws://127.0.0.1:${process.env.CORTEX_API_PORT ?? '39291'}`
       ),
-      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.55'),
+      CORTEX_ENGINE_VERSION: JSON.stringify('v0.1.56'),
     },
   },
   {


### PR DESCRIPTION
## Describe Your Changes

- This PR is to not include reasoning content in the chat/completions request, this will address the issue where qwen3 0.6b returns weird token outputs where it should not be.
- This also reduce the request payload size (prompt length).
- Ship llama.cpp - b5219 with the app.

https://github.com/user-attachments/assets/27878292-cc07-48e3-a3db-0e7fdb150b5c


## Fixes Issues

- Closes #4955 

