### PR TITLE
feat: product analytic

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -46,6 +46,7 @@
     "lucide-react": "^0.503.0",
     "motion": "^12.10.5",
     "next-themes": "^0.4.6",
+    "posthog-js": "^1.246.0",
     "react": "^19.0.0",
     "react-colorful": "^5.6.1",
     "react-dom": "^19.0.0",

--- a/web-app/src/constants/localStorage.ts
+++ b/web-app/src/constants/localStorage.ts
@@ -11,4 +11,6 @@ export const localStorageKey = {
   settingMCPSevers: 'setting-mcp-servers',
   settingLocalApiServer: 'setting-local-api-server',
   settingHardware: 'setting-hardware',
+  productAnalyticPrompt: 'productAnalyticPrompt',
+  productAnalytic: 'productAnalytic',
 }

--- a/web-app/src/containers/analytics/PromptAnalytic.tsx
+++ b/web-app/src/containers/analytics/PromptAnalytic.tsx
@@ -1,0 +1,50 @@
+import { Button } from '@/components/ui/button'
+import { useAnalytic } from '@/hooks/useAnalytic'
+import { IconFileTextShield } from '@tabler/icons-react'
+import posthog from 'posthog-js'
+
+export function PromptAnalytic() {
+  const { setProductAnalyticPrompt, setProductAnalytic } = useAnalytic()
+
+  const handleProductAnalytics = (isAllowed: boolean) => {
+    if (isAllowed) {
+      posthog.opt_in_capturing()
+      setProductAnalytic(true)
+      setProductAnalyticPrompt(false)
+    } else {
+      posthog.opt_out_capturing()
+      setProductAnalytic(false)
+      setProductAnalyticPrompt(false)
+    }
+  }
+
+  return (
+    <div className="fixed bottom-4 right-4 z-50 p-4 shadow-lg bg-main-view w-100 border border-main-view-fg/8 rounded-lg">
+      <div className="flex items-center gap-2">
+        <IconFileTextShield className="text-accent" />
+        <h2 className="font-medium text-main-view-fg/80">
+          Help Us Improve Jan
+        </h2>
+      </div>
+      <p className="mt-2 text-sm text-main-view-fg/70">
+        We collect anonymous data to understand feature usage. Your chats and
+        personal information are never tracked. You can change this anytime
+        in&nbsp;
+        <span className="font-medium text-main-view-fg">{`Settings > Privacy.`}</span>
+      </p>
+      <p className="mt-2 text-sm text-main-view-fg/80">
+        Would you like to help us to improve Jan?
+      </p>
+      <div className="mt-4 flex justify-end space-x-2">
+        <Button
+          variant="link"
+          className="text-main-view-fg/70"
+          onClick={() => handleProductAnalytics(false)}
+        >
+          Deny
+        </Button>
+        <Button onClick={() => handleProductAnalytics(true)}>Allow</Button>
+      </div>
+    </div>
+  )
+}

