### PR TITLE
fix: border for the search box in my models

### DIFF
--- a/web/containers/ModelSearch/index.tsx
+++ b/web/containers/ModelSearch/index.tsx
@@ -57,7 +57,7 @@ const ModelSearch = ({ onSearchLocal }: Props) => {
       value={searchText}
       clearable={searchText.length > 0}
       onClear={onClear}
-      className="border-1 bg-[hsla(var(--app-bg))]"
+      className="bg-[hsla(var(--app-bg))]"
       onClick={() => {
         onSearchLocal?.(inputRef.current?.value ?? '')
       }}


### PR DESCRIPTION
This pull request includes a small change to the `ModelSearch` component in `web/containers/ModelSearch/index.tsx`. The `className` property was updated to remove the `border-1` class, simplifying the styling.