### PR TITLE
fix: hidden date when value 0

### DIFF
--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -245,7 +245,7 @@ export const ThreadContent = memo(
                   <span className="text-main-view-fg font-medium">
                     {assistant?.name || 'Jan'}
                   </span>
-                  {item?.created_at && (
+                  {item?.created_at && item?.created_at !== 0 && (
                     <span className="text-xs mt-0.5">
                       {formatDate(item?.created_at)}
                     </span>


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `ThreadContent` component in `ThreadContent.tsx`. The change ensures that the `created_at` timestamp is only displayed if it exists and is not equal to `0`.

## Fixes Issues
https://discord.com/channels/1107178041848909847/1375152294664081489/1375152294664081489

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `created_at` timestamp display in `ThreadContent.tsx` to only show when not `0`.
> 
>   - **Behavior**:
>     - In `ThreadContent.tsx`, `created_at` timestamp is now only displayed if it exists and is not `0`.
>   - **Fixes**:
>     - Addresses issue in Discord channel link provided in the PR description.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 5b884f17d57c412edd36d1c2ef2baa6eb4106d17. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->