### PR TITLE
chore: allow users to setting model offload

### DIFF
--- a/extensions/inference-cortex-extension/resources/default_settings.json
+++ b/extensions/inference-cortex-extension/resources/default_settings.json
@@ -1,5 +1,14 @@
 [
   {
+    "key": "auto_unload_models",
+    "title": "Auto-Unload Old Models",
+    "description": "Automatically unloads models that are not in use to free up memory. Ensure only one model is loaded at a time.",
+    "controllerType": "checkbox",
+    "controllerProps": {
+      "value": true
+    }
+  },
+  {
     "key": "cont_batching",
     "title": "Continuous Batching",
     "description": "Allows processing prompts in parallel with text generation, which usually improves performance.",

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -127,11 +127,9 @@ export const useChat = () => {
         let availableTools = selectedModel?.capabilities?.includes('tools')
           ? tools
           : []
-        while (
-          !isCompleted &&
-          !abortController.signal.aborted
-          // TODO: Max attempts can be set in the provider settings later
-        ) {
+        // TODO: Later replaced by Agent setup?
+        const followUpWithToolUse = true
+        while (!isCompleted && !abortController.signal.aborted) {
           const completion = await sendCompletion(
             activeThread,
             provider,
@@ -201,7 +199,8 @@ export const useChat = () => {
           addMessage(updatedMessage ?? finalContent)
 
           isCompleted = !toolCalls.length
-          availableTools = []
+          // Do not create agent loop if there is no need for it
+          if (!followUpWithToolUse) availableTools = []
         }
       } catch (error) {
         toast.error(

--- a/web-app/src/lib/completion.ts
+++ b/web-app/src/lib/completion.ts
@@ -341,7 +341,7 @@ export const postMessageProcessing = async (
       }
       builder.addToolMessage(result.content[0]?.text ?? '', toolCall.id)
       // update message metadata
-      return message
     }
+    return message
   }
 }

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -79,13 +79,14 @@ export const getProviders = async (): Promise<ModelProvider[]> => {
         provider: providerName,
         settings: Object.values(modelSettings).reduce(
           (acc, setting) => {
+            const value = model[
+              setting.key as keyof typeof model
+            ] as keyof typeof setting.controller_props.value
             acc[setting.key] = {
               ...setting,
               controller_props: {
                 ...setting.controller_props,
-                value: model[
-                  setting.key as keyof typeof model
-                ] as unknown as keyof typeof setting.controller_props.value,
+                value: value ?? setting.controller_props.value,
               },
             }
             return acc

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -77,7 +77,21 @@ export const getProviders = async (): Promise<ModelProvider[]> => {
             ? (model.capabilities as string[])
             : [ModelCapabilities.COMPLETION],
         provider: providerName,
-        settings: modelSettings ,
+        settings: Object.values(modelSettings).reduce(
+          (acc, setting) => {
+            acc[setting.key] = {
+              ...setting,
+              controller_props: {
+                ...setting.controller_props,
+                value: model[
+                  setting.key as keyof typeof model
+                ] as unknown as keyof typeof setting.controller_props.value,
+              },
+            }
+            return acc
+          },
+          {} as Record<string, ProviderSetting>
+        ),
       })),
     }
     runtimeProviders.push(provider)


### PR DESCRIPTION
## Describe Your Changes
This PR added a model load setting, allowing users to decide whether old models will be unloaded when starting a new one.

![CleanShot 2025-05-29 at 12 29 08@2x](https://github.com/user-attachments/assets/75ac4832-0786-400e-a222-b623ff3ec67f)

This also resolved an issue where the default model settings were not the same as those specified in the model.yaml file.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds `auto_unload_models` setting to automatically unload unused models, implemented in `index.ts` and defined in `default_settings.json`.
> 
>   - **Behavior**:
>     - Adds `auto_unload_models` setting in `default_settings.json` to automatically unload unused models.
>     - Implements `auto_unload_models` logic in `loadModel()` in `index.ts` to unload previous models when a new one is loaded.
>   - **Settings**:
>     - Registers `auto_unload_models` in `onLoad()` in `index.ts`.
>     - Updates `onSettingUpdate()` in `index.ts` to handle `auto_unload_models` changes.
>   - **Misc**:
>     - Minor refactoring in `useChat.ts` and `completion.ts` for code clarity.
>     - Updates `getProviders()` in `providers.ts` to include new setting in model settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a3052fa048b9c35bf2396f04f26cef9ac6c73c1c. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->