### PR TITLE
fix: should not normalize user input content

### DIFF
--- a/web/utils/messageRequestBuilder.ts
+++ b/web/utils/messageRequestBuilder.ts
@@ -155,7 +155,8 @@ export class MessageRequestBuilder {
     const stack = new Stack<ChatCompletionMessage>()
     for (const message of messages) {
       // Handle message content such as reasoning tags
-      message.content = this.reasoningTagHandle(message)
+      if (message.role === ChatCompletionRole.Assistant)
+        message.content = this.reasoningTagHandle(message)
       if (stack.isEmpty()) {
         stack.push(message)
         continue


### PR DESCRIPTION
## Describe Your Changes

From the PR #4983, we normalize completion request to not have reasoning_content in the request body, but somehow users could create thinking input manually which should be kept. This PR is to filter out user messages from the normalization.

https://github.com/user-attachments/assets/bd0607b7-6941-4cf3-b4c6-594377bb65cb

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
