### PR TITLE
chore: fix auto focus chat input

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -3,6 +3,7 @@
 import TextareaAutosize from 'react-textarea-autosize'
 import { cn } from '@/lib/utils'
 import { usePrompt } from '@/hooks/usePrompt'
+import { useThreads } from '@/hooks/useThreads'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import { ArrowRight } from 'lucide-react'
@@ -47,6 +48,7 @@ const ChatInput = ({
   const { streamingContent, updateTools, abortControllers, loadingModel } =
     useAppState()
   const { prompt, setPrompt } = usePrompt()
+  const { currentThreadId } = useThreads()
   const { t } = useTranslation()
   const { spellCheckChatInput } = useGeneralSetting()
   const { tokenSpeed } = useAppState()
@@ -95,11 +97,29 @@ const ChatInput = ({
     return unsubscribe
   }, [updateTools])
 
+  // Focus when component mounts
   useEffect(() => {
     if (textareaRef.current) {
       textareaRef.current.focus()
     }
   }, [])
+
+  // Focus when thread changes
+  useEffect(() => {
+    if (textareaRef.current) {
+      textareaRef.current.focus()
+    }
+  }, [currentThreadId])
+
+  // Focus when streaming content finishes
+  useEffect(() => {
+    if (!streamingContent && textareaRef.current) {
+      // Small delay to ensure UI has updated
+      setTimeout(() => {
+        textareaRef.current?.focus()
+      }, 10)
+    }
+  }, [streamingContent])
 
   const stopStreaming = useCallback(
     (threadId: string) => {
@@ -227,7 +247,9 @@ const ChatInput = ({
             {showSpeedToken && (
               <div className="flex items-center gap-1 text-main-view-fg/60 text-xs">
                 <IconBrandSpeedtest size={18} />
-                <span>{Math.round(tokenSpeed?.tokenSpeed ?? 0)} tokens/sec</span>
+                <span>
+                  {Math.round(tokenSpeed?.tokenSpeed ?? 0)} tokens/sec
+                </span>
               </div>
             )}
           </div>


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces enhancements to the `ChatInput` component in `web-app/src/containers/ChatInput.tsx`, focusing on improving user experience by adding automatic focus behavior and making minor code adjustments for readability.

### Enhancements to user experience:
* Added a new `useEffect` hook to automatically focus the chat input when the component mounts.
* Introduced focus behavior when the `currentThreadId` changes, ensuring the chat input remains contextually relevant.
* Implemented focus restoration with a slight delay after streaming content finishes to improve usability.

### Code adjustments:
* Imported the `useThreads` hook and integrated `currentThreadId` into the `ChatInput` component for thread-specific behavior. [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R6) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417R51)
* Reformatted the token speed display for improved readability without altering functionality.

## Fixes Issues

https://discord.com/channels/1107178041848909847/1374195189132034089/1374195189132034089
- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
