### PR TITLE
fix: close side windows should not kill background processes

### DIFF
--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -63,7 +63,7 @@ pub async fn run_mcp_commands<R: Runtime>(
                 if command.clone() == "uvx" {
                     let bun_x_path = format!("{}/uv", bin_path.display());
                     cmd = Command::new(bun_x_path);
-                    cmd.arg("tool run");
+                    cmd.arg("tool");
                     cmd.arg("run");
                 }
                 println!("Command: {cmd:#?}");

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -100,7 +100,7 @@ pub fn run() {
             setup_mcp(app);
             setup_sidecar(app).expect("Failed to setup sidecar");
             setup_engine_binaries(app).expect("Failed to setup engine binaries");
-            // TODO(any) need to wire up with frontend 
+            // TODO(any) need to wire up with frontend
             // let handle = app.handle().clone();
             // tauri::async_runtime::spawn(async move {
             //     handle_app_update(handle).await.unwrap();
@@ -109,11 +109,13 @@ pub fn run() {
         })
         .on_window_event(|window, event| match event {
             tauri::WindowEvent::CloseRequested { .. } => {
-                let client = Client::new();
-                let url = "http://127.0.0.1:39291/processManager/destroy";
-                let _ = client.delete(url).send();
+                if window.label() == "main" {
+                    let client = Client::new();
+                    let url = "http://127.0.0.1:39291/processManager/destroy";
+                    let _ = client.delete(url).send();
 
-                window.emit("kill-sidecar", ()).unwrap();
+                    window.emit("kill-sidecar", ()).unwrap();
+                }
             }
             _ => {}
         })


### PR DESCRIPTION
## Describe Your Changes

This PR fixes an issue where users close any side windows of the app could cause background services to be terminated (cortex, llama.cpp). It should just kill these processes on exit.

This include a small fix when running tool using uvx
![CleanShot 2025-05-22 at 23 02 58@2x](https://github.com/user-attachments/assets/d178ab99-2085-4555-9b0e-b5045d225a3d)



## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix window event handling to only terminate background processes when the main window is closed, and update command argument in `run_mcp_commands()`.
> 
>   - **Behavior**:
>     - Modify `on_window_event` in `src-tauri/src/lib.rs` to only terminate background processes when the main window is closed.
>     - Change command argument in `run_mcp_commands()` in `src-tauri/src/core/mcp.rs` from `"tool run"` to `"tool"`.
>   - **Misc**:
>     - Fixes a comment typo in `src-tauri/src/lib.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ea7b200a636028af9d0b3910ac8f2a77c735a3d8. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->