### PR TITLE
enhance: setup screen redirect to hub

### DIFF
--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -30,11 +30,13 @@ function SetupScreen() {
           <div className="flex gap-4 flex-col">
             <Card
               header={
-                <div>
-                  <h1 className="text-main-view-fg font-medium text-base">
-                    Setup Local Model
-                  </h1>
-                </div>
+                <Link to={route.hub}>
+                  <div>
+                    <h1 className="text-main-view-fg font-medium text-base">
+                      Set up local model
+                    </h1>
+                  </div>
+                </Link>
               }
             ></Card>
             <Card
@@ -49,7 +51,7 @@ function SetupScreen() {
                   }}
                 >
                   <h1 className="text-main-view-fg font-medium text-base">
-                    Setup Remote Provider
+                    Set up remote provider
                   </h1>
                 </Link>
               }


### PR DESCRIPTION
## Describe Your Changes

This pull request makes minor updates to the `SetupScreen` component in `web-app/src/containers/SetupScreen.tsx` to improve the user interface text and navigation.

Text improvements:

* Updated headings to use consistent capitalization: changed "Setup Local Model" to "Set up local model" and "Setup Remote Provider" to "Set up remote provider" for better readability. [[1]](diffhunk://#diff-d892c5ebcde40fcdfb642657b6f87fb36bcd63218c78b644c842a781a9675892R33-R39) [[2]](diffhunk://#diff-d892c5ebcde40fcdfb642657b6f87fb36bcd63218c78b644c842a781a9675892L52-R54)

Navigation improvement:

* Wrapped the "Set up local model" heading in a `Link` component to allow navigation to the hub route, improving user experience.

## Fixes Issues
https://discord.com/channels/1107178041848909847/1374353260261015625/1374353260261015625
- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `SetupScreen.tsx` by improving text consistency and adding navigation to the hub route.
> 
>   - **Text Improvements**:
>     - Changed "Setup Local Model" to "Set up local model" and "Setup Remote Provider" to "Set up remote provider" in `SetupScreen.tsx` for consistent capitalization.
>   - **Navigation Improvement**:
>     - Wrapped "Set up local model" heading in a `Link` component to enable navigation to the hub route in `SetupScreen.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6b766b35c9a1e1905d17ea8b2b24e44f5ba6f2e9. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->