### PR TITLE
fix: distinguish between hub and models search

### DIFF
--- a/core/src/browser/extensions/model.ts
+++ b/core/src/browser/extensions/model.ts
@@ -40,4 +40,9 @@ export abstract class ModelExtension
    * Delete a model source
    */
   abstract deleteSource(source: string): Promise<void>
+
+  /**
+   * Fetch models hub
+   */
+  abstract fetchModelsHub(): Promise<void>
 }

--- a/extensions/model-extension/src/index.ts
+++ b/extensions/model-extension/src/index.ts
@@ -67,7 +67,7 @@ export default class JanModelExtension extends ModelExtension {
     }
 
     // Sync with cortexsohub
-    this.fetchCortexsoModels()
+    this.fetchModelsHub()
   }
 
   /**
@@ -450,7 +450,7 @@ export default class JanModelExtension extends ModelExtension {
   /**
    * Fetch models from cortex.so
    */
-  private fetchCortexsoModels = async () => {
+  fetchModelsHub = async () => {
     const models = await this.fetchModels()
 
     return this.queue.add(() =>

--- a/web/hooks/useEngineManagement.ts
+++ b/web/hooks/useEngineManagement.ts
@@ -12,6 +12,7 @@ import {
   ModelEvent,
   ModelSource,
   ModelSibling,
+  ModelExtension,
 } from '@janhq/core'
 import { useAtom, useAtomValue } from 'jotai'
 import { atomWithStorage } from 'jotai/utils'
@@ -496,4 +497,22 @@ export const useRefreshModelList = (engine: string) => {
   )
 
   return { refreshingModels, refreshModels }
+}
+
+export const useFetchModelsHub = () => {
+  const extension = useMemo(
+    () => extensionManager.get<ModelExtension>(ExtensionTypeEnum.Model) ?? null,
+    []
+  )
+
+  const { data, error, mutate } = useSWR(
+    extension ? 'fetchModelsHub' : null,
+    () => extension?.fetchModelsHub(),
+    {
+      revalidateOnFocus: false,
+      revalidateOnReconnect: true,
+    }
+  )
+
+  return { modelsHub: data, error, mutate }
 }

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -25,7 +25,10 @@ import { twMerge } from 'tailwind-merge'
 import CenterPanelContainer from '@/containers/CenterPanelContainer'
 import ModelSearch from '@/containers/ModelSearch'
 
-import { useGetEngineModelSources } from '@/hooks/useEngineManagement'
+import {
+  useFetchModelsHub,
+  useGetEngineModelSources,
+} from '@/hooks/useEngineManagement'
 import { setImportModelStageAtom } from '@/hooks/useImportModel'
 
 import {
@@ -85,6 +88,7 @@ const hubCompatibleAtom = atom(false)
 const HubScreen = () => {
   const { sources } = useGetModelSources()
   const { sources: remoteModelSources } = useGetEngineModelSources()
+  const { mutate: fetchModelsHub } = useFetchModelsHub()
   const { addModelSource } = useModelSourcesMutation()
   const [searchValue, setSearchValue] = useState('')
   const [sortSelected, setSortSelected] = useState('newest')
@@ -267,6 +271,10 @@ const HubScreen = () => {
       reader.readAsDataURL(files[0])
     },
   })
+
+  useEffect(() => {
+    fetchModelsHub()
+  }, [])
 
   return (
     <CenterPanelContainer>

--- a/web/screens/Hub/index.tsx
+++ b/web/screens/Hub/index.tsx
@@ -422,7 +422,10 @@ const HubScreen = () => {
                 <div className="absolute left-1/2 top-1/2 z-10 mx-auto w-4/5 -translate-x-1/2 -translate-y-1/2 rounded-xl sm:w-2/6">
                   <div className="flex flex-col items-center justify-between gap-2 sm:flex-row">
                     <div className="w-full" ref={dropdownRef}>
-                      <ModelSearch onSearchLocal={onSearchUpdate} />
+                      <ModelSearch
+                        onSearchLocal={onSearchUpdate}
+                        supportModelImport
+                      />
                       <div
                         className={twMerge(
                           'invisible absolute mt-2 max-h-[400px] w-full overflow-y-auto rounded-lg border border-[hsla(var(--app-border))] bg-[hsla(var(--app-bg))] shadow-lg',


### PR DESCRIPTION
## Describe Your Changes

- This PR is to distinguish between model search in hub and in my models page where:
 - Model Hub should allow users to import models.
 - My Models should only allow users to search for downloaded models since there are no detail page implemented in this page.
 - Model Hub should be refreshed on mount.

https://github.com/user-attachments/assets/3c72783d-094c-42c8-9ba3-bc3bbbc7c2d5


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
