### PR TITLE
fix: copy icon indicator when success

### DIFF
--- a/web-app/src/containers/dynamicControllerSetting/InputControl.tsx
+++ b/web-app/src/containers/dynamicControllerSetting/InputControl.tsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Input } from '@/components/ui/input'
-import { Copy, Eye, EyeOff } from 'lucide-react'
+import { Copy, Eye, EyeOff, CopyCheck } from 'lucide-react'
 import { cn } from '@/lib/utils'
 
 type InputControl = {
@@ -21,11 +21,16 @@ export function InputControl({
   inputActions = [],
 }: InputControl) {
   const [showPassword, setShowPassword] = useState(false)
+  const [isCopied, setIsCopied] = useState(false)
   const hasInputActions = inputActions && inputActions.length > 0
 
   const copyToClipboard = () => {
     if (value) {
       navigator.clipboard.writeText(value)
+      setIsCopied(true)
+      setTimeout(() => {
+        setIsCopied(false)
+      }, 1000)
     }
   }
 
@@ -65,7 +70,11 @@ export function InputControl({
             onClick={copyToClipboard}
             className="p-1 rounded hover:bg-main-view-fg/5 text-main-view-fg/70"
           >
-            <Copy size={16} />
+            {isCopied ? (
+              <CopyCheck className="text-accent" size={16} />
+            ) : (
+              <Copy size={16} />
+            )}
           </button>
         )}
       </div>


### PR DESCRIPTION
## Describe Your Changes

This pull request enhances the `InputControl` component by adding a visual indicator for successful copy-to-clipboard actions. The changes include introducing a new state to manage the copied status and updating the UI to display a different icon when content is successfully copied.

### Enhancements to `InputControl` component:

* Imported the `CopyCheck` icon from the `lucide-react` library to represent a successful copy action. (`web-app/src/containers/dynamicControllerSetting/InputControl.tsx`, [web-app/src/containers/dynamicControllerSetting/InputControl.tsxL3-R3](diffhunk://#diff-ec2a5ac441266de17b4ce21f7d6a6316dc15f675967394ec588c9907224d6e44L3-R3))
* Added a new state variable, `isCopied`, to track whether the copy-to-clipboard action was successful. The state resets after 1 second. (`web-app/src/containers/dynamicControllerSetting/InputControl.tsx`, [web-app/src/containers/dynamicControllerSetting/InputControl.tsxR24-R33](diffhunk://#diff-ec2a5ac441266de17b4ce21f7d6a6316dc15f675967394ec588c9907224d6e44R24-R33))
* Updated the copy button to conditionally render the `CopyCheck` icon when `isCopied` is true, providing immediate feedback to the user. (`web-app/src/containers/dynamicControllerSetting/InputControl.tsx`, [web-app/src/containers/dynamicControllerSetting/InputControl.tsxR73-R77](diffhunk://#diff-ec2a5ac441266de17b4ce21f7d6a6316dc15f675967394ec588c9907224d6e44R73-R77))

## Fixes Issues

![Screenshot 2025-05-24 at 01 17 19](https://github.com/user-attachments/assets/052d034e-6dac-46bd-aa6a-ccd327eb2c6d)
![Screenshot 2025-05-24 at 01 17 16](https://github.com/user-attachments/assets/e6e31526-fec5-4c54-9841-4e1a07208403)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
