### PR TITLE
chore: handle chat functions

### DIFF
--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -7,7 +7,7 @@ import { Progress } from '@/components/ui/progress'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { abortDownload } from '@/services/models'
 import { DownloadEvent, DownloadState, events } from '@janhq/core'
-import { IconPlayerPauseFilled, IconX } from '@tabler/icons-react'
+import { IconX } from '@tabler/icons-react'
 import { useCallback, useEffect, useMemo } from 'react'
 
 export function DownloadManagement() {

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -1,20 +1,27 @@
 import { create } from 'zustand'
 import { ThreadMessage } from '@janhq/core'
+import { MCPTool } from '@/types/completion'
 
 type AppState = {
   streamingContent?: ThreadMessage
   loadingModel?: boolean
+  tools: MCPTool[]
   updateStreamingContent: (content: ThreadMessage | undefined) => void
   updateLoadingModel: (loading: boolean) => void
+  updateTools: (tools: MCPTool[]) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
   streamingContent: undefined,
   loadingModel: false,
+  tools: [],
   updateStreamingContent: (content) => {
     set({ streamingContent: content })
   },
   updateLoadingModel: (loading) => {
     set({ loadingModel: loading })
+  },
+  updateTools: (tools) => {
+    set({ tools })
   },
 }))

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -1,0 +1,149 @@
+import { useCallback, useMemo } from 'react'
+import { usePrompt } from './usePrompt'
+import { useModelProvider } from './useModelProvider'
+import { useThreads } from './useThreads'
+import { useAppState } from './useAppState'
+import { useMessages } from './useMessages'
+import { useRouter } from '@tanstack/react-router'
+import { defaultModel } from '@/lib/models'
+import { route } from '@/constants/routes'
+import {
+  emptyThreadContent,
+  extractToolCall,
+  newAssistantThreadContent,
+  newUserThreadContent,
+  postMessageProcessing,
+  sendCompletion,
+  startModel,
+} from '@/lib/completion'
+import { CompletionMessagesBuilder } from '@/lib/messages'
+import { ChatCompletionMessageToolCall } from 'openai/resources'
+
+export const useChat = () => {
+  const { prompt, setPrompt } = usePrompt()
+  const { tools } = useAppState()
+
+  const { getProviderByName, selectedModel, selectedProvider } =
+    useModelProvider()
+
+  const { getCurrentThread: retrieveThread, createThread } = useThreads()
+  const { updateStreamingContent, updateLoadingModel } = useAppState()
+  const { addMessage } = useMessages()
+  const router = useRouter()
+
+  const provider = useMemo(() => {
+    return getProviderByName(selectedProvider)
+  }, [selectedProvider, getProviderByName])
+  const getCurrentThread = useCallback(async () => {
+    let currentThread = retrieveThread()
+    if (!currentThread) {
+      currentThread = await createThread(
+        {
+          id: selectedModel?.id ?? defaultModel(selectedProvider),
+          provider: selectedProvider,
+        },
+        prompt
+      )
+      router.navigate({
+        to: route.threadsDetail,
+        params: { threadId: currentThread.id },
+      })
+    }
+    return currentThread
+  }, [
+    createThread,
+    prompt,
+    retrieveThread,
+    router,
+    selectedModel?.id,
+    selectedProvider,
+  ])
+
+  const sendMessage = useCallback(
+    async (message: string) => {
+      const activeThread = await getCurrentThread()
+
+      if (!activeThread || !provider) return
+
+      updateStreamingContent(emptyThreadContent)
+      addMessage(newUserThreadContent(activeThread.id, message))
+      setPrompt('')
+      try {
+        if (selectedModel?.id) {
+          updateLoadingModel(true)
+          await startModel(provider.provider, selectedModel.id).catch(
+            console.error
+          )
+          updateLoadingModel(false)
+        }
+
+        const builder = new CompletionMessagesBuilder()
+        // REMARK: Would it possible to not attach the entire message history to the request?
+        // TODO: If not amend messages history here
+        builder.addUserMessage(message)
+
+        let isCompleted = false
+
+        while (!isCompleted) {
+          const completion = await sendCompletion(
+            activeThread,
+            provider,
+            builder.getMessages(),
+            tools
+          )
+
+          if (!completion) throw new Error('No completion received')
+          let accumulatedText = ''
+          const currentCall: ChatCompletionMessageToolCall | null = null
+          const toolCalls: ChatCompletionMessageToolCall[] = []
+          for await (const part of completion) {
+            const delta = part.choices[0]?.delta?.content || ''
+            if (part.choices[0]?.delta?.tool_calls) {
+              extractToolCall(part, currentCall, toolCalls)
+            }
+            if (delta) {
+              accumulatedText += delta
+              // Create a new object each time to avoid reference issues
+              // Use a timeout to prevent React from batching updates too quickly
+              const currentContent = newAssistantThreadContent(
+                activeThread.id,
+                accumulatedText
+              )
+              updateStreamingContent(currentContent)
+              await new Promise((resolve) => setTimeout(resolve, 0))
+            }
+          }
+          // Create a final content object for adding to the thread
+          const finalContent = newAssistantThreadContent(
+            activeThread.id,
+            accumulatedText
+          )
+          builder.addAssistantMessage(accumulatedText, undefined, toolCalls)
+          const updatedMessage = await postMessageProcessing(
+            toolCalls,
+            builder,
+            finalContent
+          )
+          addMessage(updatedMessage ?? finalContent)
+
+          isCompleted = !toolCalls.length
+        }
+      } catch (error) {
+        console.error('Error sending message:', error)
+      }
+      updateStreamingContent(undefined)
+    },
+    [
+      getCurrentThread,
+      provider,
+      updateStreamingContent,
+      addMessage,
+      setPrompt,
+      selectedModel,
+      tools,
+      updateLoadingModel,
+    ]
+  )
+
+  return { sendMessage }
+}

--- a/web-app/src/hooks/useMessages.ts
+++ b/web-app/src/hooks/useMessages.ts
@@ -9,6 +9,7 @@ import {
 
 type MessageState = {
   messages: Record<string, ThreadMessage[]>
+  getMessages: (threadId: string) => ThreadMessage[]
   setMessages: (threadId: string, messages: ThreadMessage[]) => void
   addMessage: (message: ThreadMessage) => void
   deleteMessage: (threadId: string, messageId: string) => void
@@ -16,8 +17,11 @@ type MessageState = {
 
 export const useMessages = create<MessageState>()(
   persist(
-    (set) => ({
+    (set, get) => ({
       messages: {},
+      getMessages: (threadId) => {
+        return get().messages[threadId] || []
+      },
       setMessages: (threadId, messages) => {
         set((state) => ({
           messages: {


### PR DESCRIPTION
## Describe Your Changes

This PR provides chat functions to the new FE, including the ability to regenerate an assistant's response, refactor completion handlers to a new hook to clean up the ChatInput component, and share chat functions across components.

https://github.com/user-attachments/assets/674358a3-b0d0-40ed-ab3b-4d7fafb0b66e

## How to test this PR?

- [ ] Create a new thread with any models
- [ ] Send a message and wait for assistant response
- [ ] See the regenerate button
- [ ] Click and see model regenerates assistant response
