### PR TITLE
chore: providers should default on

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
         "font-src": [
           "https://fonts.gstatic.com blob: data: tauri://localhost http://tauri.localhost"
         ],
-        "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net/npm/emoji-datasource-apple",
+        "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net",
         "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com",
         "script-src": "'self' asset: $APPDATA/**.* http://asset.localhost"
       },

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -42,7 +42,7 @@
         "font-src": [
           "https://fonts.gstatic.com blob: data: tauri://localhost http://tauri.localhost"
         ],
-        "img-src": "'self' asset: http://asset.localhost blob: data:",
+        "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net/npm/emoji-datasource-apple",
         "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com",
         "script-src": "'self' asset: $APPDATA/**.* http://asset.localhost"
       },

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -55,7 +55,7 @@ export const useModelProvider = create<ModelProviderState>()(
               }),
               api_key: existingProvider?.api_key || provider.api_key,
               base_url: existingProvider?.base_url || provider.base_url,
-              active: existingProvider ? existingProvider?.active : false,
+              active: existingProvider ? existingProvider?.active : true,
             }
           })
 


### PR DESCRIPTION
## Describe Your Changes

- All providers should be default on in the first launch

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Set default provider `active` state to `true` and update `img-src` in `tauri.conf.json`.
> 
>   - **Behavior**:
>     - Default `active` state for providers set to `true` in `useModelProvider` in `useModelProvider.ts`.
>     - Updated `img-src` in `tauri.conf.json` to include `https://cdn.jsdelivr.net`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b0c01aaeeaa411e106bdaceb0b21702aa4d8257a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->