### PR TITLE
chore: hide reveal password

### DIFF
--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -75,6 +75,10 @@
   a {
     @apply !text-accent;
   }
+
+  ::-ms-reveal {
+    display: none;
+  }
 }
 
 @layer utilities {


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small change to the `web-app/src/index.css` file. It adds a rule to hide the `::-ms-reveal` pseudo-element by setting its `display` property to `none`.

## Fixes Issues

https://learn.microsoft.com/en-us/microsoft-edge/web-platform/password-reveal

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add CSS rule to hide `::-ms-reveal` pseudo-element in `index.css` to prevent password reveal button in Edge.
> 
>   - **CSS Changes**:
>     - Add rule to `index.css` to hide `::-ms-reveal` pseudo-element by setting `display: none;` to prevent password reveal button in Edge.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 0e086abfe2e4a1ae1b0978f5d909b2d2b6c6ab2e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->