### PR TITLE
chore: render markdown on user message

### DIFF
--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -21,12 +21,14 @@ interface MarkdownProps {
   className?: string
   components?: Components
   enableRawHtml?: boolean
+  isUser?: boolean
 }
 
 function RenderMarkdownComponent({
   content,
   enableRawHtml,
   className,
+  isUser,
   components,
 }: MarkdownProps) {
   const { codeBlockStyle, showLineNumbers } = useCodeblock()
@@ -71,7 +73,7 @@ function RenderMarkdownComponent({
 
         const shouldVirtualize = code.split('\n').length > 300
 
-        return !isInline ? (
+        return !isInline && !isUser ? (
           <div className="relative overflow-hidden border rounded-md border-main-view-fg/2">
             <div className="flex items-center justify-between px-4 py-2 bg-main-view/10">
               <span className="font-medium text-xs font-sans">
@@ -135,9 +137,7 @@ function RenderMarkdownComponent({
             </SyntaxHighlighter>
           </div>
         ) : (
-          <code className={className} {...props}>
-            {children}
-          </code>
+          <code className={cn(className)}>{children}</code>
         )
       },
     }),

--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -185,10 +185,14 @@ export const ThreadContent = memo(
       <Fragment>
         {item.content?.[0]?.text && item.role === 'user' && (
           <div className="w-full">
-            <div className="flex justify-end w-full text-start break-words whitespace-normal">
-              <div className="bg-main-view-fg/4 relative text-main-view-fg p-2 rounded-md inline-block max-w-[70%]">
-                <div className="whitespace-pre-wrap select-text">
-                  {item.content?.[0].text.value}
+            <div className="flex justify-end w-full h-full text-start break-words whitespace-normal">
+              <div className="bg-main-view-fg/4 relative text-main-view-fg p-2 rounded-md inline-block max-w-[80%] ">
+                <div className="select-text">
+                  <RenderMarkdown
+                    content={item.content?.[0].text.value}
+                    components={linkComponents}
+                    isUser
+                  />
                 </div>
               </div>
             </div>
@@ -274,7 +278,6 @@ export const ThreadContent = memo(
                 <div className="flex items-center gap-2 size-8 rounded-md justify-center border border-main-view-fg/10 bg-main-view-fg/5 p-1">
                   <AvatarEmoji
                     avatar={assistant?.avatar}
-                    fallback="👋"
                     imageClassName="w-6 h-6 object-contain"
                     textClassName="text-base"
                   />

--- a/web-app/src/styles/markdown.css
+++ b/web-app/src/styles/markdown.css
@@ -41,6 +41,10 @@
   p {
     line-height: 1.6;
     margin-bottom: 1em;
+
+    &:last-child {
+      margin-bottom: 0;
+    }
   }
 
   strong {
@@ -103,17 +107,17 @@
   /* Code */
   code {
     font-family: monospace;
-    @apply bg-main-view-fg/10 text-main-view-fg;
+    @apply bg-main-view-fg/6 text-main-view-fg;
     padding: 0.2em 0.4em;
     border-radius: 3px;
   }
 
   pre {
     font-family: monospace;
-    @apply bg-main-view-fg/10 text-main-view-fg;
+    @apply bg-main-view-fg/6 text-main-view-fg;
     overflow-x: auto;
     border-radius: 8px;
-    margin-bottom: 1em;
+    margin-bottom: 8px;
   }
 
   pre code {


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces updates to improve the rendering of markdown content, enhance user-specific styling, and refine the visual appearance of code blocks. The changes include adjustments to the `RenderMarkdown` component, integration of markdown rendering in user messages, and updates to CSS styles for better readability and consistency.

### Markdown rendering improvements:

* [`web-app/src/containers/RenderMarkdown.tsx`](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfR24-R31): Added a new `isUser` prop to `MarkdownProps` and updated the `RenderMarkdownComponent` to conditionally apply rendering logic based on this prop. This ensures user-specific rendering behavior, such as disabling virtualization for user messages. [[1]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfR24-R31) [[2]](diffhunk://#diff-2aadad5ab406cb9001e841638f8152ce553a86d396405e88db6de94df8e768dfL74-R76)

### Integration of markdown in user messages:

* [`web-app/src/containers/ThreadContent.tsx`](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L188-R195): Replaced plain text rendering with the `RenderMarkdown` component for user messages, enabling rich markdown support. Adjusted the layout to accommodate this change.

### Visual improvements to code blocks:

* [`web-app/src/styles/markdown.css`](diffhunk://#diff-5914a702cb868a9c714506aebd686fe01a941224bb618a16b165f74954ee428eL106-R120): Updated the background color and margin styles for `code` and `pre` elements to improve readability and align with the overall design.

### Minor layout adjustments:

* [`web-app/src/containers/ThreadContent.tsx`](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L277): Removed the fallback emoji from the `AvatarEmoji` component, simplifying its usage.

### CSS refinements:

* [`web-app/src/styles/markdown.css`](diffhunk://#diff-5914a702cb868a9c714506aebd686fe01a941224bb618a16b165f74954ee428eR44-R47): Added a rule to remove the bottom margin from the last paragraph element, ensuring cleaner spacing in markdown rendering.


## Fixes Issues

https://discord.com/channels/1107178041848909847/1374027196469084302/1374027196469084302

![Screenshot 2025-05-30 at 13 53 36](https://github.com/user-attachments/assets/cab5b6f5-b7ff-407a-a950-6abfbdc5e9ff)
![Screenshot 2025-05-30 at 13 47 13](https://github.com/user-attachments/assets/08f133e1-250c-4a0a-ac0d-17e9063e29d9)
![Screenshot 2025-05-30 at 13 52 08](https://github.com/user-attachments/assets/56830898-0dee-4a64-9605-1f588076b24c)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
