### PR TITLE
fix: broken ui download count when leftpanel close

### DIFF
--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -119,7 +119,7 @@ export function DownloadManagement() {
   return (
     <>
       {(downloadCount > 0 ||
-        (!updateState.isDownloading && updateState.downloadProgress > 0)) && (
+        (updateState.isDownloading && updateState.downloadProgress > 0)) && (
         <Popover open={isPopoverOpen} onOpenChange={setIsPopoverOpen}>
           <PopoverTrigger asChild>
             {isLeftPanelOpen ? (
@@ -142,7 +142,7 @@ export function DownloadManagement() {
                     className="text-main-view-fg/50 -mt-1"
                     size={20}
                   />
-                  <div className="bg-primary font-bold size-5 rounded-full absolute -top-2 -right-1 flex items-center justify-center text-primary-fg">
+                  <div className="bg-primary font-bold size-5 rounded-full absolute -top-4 -right-4 flex items-center justify-center text-primary-fg">
                     {downloadCount}
                   </div>
                 </div>


### PR DESCRIPTION
## Describe Your Changes

This pull request makes adjustments to the `DownloadManagement` component in `web-app/src/containers/DownloadManegement.tsx`, focusing on refining the download state logic and improving the UI for the download count badge.

### Refinements to download state logic:
* Updated the conditional rendering logic to ensure the popover is displayed only when downloads are in progress and the download progress is greater than 0.

### UI improvements:
* Adjusted the position of the download count badge by modifying its `top` and `right` offsets, moving it further outward for better visibility.

## Fixes Issues

![Screenshot 2025-05-24 at 00 54 23](https://github.com/user-attachments/assets/2c4ae2c4-c89e-4bbf-8a01-8d18242773e7)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes popover display logic and adjusts download count badge position in `DownloadManagement`.
> 
>   - **Behavior**:
>     - Fixes conditional rendering in `DownloadManagement` to show popover only when `isDownloading` is true and `downloadProgress` > 0.
>   - **UI**:
>     - Adjusts download count badge position by changing `top` and `right` offsets in `DownloadManagement` for better visibility.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 05f83ee6c1710a2b91f2bb824004d62a489c0a11. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->