### PR TITLE
chore: improve switch component offset

### DIFF
--- a/web-app/src/components/ui/switch.tsx
+++ b/web-app/src/components/ui/switch.tsx
@@ -19,7 +19,7 @@ function Switch({
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(
-          'bg-main-view pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-1px)] data-[state=unchecked]:-translate-x-0'
+          'bg-main-view pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%)] data-[state=unchecked]:-translate-x-0'
         )}
       />
     </SwitchPrimitive.Root>


### PR DESCRIPTION
## Describe Your Changes
This pull request includes a minor adjustment to the `Switch` component in `web-app/src/components/ui/switch.tsx`. The change simplifies the translation calculation for the `data-[state=checked]` state of the `SwitchPrimitive.Thumb` element.

* [`web-app/src/components/ui/switch.tsx`](diffhunk://#diff-c52343474e2a1ee7fc46bda8de540434bb7904774d24c590d11357df169167ddL22-R22): Updated the `data-[state=checked]` translation value from `calc(100%-1px)` to `calc(100%)` for improved clarity and maintainability.

## Fixes Issues
https://discord.com/channels/1107178041848909847/1373886186485186621/1373886186485186621
- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
