### PR TITLE
feat: Model import (download + local import) for llama.cpp extension

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -91,21 +91,6 @@ export interface listOptions {
 }
 export type listResult = modelInfo[]
 
-// 2. /pull
-export interface pullOptions {
-  providerId: string
-  modelId: string // Identifier for the model to pull (e.g., from a known registry)
-  downloadUrl: string // URL to download the model from
-  /** optional callback to receive download progress */
-  onProgress?: (progress: { percent: number; downloadedBytes: number; totalBytes?: number }) => void
-}
-export interface pullResult {
-  success: boolean
-  path?: string // local file path to the pulled model
-  error?: string
-  modelInfo?: modelInfo // Info of the pulled model
-}
-
 // 3. /load
 export interface loadOptions {
   modelPath: string
@@ -174,24 +159,13 @@ export interface deleteResult {
 }
 
 // 7. /import
-export interface importOptions {
-  providerId: string
-  sourcePath: string // Path to the local model file to import
-  desiredModelId?: string // Optional: if user wants to name it specifically
+export interface ImportOptions {
+  [key: string]: any
 }
+
 export interface importResult {
   success: boolean
   modelInfo?: modelInfo
-  error?: string
-}
-
-// 8. /abortPull
-export interface abortPullOptions {
-  providerId: string
-  modelId: string // The modelId whose download is to be aborted
-}
-export interface abortPullResult {
-  success: boolean
   error?: string
 }
 
@@ -224,11 +198,6 @@ export abstract class AIEngine extends BaseExtension {
   abstract list(opts: listOptions): Promise<listResult>
 
   /**
-   * Pulls/downloads a model
-   */
-  abstract pull(opts: pullOptions): Promise<pullResult>
-
-  /**
    * Loads a model into memory
    */
   abstract load(opts: loadOptions): Promise<sessionInfo>
@@ -251,12 +220,12 @@ export abstract class AIEngine extends BaseExtension {
   /**
    * Imports a model
    */
-  abstract import(opts: importOptions): Promise<importResult>
+  abstract import(modelId: string, opts: ImportOptions): Promise<void>
 
   /**
-   * Aborts an ongoing model pull
+   * Aborts an ongoing model import
    */
-  abstract abortPull(opts: abortPullOptions): Promise<abortPullResult>
+  abstract abortImport(modelId: string): Promise<void>
 
   /**
    * Optional method to get the underlying chat client

--- a/extensions/llamacpp-extension/package.json
+++ b/extensions/llamacpp-extension/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "@janhq/core": "../../core/package.tgz",
-    "@tauri-apps/api": "^1.4.0",
+    "@tauri-apps/api": "^2.5.0",
     "fetch-retry": "^5.0.6",
     "ulidx": "^2.3.0"
   },

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -88,6 +88,7 @@ export default class llamacpp_extension extends AIEngine {
 
   override async import(modelId: string, opts: ImportOptions): Promise<void> {
     // TODO: sanitize modelId
+    // TODO: check if modelId already exists
     const taskId = this.createDownloadTaskId(modelId)
 
     // this is relative to Jan's data folder
@@ -151,6 +152,8 @@ export default class llamacpp_extension extends AIEngine {
       const eventName = downloadCompleted ? 'onFileDownloadSuccess' : 'onFileDownloadStopped'
       events.emit(eventName, { modelId, downloadType: 'Model' })
     }
+
+    // TODO: check if files are valid GGUF files
 
     await invoke<void>(
       'write_yaml',

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -49,6 +49,7 @@ dirs = "6.0.0"
 sysinfo = "0.34.2"
 ash = "0.38.0"
 nvml-wrapper = "0.10.0"
+serde_yaml = "0.9.34"
 
 [target.'cfg(windows)'.dependencies]
 libloading = "0.8.7"

--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -314,14 +314,6 @@ fn copy_dir_recursive(src: &PathBuf, dst: &PathBuf) -> Result<(), io::Error> {
 }
 
 #[tauri::command]
-pub async fn reset_cortex_restart_count(state: State<'_, AppState>) -> Result<(), String> {
-    let mut count = state.cortex_restart_count.lock().await;
-    *count = 0;
-    log::info!("Cortex server restart count reset to 0.");
-    Ok(())
-}
-
-#[tauri::command]
 pub fn change_app_data_folder(
     app_handle: tauri::AppHandle,
     new_data_folder: String,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -48,7 +48,6 @@ pub fn run() {
             core::cmd::read_logs,
             core::cmd::handle_app_update,
             core::cmd::change_app_data_folder,
-            core::cmd::reset_cortex_restart_count,
             // MCP commands
             core::mcp::get_tools,
             core::mcp::call_tool,

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -68,6 +68,8 @@ pub fn run() {
             core::threads::get_thread_assistant,
             core::threads::create_thread_assistant,
             core::threads::modify_thread_assistant,
+            // generic utils
+            core::utils::write_yaml,
             // Download
             core::utils::download::download_files,
             core::utils::download::cancel_download_task,


### PR DESCRIPTION
## Describe Your Changes

Example usage

```js
llamacpp = core.engineManager.get('llamacpp')

// text only
llamacpp.import('unsloth/gemma3-4b-it-Q4_K_M', {modelPath: 'https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q4_K_M.gguf'})

// with mmproj
llamacpp.import('unsloth/gemma3-4b-it-Q4_K_M', {modelPath: 'https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/gemma-3-4b-it-Q4_K_M.gguf', mmprojPath: 'https://huggingface.co/unsloth/gemma-3-4b-it-GGUF/resolve/main/mmproj-F16.gguf'})
```

Replace URL with file path (absolute) to for local model import.

### Overview

`import(modelId: string, opts: {modelPath: string, mmprojPath?: string})`
- `modelId`: unique identifier for this model, for llama.cpp
- `modelPath`: URL or local path to GGUF file
- `mmprojPath` (optional): URL or local path to GGUF file

Things to note
- The base directory for this model will be at `<Jan data folder>/models/llamacpp/<modelId>/`. 
- If `modelPath` and `mmprojPath` are URL, they will be downloaded and saved as `model.gguf` and `mmproj.gguf` respectively under the base directory (should we keep the same filename instead?)
- After that, a `model.yml` will be created with keys `model_path` and `mmproj_path`. This will point to the newly downloded files if they were URLs (**the path will be relative to Jan's data folder**). For local model import, this will point to the supplied paths

Example of download from URL (path is relative to Jan's data folder)
<img width="718" alt="image" src="https://github.com/user-attachments/assets/a4765564-16d4-419d-8bed-097b67033f2b" />

Example of local import 
<img width="692" alt="image" src="https://github.com/user-attachments/assets/495674fe-7a4b-449f-9853-923b2b46c9db" />

### Some considerations

- **Why do we need `model.yaml`? Why not symlink for local import?** On Windows, file symlinks require Admin privileges. Hence, having a redirection in `model.yml` is a workaround for this. Note that we are not fixed on `model.yml`. It can be saved together with model settings, wherever it will be.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds model import functionality to llama.cpp extension, supporting URL downloads and local paths, with YAML configuration writing.
> 
>   - **Behavior**:
>     - Adds `import(modelId: string, opts: {modelPath: string, mmprojPath?: string})` to `AIEngine` for model import.
>     - Supports downloading models from URLs and handling local paths in `llamacpp_extension`.
>     - Emits events for download progress, success, and errors.
>     - Writes `model.yml` with paths to downloaded or local files.
>   - **Code Changes**:
>     - Removes `pull` and `abortPull` methods from `AIEngine`.
>     - Updates `llamacpp_extension` to use `@tauri-apps/api/core` instead of `@tauri-apps/api/tauri`.
>     - Adds `write_yaml` command in `src-tauri/src/core/utils/mod.rs` for writing YAML files.
>   - **Dependencies**:
>     - Updates `@tauri-apps/api` to `^2.5.0` in `package.json`.
>     - Adds `serde_yaml` dependency in `Cargo.toml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1335ea79e1b5c4b02606c691be8de049fc260e5f. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->