### PR TITLE
fix: prevent send message when empty message

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -73,6 +73,9 @@ const ChatInput = ({
       setMessage('Please select a model to start chatting.')
       return
     }
+    if (!prompt.trim()) {
+      return
+    }
     setMessage('')
     sendMessage(prompt)
   }
@@ -351,7 +354,7 @@ const ChatInput = ({
                 setRows(Math.min(newRows, maxRows))
               }}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey && prompt) {
+                if (e.key === 'Enter' && !e.shiftKey && prompt.trim()) {
                   e.preventDefault()
                   // Submit the message when Enter is pressed without Shift
                   handleSendMesage(prompt)
@@ -463,9 +466,9 @@ const ChatInput = ({
               </Button>
             ) : (
               <Button
-                variant={!prompt ? null : 'default'}
+                variant={!prompt.trim() ? null : 'default'}
                 size="icon"
-                disabled={!prompt}
+                disabled={!prompt.trim()}
                 onClick={() => handleSendMesage(prompt)}
               >
                 {streamingContent ? (


### PR DESCRIPTION
## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent sending empty messages in `ChatInput.tsx` by trimming `prompt` and updating button state accordingly.
> 
>   - **Behavior**:
>     - Prevent sending empty messages by trimming `prompt` in `handleSendMesage()` and `onKeyDown` in `ChatInput.tsx`.
>     - Update button `variant` and `disabled` state to reflect trimmed `prompt` in `ChatInput.tsx`.
>   - **Functions**:
>     - Modify `handleSendMesage()` to return early if `prompt.trim()` is empty.
>     - Update `onKeyDown` event to check `prompt.trim()` before sending message.
>   - **UI**:
>     - Adjust button state based on `prompt.trim()` to disable sending when message is empty.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b928da6e44240f53ccb671060ddb7abed1bfc283. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->