### PR TITLE
feat: Support download resume

### DIFF
--- a/src-tauri/src/core/utils/download.rs
+++ b/src-tauri/src/core/utils/download.rs
@@ -182,12 +182,21 @@ async fn _download_files_internal(
             }
         }
 
-        let tmp_save_path = save_path.with_extension("tmp");
-        let url_save_path = save_path.with_extension("url");
+        let current_extension = save_path.extension().unwrap_or_default().to_string_lossy();
+        let append_extension = |ext: &str| {
+            if current_extension.is_empty() {
+                ext.to_string()
+            } else {
+                format!("{}.{}", current_extension, ext)
+            }
+        };
+        let tmp_save_path = save_path.with_extension(append_extension("tmp"));
+        let url_save_path = save_path.with_extension(append_extension("url"));
+
         let mut resume = tmp_save_path.exists()
             && tokio::fs::read_to_string(&url_save_path)
                 .await
-                .map(|url| url == item.url) // check we resume the same URL
+                .map(|url| url == item.url) // check if we resume the same URL
                 .unwrap_or(false);
 
         tokio::fs::write(&url_save_path, item.url.clone())

--- a/src-tauri/src/core/utils/download.rs
+++ b/src-tauri/src/core/utils/download.rs
@@ -173,28 +173,68 @@ async fn _download_files_internal(
             ));
         }
 
-        log::info!("Started downloading: {}", item.url);
-        let resp = client.get(&item.url).send().await.map_err(err_to_string)?;
-        if !resp.status().is_success() {
-            return Err(format!(
-                "Failed to download: HTTP status {}, {}",
-                resp.status(),
-                resp.text().await.unwrap_or_default()
-            ));
-        }
-
         // Create parent directories if they don't exist
         if let Some(parent) = save_path.parent() {
             if !parent.exists() {
-                tokio::fs::create_dir_all(parent).await.map_err(err_to_string)?;
+                tokio::fs::create_dir_all(parent)
+                    .await
+                    .map_err(err_to_string)?;
             }
         }
-        let mut file = File::create(&save_path).await.map_err(err_to_string)?;
+
+        let tmp_save_path = save_path.with_extension("tmp");
+        let url_save_path = save_path.with_extension("url");
+        let mut resume = tmp_save_path.exists()
+            && tokio::fs::read_to_string(&url_save_path)
+                .await
+                .map(|url| url == item.url) // check we resume the same URL
+                .unwrap_or(false);
+
+        tokio::fs::write(&url_save_path, item.url.clone())
+            .await
+            .map_err(err_to_string)?;
+
+        log::info!("Started downloading: {}", item.url);
+        let mut download_delta = 0u64;
+        let resp = if resume {
+            let downloaded_size = tmp_save_path.metadata().map_err(err_to_string)?.len();
+            match _get_maybe_resume(&client, &item.url, downloaded_size).await {
+                Ok(resp) => {
+                    log::info!(
+                        "Resume download: {}, already downloaded {} bytes",
+                        item.url,
+                        downloaded_size
+                    );
+                    download_delta += downloaded_size;
+                    resp
+                }
+                Err(e) => {
+                    // fallback to normal download
+                    log::warn!("Failed to resume download: {}", e);
+                    resume = false;
+                    _get_maybe_resume(&client, &item.url, 0).await?
+                }
+            }
+        } else {
+            _get_maybe_resume(&client, &item.url, 0).await?
+        };
+        let mut stream = resp.bytes_stream();
+
+        let file = if resume {
+            // resume download, append to existing file
+            tokio::fs::OpenOptions::new()
+                .write(true)
+                .append(true)
+                .open(&tmp_save_path)
+                .await
+                .map_err(err_to_string)?
+        } else {
+            // start new download, create a new file
+            File::create(&tmp_save_path).await.map_err(err_to_string)?
+        };
+        let mut writer = tokio::io::BufWriter::new(file);
 
         // write chunk to file