--- a/web-app/src/hooks/useAnalytic.ts
+++ b/web-app/src/hooks/useAnalytic.ts
@@ -1,0 +1,78 @@
+import { localStorageKey } from '@/constants/localStorage'
+import { create } from 'zustand'
+import { createJSONStorage, persist } from 'zustand/middleware'
+
+export const useAnalytic = () => {
+  const { productAnalyticPrompt, setProductAnalyticPrompt } =
+    useProductAnalyticPrompt()
+  const { productAnalytic, setProductAnalytic } = useProductAnalytic()
+
+  const updateAnalytic = ({
+    productAnalyticPrompt,
+    productAnalytic,
+  }: {
+    productAnalyticPrompt: boolean
+    productAnalytic: boolean
+  }) => {
+    setProductAnalyticPrompt(productAnalyticPrompt)
+    setProductAnalytic(productAnalytic)
+  }
+
+  return {
+    productAnalyticPrompt,
+    setProductAnalyticPrompt,
+    productAnalytic,
+    setProductAnalytic,
+    updateAnalytic,
+  }
+}
+
+export type ProductAnalyticPrompState = {
+  productAnalyticPrompt: boolean
+  setProductAnalyticPrompt: (value: boolean) => void
+}
+
+export const useProductAnalyticPrompt = create<ProductAnalyticPrompState>()(
+  persist(
+    (set) => {
+      // Initialize isDark based on OS preference if theme is auto
+      const initialState = {
+        productAnalyticPrompt: true,
+        setProductAnalyticPrompt: async (value: boolean) => {
+          set(() => ({ productAnalyticPrompt: value }))
+        },
+      }
+
+      return initialState
+    },
+    {
+      name: localStorageKey.productAnalyticPrompt,
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)
+
+export type ProductAnalyticState = {
+  productAnalytic: boolean
+  setProductAnalytic: (value: boolean) => void
+}
+
+export const useProductAnalytic = create<ProductAnalyticState>()(
+  persist(
+    (set) => {
+      // Initialize isDark based on OS preference if theme is auto
+      const initialState = {
+        productAnalytic: false,
+        setProductAnalytic: async (value: boolean) => {
+          set(() => ({ productAnalytic: value }))
+        },
+      }
+
+      return initialState
+    },
+    {
+      name: localStorageKey.productAnalytic,
+      storage: createJSONStorage(() => localStorage),
+    }
+  )
+)

--- a/web-app/src/hooks/useAnalytic.ts
+++ b/web-app/src/hooks/useAnalytic.ts
@@ -27,15 +27,14 @@ export const useAnalytic = () => {
   }
 }
 
-export type ProductAnalyticPrompState = {
+export type ProductAnalyticPromptState = {
   productAnalyticPrompt: boolean
   setProductAnalyticPrompt: (value: boolean) => void
 }
 
-export const useProductAnalyticPrompt = create<ProductAnalyticPrompState>()(
+export const useProductAnalyticPrompt = create<ProductAnalyticPromptState>()(
   persist(
     (set) => {
-      // Initialize isDark based on OS preference if theme is auto
       const initialState = {
         productAnalyticPrompt: true,
         setProductAnalyticPrompt: async (value: boolean) => {
@@ -60,7 +59,6 @@ export type ProductAnalyticState = {
 export const useProductAnalytic = create<ProductAnalyticState>()(
   persist(
     (set) => {
-      // Initialize isDark based on OS preference if theme is auto
       const initialState = {
         productAnalytic: false,
         setProductAnalytic: async (value: boolean) => {

--- a/web-app/src/providers/AnalyticProvider.tsx
+++ b/web-app/src/providers/AnalyticProvider.tsx
@@ -1,0 +1,65 @@
+import posthog from 'posthog-js'
+import { useEffect } from 'react'
+
+import { getAppDistinctId, updateDistinctId } from '@/services/analytic'
+import { useAnalytic } from '@/hooks/useAnalytic'
+
+export function AnalyticProvider() {
+  const { productAnalytic } = useAnalytic()
+
+  useEffect(() => {
+    if (!POSTHOG_KEY || !POSTHOG_HOST) {
+      console.warn(
+        'PostHog not initialized: Missing POSTHOG_KEY or POSTHOG_HOST environment variables'
+      )
+      return
+    }
+    if (productAnalytic) {
+      posthog.init(POSTHOG_KEY, {
+        api_host: POSTHOG_HOST,
+        autocapture: false,
+        capture_pageview: false,
+        capture_pageleave: false,
+        disable_session_recording: true,
+        person_profiles: 'always',
+        persistence: 'localStorage',
+        opt_out_capturing_by_default: true,
+
+        sanitize_properties: function (properties) {
+          const denylist = [
+            '$pathname',
+            '$initial_pathname',
+            '$current_url',
+            '$initial_current_url',
+            '$host',
+            '$initial_host',
+            '$initial_person_info',
+          ]
+
+          denylist.forEach((key) => {
+            if (properties[key]) {
+              properties[key] = null // Set each denied property to null
+            }
+          })
+
+          return properties
+        },
+      })
+      // Attempt to restore distinct Id from app global settings
+      getAppDistinctId()
+        .then((id) => {
+          if (id) posthog.identify(id)
+        })
+        .finally(() => {
+          posthog.opt_in_capturing()
+          posthog.register({ app_version: VERSION })
+          updateDistinctId(posthog.get_distinct_id())
+        })
+    } else {
+      posthog.opt_out_capturing()
+    }
+  }, [productAnalytic])
+
+  // This component doesn't render anything
+  return null
+}

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -12,14 +12,20 @@ import { DataProvider } from '@/providers/DataProvider'
 import { route } from '@/constants/routes'
 import { ExtensionProvider } from '@/providers/ExtensionProvider'
 import { ToasterProvider } from '@/providers/ToasterProvider'
+import { useAnalytic } from '@/hooks/useAnalytic'
+import { PromptAnalytic } from '@/containers/analytics/PromptAnalytic'
+import { AnalyticProvider } from '@/providers/AnalyticProvider'
 
 export const Route = createRootRoute({
   component: RootLayout,
 })
 
 const AppLayout = () => {
+  const { productAnalyticPrompt } = useAnalytic()
+
   return (
     <Fragment>
+      <AnalyticProvider />
       <KeyboardShortcutsProvider />
       <main className="relative h-svh text-sm antialiased select-none bg-app">
         {/* Fake absolute panel top to enable window drag */}
@@ -37,6 +43,7 @@ const AppLayout = () => {
           </div>
         </div>
       </main>
+      {productAnalyticPrompt && <PromptAnalytic />}
     </Fragment>
   )
 }

--- a/web-app/src/routes/settings/privacy.tsx
+++ b/web-app/src/routes/settings/privacy.tsx
@@ -5,6 +5,8 @@ import HeaderPage from '@/containers/HeaderPage'
 import { Switch } from '@/components/ui/switch'
 import { Card, CardItem } from '@/containers/Card'
 import { useTranslation } from 'react-i18next'
+import { useAnalytic } from '@/hooks/useAnalytic'
+import posthog from 'posthog-js'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.privacy as any)({
@@ -13,6 +15,7 @@ export const Route = createFileRoute(route.settings.privacy as any)({
 
 function Privacy() {
   const { t } = useTranslation()
+  const { setProductAnalytic, productAnalytic } = useAnalytic()
 
   return (
     <div className="flex flex-col h-full">
@@ -30,7 +33,17 @@ function Privacy() {
                     Analytics
                   </h1>
                   <div className="flex items-center gap-2">
-                    <Switch />
+                    <Switch
+                      checked={productAnalytic}
+                      onCheckedChange={(state) => {
+                        if (state) {
+                          posthog.opt_in_capturing()
+                        } else {
+                          posthog.opt_out_capturing()
+                        }
+                        setProductAnalytic(state)
+                      }}
+                    />
                   </div>
                 </div>
               }

--- a/web-app/src/services/analytic.ts
+++ b/web-app/src/services/analytic.ts
@@ -1,0 +1,24 @@
+import { AppConfiguration } from '@janhq/core'
+
+/**
+ * Update app distinct Id
+ * @param id
+ */
+export const updateDistinctId = async (id: string) => {
+  const appConfiguration: AppConfiguration =
+    await window.core?.api?.getAppConfigurations()
+  appConfiguration.distinct_id = id
+  await window.core?.api?.updateAppConfiguration({
+    configuration: appConfiguration,
+  })
+}
+
+/**
+ * Retrieve app distinct Id
+ * @param id
+ */
+export const getAppDistinctId = async (): Promise<string | undefined> => {
+  const appConfiguration: AppConfiguration =
+    await window.core?.api?.getAppConfigurations()
+  return appConfiguration.distinct_id
+}

--- a/web-app/src/types/global.d.ts
+++ b/web-app/src/types/global.d.ts
@@ -16,6 +16,8 @@ declare global {
   declare const IS_ANDROID: boolean
   declare const PLATFORM: string
   declare const VERSION: string
+  declare const POSTHOG_KEY: string
+  declare const POSTHOG_HOST: string
   interface Window {
     core: AppCore | undefined
   }

--- a/web-app/vite.config.ts
+++ b/web-app/vite.config.ts
@@ -1,4 +1,4 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import path from 'path'
@@ -8,61 +8,69 @@ import packageJson from './package.json'
 const host = process.env.TAURI_DEV_HOST
 
 // https://vite.dev/config/
-export default defineConfig({
-  plugins: [
-    TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),
-    react(),
-    tailwindcss(),
-    nodePolyfills({
-      include: ['path'],
-    }),
-  ],
-  resolve: {
-    alias: {
-      '@': path.resolve(__dirname, './src'),
-    },
-  },
-  define: {
-    IS_TAURI: JSON.stringify(process.env.IS_TAURI),
-    IS_MACOS: JSON.stringify(
-      process.env.TAURI_ENV_PLATFORM?.includes('darwin') ?? 'false'
-    ),
-    IS_WINDOWS: JSON.stringify(
-      process.env.TAURI_ENV_PLATFORM?.includes('windows') ?? 'false'
-    ),
-    IS_LINUX: JSON.stringify(
-      process.env.TAURI_ENV_PLATFORM?.includes('unix') ?? 'false'
-    ),
-    IS_IOS: JSON.stringify(
-      process.env.TAURI_ENV_PLATFORM?.includes('ios') ?? 'false'
-    ),
-    IS_ANDROID: JSON.stringify(
-      process.env.TAURI_ENV_PLATFORM?.includes('android') ?? 'false'
-    ),
-    PLATFORM: JSON.stringify(process.env.TAURI_ENV_PLATFORM),
+export default defineConfig(({ mode }) => {
+  // Load env file based on `mode` in the current working directory.
+  const env = loadEnv(mode, process.cwd(), '')
 
-    VERSION: JSON.stringify(packageJson.version),
-  },
-
-  // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
-  //
-  // 1. prevent vite from obscuring rust errors
-  clearScreen: false,
-  // 2. tauri expects a fixed port, fail if that port is not available
-  server: {
-    port: 1420,
-    strictPort: true,
-    host: host || false,
-    hmr: host
-      ? {
-          protocol: 'ws',
-          host,
-          port: 1421,
-        }
-      : undefined,
-    watch: {
-      // 3. tell vite to ignore watching `src-tauri`
-      ignored: ['**/src-tauri/**'],
+  return {
+    plugins: [
+      TanStackRouterVite({ target: 'react', autoCodeSplitting: true }),
+      react(),
+      tailwindcss(),
+      nodePolyfills({
+        include: ['path'],
+      }),
+    ],
+    resolve: {
+      alias: {
+        '@': path.resolve(__dirname, './src'),
+      },
     },
-  },
+    define: {
+      IS_TAURI: JSON.stringify(process.env.IS_TAURI),
+      IS_MACOS: JSON.stringify(
+        process.env.TAURI_ENV_PLATFORM?.includes('darwin') ?? 'false'
+      ),
+      IS_WINDOWS: JSON.stringify(
+        process.env.TAURI_ENV_PLATFORM?.includes('windows') ?? 'false'
+      ),
+      IS_LINUX: JSON.stringify(
+        process.env.TAURI_ENV_PLATFORM?.includes('unix') ?? 'false'
+      ),
+      IS_IOS: JSON.stringify(
+        process.env.TAURI_ENV_PLATFORM?.includes('ios') ?? 'false'
+      ),
+      IS_ANDROID: JSON.stringify(
+        process.env.TAURI_ENV_PLATFORM?.includes('android') ?? 'false'
+      ),
+      PLATFORM: JSON.stringify(process.env.TAURI_ENV_PLATFORM),
+
+      VERSION: JSON.stringify(packageJson.version),
+
+      POSTHOG_KEY: JSON.stringify(env.POSTHOG_KEY),
+      POSTHOG_HOST: JSON.stringify(env.POSTHOG_HOST),
+    },
+
+    // Vite options tailored for Tauri development and only applied in `tauri dev` or `tauri build`
+    //
+    // 1. prevent vite from obscuring rust errors
+    clearScreen: false,
+    // 2. tauri expects a fixed port, fail if that port is not available
+    server: {
+      port: 1420,
+      strictPort: true,
+      host: host || false,
+      hmr: host
+        ? {
+            protocol: 'ws',
+            host,
+            port: 1421,
+          }
+        : undefined,
+      watch: {
+        // 3. tell vite to ignore watching `src-tauri`
+        ignored: ['**/src-tauri/**'],
+      },
+    },
+  }
 })


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a product analytics feature using PostHog to collect anonymous usage data. Key changes include the integration of PostHog, a new analytics consent prompt, state management for user preferences, and updates to the app's configuration and environment setup.

### Product Analytics Integration:
* **PostHog library added**: Added `posthog-js` as a dependency in `package.json` for analytics functionality.
* **Analytics provider**: Implemented `AnalyticProvider` to initialize PostHog with environment variables and manage user consent for data collection.

### User Consent Management:
* **Consent prompt**: Created `PromptAnalytic` component to display a user prompt for opting into or out of analytics.
* **State management**: Added `useAnalytic`, `useProductAnalyticPrompt`, and `useProductAnalytic` hooks using Zustand for managing analytics-related states and storing preferences in `localStorage`.

### UI Updates:
* **Privacy settings**: Updated the privacy settings page to include a toggle for enabling/disabling analytics. [[1]](diffhunk://#diff-b49b521769c1e371caa7220ef8866a93269089ce8361ef4fb76d850ab143ea34R18) [[2]](diffhunk://#diff-b49b521769c1e371caa7220ef8866a93269089ce8361ef4fb76d850ab143ea34L33-R46)
* **Analytics prompt display**: Integrated the consent prompt into the app layout, displayed conditionally based on user preferences. [[1]](diffhunk://#diff-fc505ac4f5b3db023ce8295dad8eeff8d37a451458d6e56b86aa0d54e0b49c0fR15-R28) [[2]](diffhunk://#diff-fc505ac4f5b3db023ce8295dad8eeff8d37a451458d6e56b86aa0d54e0b49c0fR46)

### App Configuration:
* **Environment variables**: Updated `vite.config.ts` to load `POSTHOG_KEY` and `POSTHOG_HOST` from environment files. [[1]](diffhunk://#diff-48ffc88488593c2e76f7d938702a4b1fd2c548b91db3c226e2f6c4a09d329f34L11-R15) [[2]](diffhunk://#diff-48ffc88488593c2e76f7d938702a4b1fd2c548b91db3c226e2f6c4a09d329f34R49-R51)
* **Distinct ID management**: Added utility functions to retrieve and update the app's distinct ID for PostHog in `analytic.ts`.

## Fixes Issues

![Screenshot 2025-05-25 at 15 18 16](https://github.com/user-attachments/assets/f08813b6-afba-40c5-ab11-5e41ba13097e)
![Screenshot 2025-05-25 at 15 18 05](https://github.com/user-attachments/assets/29158260-a928-4748-bad8-c25fba0d9555)

Posthog
![Screenshot 2025-05-25 at 15 14 32](https://github.com/user-attachments/assets/32ee1287-8d5b-4af2-aeed-68863a172db5)
![Screenshot 2025-05-25 at 15 16 45](https://github.com/user-attachments/assets/2c22e826-cd81-45f3-8453-f82250377625)
![Screenshot 2025-05-25 at 15 17 24](https://github.com/user-attachments/assets/866a3dcc-5227-426a-b1b1-61f2edd4d6db)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Introduces product analytics using PostHog with user consent management and updates to app configuration.
> 
>   - **Product Analytics Integration**:
>     - Added `posthog-js` to `package.json` for analytics.
>     - Implemented `AnalyticProvider` in `AnalyticProvider.tsx` to initialize PostHog and manage user consent.
>   - **User Consent Management**:
>     - Created `PromptAnalytic` component in `PromptAnalytic.tsx` for user consent prompt.
>     - Added `useAnalytic`, `useProductAnalyticPrompt`, and `useProductAnalytic` hooks in `useAnalytic.ts` for state management using Zustand.
>   - **UI Updates**:
>     - Updated privacy settings in `privacy.tsx` to include analytics toggle.
>     - Integrated consent prompt in `__root.tsx` based on user preferences.
>   - **App Configuration**:
>     - Updated `vite.config.ts` to load `POSTHOG_KEY` and `POSTHOG_HOST` from environment variables.
>     - Added functions in `analytic.ts` to manage distinct IDs for PostHog.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 78a0330400c6bf25fc9931412b10606eb9ce7cb7. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->