### PR TITLE
fix: windows installer and allowed origins

### DIFF
--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -219,7 +219,7 @@ pub fn setup_sidecar(app: &App) -> Result<(), String> {
         "--cors",
         "ON",
         "--allowed_origins",
-        "http://localhost:3000,http://localhost:1420",
+        "http://localhost:3000,http://localhost:1420,tauri://localhost,http://tauri.localhost",
         "config",
         "--api_keys",
         app_state.inner().app_token.as_deref().unwrap_or(""),

--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -630,8 +630,11 @@ Section Install
 
   ; Copy resources
     CreateDirectory "$INSTDIR\binaries"
+    CreateDirectory "$INSTDIR\binaries\engines"
     CreateDirectory "$INSTDIR\resources"
-    SetOutPath "$INSTDIR\binaries"
+    CreateDirectory "$INSTDIR\resources\pre-install"
+    CreateDirectory "$INSTDIR\resources\themes"
+    SetOutPath "$INSTDIR\binaries\engines"
     File /nonfatal /a /r "D:\a\jan\jan\src-tauri\binaries\engines\"
     SetOutPath $INSTDIR
     ; File /a "/oname=cublas64_11.dll" "D:\a\jan\jan\src-tauri\binaries\cublas64_11.dll"
@@ -645,8 +648,9 @@ Section Install
     File /a "/oname=vcruntime140_1.dll" "D:\a\jan\jan\src-tauri\binaries\vcruntime140_1.dll"
     File /a "/oname=vcruntime140.dll" "D:\a\jan\jan\src-tauri\binaries\vcruntime140.dll"
     File /a "/oname=vulkan-1.dll" "D:\a\jan\jan\src-tauri\binaries\vulkan-1.dll"
-    SetOutPath "$INSTDIR\resources"
+    SetOutPath "$INSTDIR\resources\pre-install"
     File /nonfatal /a /r "D:\a\jan\jan\src-tauri\resources\pre-install\"
+    SetOutPath "$INSTDIR\resources\themes"
     File /nonfatal /a /r "D:\a\jan\jan\src-tauri\resources\themes\"
     SetOutPath $INSTDIR
 


### PR DESCRIPTION
## Describe Your Changes

This pull request includes updates to the Tauri application setup and the Windows installer configuration. The most important changes involve expanding allowed origins for the sidecar setup and restructuring the installer directories to include new subdirectories for engines, pre-install resources, and themes.

### Updates to Tauri application setup:

* [`src-tauri/src/core/setup.rs`](diffhunk://#diff-5d6e1079ed2c01af0b0fd41ba3f1189e30abd5666c7a4a08b30957975685b252L222-R222): Expanded the `--allowed_origins` list to include `tauri://localhost` and `http://tauri.localhost`, enabling additional origins for local development and testing.

### Updates to Windows installer configuration:

* `src-tauri/tauri.bundle.windows.nsis.template`: 
  - Added a new subdirectory `$INSTDIR\binaries\engines` and updated the `SetOutPath` commands to reflect this change.
  - Added new subdirectories `$INSTDIR\resources\pre-install` and `$INSTDIR\resources\themes`, and updated the `SetOutPath` and `File` commands to include these directories for pre-install resources and themes.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
