### PR TITLE
chore: cleanup whitespace left panel on thread list

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -290,7 +290,7 @@ const LeftPanel = () => {
                 </>
               )}
 
-              <div className="flex flex-col mb-4">
+              <div className="flex flex-col">
                 <ThreadList threads={unFavoritedThreads} />
               </div>
             </div>


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `LeftPanel` component in `web-app/src/containers/LeftPanel.tsx`. The change removes an unnecessary bottom margin (`mb-4`) from a `div` wrapping the `ThreadList` component.

## Fixes Issues
https://discord.com/channels/1107178041848909847/1365253683272618025
- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
