### PR TITLE
Fix: janhq url correction

### DIFF
--- a/web-app/src/routes/settings/general.tsx
+++ b/web-app/src/routes/settings/general.tsx
@@ -279,7 +279,7 @@ function General() {
                 description="See what's new in the latest version"
                 actions={
                   <a
-                    href="https://github.com/janhq/jan/releases"
+                    href="https://github.com/menloresearch/jan/releases"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -299,7 +299,7 @@ function General() {
                 description="Contribute to Jan's development"
                 actions={
                   <a
-                    href="https://github.com/janhq/jan"
+                    href="https://github.com/menloresearch/jan"
                     target="_blank"
                     rel="noopener noreferrer"
                   >
@@ -339,7 +339,7 @@ function General() {
                 description="Found a bug? Let us know on GitHub"
                 actions={
                   <a
-                    href="https://github.com/janhq/jan/issues/new"
+                    href="https://github.com/menloresearch/jan/issues/new"
                     target="_blank"
                   >
                     <div className="flex items-center gap-1">


### PR DESCRIPTION
This pull request updates several GitHub links in the `General` settings page of the application to reflect a change in the repository's ownership or organization. 

Link updates in `web-app/src/routes/settings/general.tsx`:

* Updated the "What's new" link to point to `https://github.com/menloresearch/jan/releases` instead of the previous `https://github.com/janhq/jan/releases`.
* Updated the "Contribute to development" link to point to `https://github.com/menloresearch/jan` instead of the previous `https://github.com/janhq/jan`.
* Updated the "Report a bug" link to point to `https://github.com/menloresearch/jan/issues/new` instead of the previous `https://github.com/janhq/jan/issues/new`.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update GitHub links in `general.tsx` to reflect new repository ownership under `menloresearch`.
> 
>   - **Link Updates in `general.tsx`**:
>     - Updated "What's new" link to `https://github.com/menloresearch/jan/releases`.
>     - Updated "Contribute to development" link to `https://github.com/menloresearch/jan`.
>     - Updated "Report a bug" link to `https://github.com/menloresearch/jan/issues/new`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for eb97e4ef262f6f337f0004620fd98bacef8324d4. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->