-        let mut stream = resp.bytes_stream();
-        let mut download_delta = 0u64;
-
         while let Some(chunk) = stream.next().await {
             if cancel_token.is_cancelled() {
                 log::info!("Download cancelled for task: {}", task_id);
@@ -203,22 +243,63 @@ async fn _download_files_internal(
             }
 
             let chunk = chunk.map_err(err_to_string)?;
-            file.write_all(&chunk).await.map_err(err_to_string)?;
+            writer.write_all(&chunk).await.map_err(err_to_string)?;
             download_delta += chunk.len() as u64;
 
-            // only update every 1MB
-            if download_delta >= 1024 * 1024 {
+            // only update every 10 MB
+            if download_delta >= 10 * 1024 * 1024 {
                 evt.transferred += download_delta;
                 app.emit(&evt_name, evt.clone()).unwrap();
                 download_delta = 0u64;
             }
         }
 
-        file.flush().await.map_err(err_to_string)?;
+        writer.flush().await.map_err(err_to_string)?;
         evt.transferred += download_delta;
+
+        // rename tmp file to final file
+        tokio::fs::rename(&tmp_save_path, &save_path)
+            .await
+            .map_err(err_to_string)?;
+        tokio::fs::remove_file(&url_save_path)
+            .await
+            .map_err(err_to_string)?;
         log::info!("Finished downloading: {}", item.url);
     }
 
     app.emit(&evt_name, evt.clone()).unwrap();
     Ok(())
+}
+
+async fn _get_maybe_resume(
+    client: &reqwest::Client,
+    url: &str,
+    start_bytes: u64,
+) -> Result<reqwest::Response, String> {
+    if start_bytes > 0 {
+        let resp = client
+            .get(url)
+            .header("Range", format!("bytes={}-", start_bytes))
+            .send()
+            .await
+            .map_err(err_to_string)?;
+        if resp.status() != reqwest::StatusCode::PARTIAL_CONTENT {
+            return Err(format!(
+                "Failed to resume download: HTTP status {}, {}",
+                resp.status(),
+                resp.text().await.unwrap_or_default()
+            ));
+        }
+        Ok(resp)
+    } else {
+        let resp = client.get(url).send().await.map_err(err_to_string)?;
+        if !resp.status().is_success() {
+            return Err(format!(
+                "Failed to download: HTTP status {}, {}",
+                resp.status(),
+                resp.text().await.unwrap_or_default()
+            ));
+        }
+        Ok(resp)
+    }
 }


### PR DESCRIPTION
## Describe Your Changes

Add support for resuming download.

Outline of logic: Given that we want to download from URL `url` and save to `save_path`
- We will write to `save_path.tmp` first, and save download `url` to `save_path.url`
- When trying to resume download, we will check if `save_path.tmp` exists, and whether the saved URL in `save_path.url` matches the provided `url`
  - The saved URL provides a simple safety check against resuming with a different URL, though it is not yet fool-proof. Perhaps we can also save [Etag](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/ETag) to check?
- If we resume download, we will use [Range header](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Headers/Range) to request the starting bytes. The starting bytes is the filesize of `save_path.tmp`
  - If server supports Range header, it will respond with [206 Partial Content](https://developer.mozilla.org/en-US/docs/Web/HTTP/Reference/Status/206). We will check for this, and fallback to normal download otherwise
  - We will open the file with append mode instead of creating a new file
- When download finish, we will rename `save_path.tmp` to `save_path`, and remove `save_path.url`

Note: we really should have file checksum check to ensure resume logic did not go wrong. But it can be a bit tricky about who should provide the checksum.

Other misc changes
- Use buffered writer
- Change update interval to every 10MB

https://github.com/user-attachments/assets/5f76c164-04ef-4bd1-94d3-4a41ed3dc7fb

## Fixes Issues

- Closes #5001

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for resuming downloads with partial content requests and temporary file management in `download.rs`.
> 
>   - **Behavior**:
>     - Adds download resume support in `_download_files_internal()` by checking for existing `.tmp` and `.url` files.
>     - Uses `Range` header to request partial content if resuming, falling back to full download if not supported.
>     - Renames `.tmp` file to final file upon completion and removes `.url` file.
>   - **Functions**:
>     - Adds `_get_maybe_resume()` to handle HTTP requests with `Range` header.
>   - **Misc**:
>     - Uses `tokio::io::BufWriter` for buffered writing in `_download_files_internal()`.
>     - Changes update interval to every 10MB in `_download_files_internal()`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3bb772456a157f0eac7c43a78a3ec8a8728c29a5. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->