### PR TITLE
chore: test ci

### DIFF
--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -5,6 +5,7 @@ use core::{
     state::{generate_app_token, AppState},
     utils::download::DownloadManagerState,
 };
+
 use std::{collections::HashMap, sync::Arc};
 
 use tauri::Emitter;


### PR DESCRIPTION
This pull request includes a minor change to the `src-tauri/src/lib.rs` file. It adds a blank line between the `use core::{` block and the `use std::{` block to improve code readability.