### PR TITLE
chore: Pin rmcp commit

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -33,11 +33,12 @@ tauri-plugin-store = "2"
 hyper = { version = "0.14", features = ["server"] }
 reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
 tokio = { version = "1", features = ["full"] }
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "c1c4c9a0c9afbfbbf9eb42d6f8b00d8546fbdc2c", features = [
     "client",
-    "transport-sse",
+    "transport-sse-client",
     "transport-child-process",
     "tower",
+    "reqwest",
 ] }
 uuid = { version = "1.7", features = ["v4"] }
 env = "1.0.1"

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -63,7 +63,7 @@ pub async fn run_mcp_commands(
                 });
 
                 let service =
-                    ().serve(TokioChildProcess::new(&mut cmd).map_err(|e| e.to_string())?)
+                    ().serve(TokioChildProcess::new(cmd).map_err(|e| e.to_string())?)
                         .await
                         .map_err(|e| e.to_string())?;
 


### PR DESCRIPTION
## Describe Your Changes

Pin rmcp to latest commit to avoid breaking changes, as well as ensure we use the same version across the team

- `transport-sse` becomes `transport-sse-client`: https://github.com/modelcontextprotocol/rust-sdk/pull/167
- Requires explicit `reqwest` feature: https://github.com/modelcontextprotocol/rust-sdk/pull/185

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
