### PR TITLE
fix: `copy:lib` on macos when directory already exists

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "copy:lib": "run-script-os",
     "copy:lib:linux": "cpx \"./lib/linux/*.so\" \"./src-tauri/resources/lib/\"",
     "copy:lib:win32": "cpx \"./lib/windows/*.dll\" \"./src-tauri/resources/lib/\"",
-    "copy:lib:darwin": "mkdir \"./src-tauri/resources/lib/\"",
+    "copy:lib:darwin": "mkdir -p \"./src-tauri/resources/lib/\"",
     "dev:tauri": "yarn build:icon && yarn copy:assets:tauri && tauri dev",
     "build:tauri:linux:win32": "yarn download:bin && yarn install:cortex && yarn build:icon && yarn copy:assets:tauri && yarn tauri build",
     "build:tauri:darwin": "yarn install:cortex && yarn build:icon && yarn copy:assets:tauri && yarn tauri build --target universal-apple-darwin",


### PR DESCRIPTION
## Describe Your Changes

After #4925, on Linux and Windows, we bundle dynamic libs via `resources/lib` and declare it under tauri resources. Hence, tauri expects `resources/lib` to exist. On macOS, even though we don't bundle any libs, we still need to create this directory.

Currently, we use `mkdir`, which will return an error if the directory already exists. This PR adds the `-p` flag so that it's not an error.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `-p` flag to `mkdir` in `copy:lib:darwin` script to prevent errors if directory exists on macOS.
> 
>   - **Behavior**:
>     - Adds `-p` flag to `mkdir` in `copy:lib:darwin` script in `package.json` to prevent errors if directory exists.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 4304ed7accde7521f38e14fb2933a179e54737f8. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->