### PR TITLE
chore: delete Tauri pre-install in `make clean`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,7 @@ ifeq ($(OS),Windows_NT)
 	-powershell -Command "Remove-Item -Recurse -Force ./pre-install/*.tgz"
 	-powershell -Command "Remove-Item -Recurse -Force ./extensions/*/*.tgz"
 	-powershell -Command "Remove-Item -Recurse -Force ./electron/pre-install/*.tgz"
+	-powershell -Command "Remove-Item -Recurse -Force ./src-tauri/resources/pre-install/*.tgz"
 	-powershell -Command "if (Test-Path \"$($env:USERPROFILE)\jan\extensions\") { Remove-Item -Path \"$($env:USERPROFILE)\jan\extensions\" -Recurse -Force }"
 else ifeq ($(shell uname -s),Linux)
 	find . -name "node_modules" -type d -prune -exec rm -rf '{}' +
@@ -144,6 +145,7 @@ else ifeq ($(shell uname -s),Linux)
 	rm -rf ./pre-install/*.tgz
 	rm -rf ./extensions/*/*.tgz
 	rm -rf ./electron/pre-install/*.tgz
+	rm -rf ./src-tauri/resources/pre-install/*.tgz
 	rm -rf "~/jan/extensions"
 	rm -rf "~/.cache/jan*"
 else
@@ -158,6 +160,7 @@ else
 	rm -rf ./pre-install/*.tgz
 	rm -rf ./extensions/*/*.tgz
 	rm -rf ./electron/pre-install/*.tgz
+	rm -rf ./src-tauri/resources/pre-install/*.tgz
 	rm -rf ~/jan/extensions
 	rm -rf ~/Library/Caches/jan*
 endif


### PR DESCRIPTION
## Describe Your Changes

- Add command to delete Tauri pre-install folder in `make clean`

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
