### PR TITLE
Ci/add tauri build nightly manual

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -1,0 +1,225 @@
+name: Tauri Builder - Nightly / Manual
+
+on:
+  schedule:
+    - cron: '0 20 * * 1,2,3' # At 8 PM UTC on Monday, Tuesday, and Wednesday which is 3 AM UTC+7 Tuesday, Wednesday, and Thursday
+  workflow_dispatch:
+    inputs:
+      public_provider:
+        type: choice
+        description: 'Public Provider'
+        options:
+          - none
+          - aws-s3
+        default: none
+  pull_request:
+    branches:
+      - release/**
+
+jobs:
+  set-public-provider:
+    runs-on: ubuntu-latest
+    outputs:
+      public_provider: ${{ steps.set-public-provider.outputs.public_provider }}
+      ref: ${{ steps.set-public-provider.outputs.ref }}
+    steps:
+      - name: Set public provider
+        id: set-public-provider
+        run: |
+          if [ "${{ github.event_name }}" == "workflow_dispatch" ]; then
+            echo "::set-output name=public_provider::${{ github.event.inputs.public_provider }}"
+            echo "::set-output name=ref::${{ github.ref }}"
+          else
+            if [ "${{ github.event_name }}" == "schedule" ]; then
+              echo "::set-output name=public_provider::aws-s3"
+              echo "::set-output name=ref::refs/heads/dev"
+            elif [ "${{ github.event_name }}" == "push" ]; then
+              echo "::set-output name=public_provider::aws-s3"
+              echo "::set-output name=ref::${{ github.ref }}"
+            elif [ "${{ github.event_name }}" == "pull_request_review" ]; then
+              echo "::set-output name=public_provider::none"
+              echo "::set-output name=ref::${{ github.ref }}"
+            else
+              echo "::set-output name=public_provider::none"
+              echo "::set-output name=ref::${{ github.ref }}"
+            fi
+          fi
+  # Job create Update app version based on latest release tag with build number and save to output
+  get-update-version:
+    uses: ./.github/workflows/template-get-update-version.yml
+
+  build-macos:
+    uses: ./.github/workflows/template-tauri-build-macos.yml
+    needs: [get-update-version, set-public-provider]
+    secrets: inherit
+    with:
+      ref: ${{ needs.set-public-provider.outputs.ref }}
+      public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: nightly
+      cortex_api_port: '39261'
+
+  build-windows-x64:
+    uses: ./.github/workflows/template-tauri-build-windows-x64.yml
+    secrets: inherit
+    needs: [get-update-version, set-public-provider]
+    with:
+      ref: ${{ needs.set-public-provider.outputs.ref }}
+      public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: nightly
+      cortex_api_port: '39261'
+  build-linux-x64:
+    uses: ./.github/workflows/template-tauri-build-linux-x64.yml
+    secrets: inherit
+    needs: [get-update-version, set-public-provider]
+    with:
+      ref: ${{ needs.set-public-provider.outputs.ref }}
+      public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+      channel: nightly
+      cortex_api_port: '39261'
+
+  sync-temp-to-latest:
+    needs:
+      [
+        get-update-version,
+        set-public-provider,
+        build-windows-x64,
+        build-linux-x64,
+        build-macos,
+      ]
+    runs-on: ubuntu-latest
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+      - name: create latest.json file
+        run: |
+
+          VERSION=${{ needs.get-update-version.outputs.new_version }}
+          PUB_DATE=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          LINUX_SIGNATURE="${{ needs.build-linux-x64.outputs.APPIMAGE_SIG }}"
+          LINUX_URL="https://delta.jan.ai/nightly/${{ needs.build-linux-x64.outputs.APPIMAGE_FILE_NAME }}"
+          WINDOWS_SIGNATURE="${{ needs.build-windows-x64.outputs.WIN_SIG }}"
+          WINDOWS_URL="https://delta.jan.ai/nightly/${{ needs.build-windows-x64.outputs.FILE_NAME }}"
+          DARWIN_SIGNATURE="${{ needs.build-macos.outputs.MAC_UNIVERSAL_SIG }}"
+          DARWIN_URL="https://delta.jan.ai/nightly/Jan-nightly_${{ needs.get-update-version.outputs.new_version }}.app.tar.gz"
+
+          jq --arg version "$VERSION" \
+            --arg pub_date "$PUB_DATE" \
+            --arg linux_signature "$LINUX_SIGNATURE" \
+            --arg linux_url "$LINUX_URL" \
+            --arg windows_signature "$WINDOWS_SIGNATURE" \
+            --arg windows_url "$WINDOWS_URL" \
+            --arg darwin_arm_signature "$DARWIN_SIGNATURE" \
+            --arg darwin_arm_url "$DARWIN_URL" \
+            --arg darwin_amd_signature "$DARWIN_SIGNATURE" \
+            --arg darwin_amd_url "$DARWIN_URL" \
+            '.version = $version
+              | .pub_date = $pub_date
+              | .platforms["linux-x86_64"].signature = $linux_signature
+              | .platforms["linux-x86_64"].url = $linux_url
+              | .platforms["windows-x86_64"].signature = $windows_signature
+              | .platforms["windows-x86_64"].url = $windows_url
+              | .platforms["darwin-aarch64"].signature = $darwin_arm_signature
+              | .platforms["darwin-aarch64"].url = $darwin_arm_url
+              | .platforms["darwin-x86_64"].signature = $darwin_amd_signature
+              | .platforms["darwin-x86_64"].url = $darwin_amd_url' \
+            src-tauri/latest.json.template > latest.json
+            cat latest.json
+      - name: Sync temp to latest
+        if: ${{ needs.set-public-provider.outputs.public_provider == 'aws-s3' }}
+        run: |
+          aws s3 cp ./latest.json s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-nightly/latest.json
+          aws s3 sync s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-nightly/ s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/nightly/
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'
+
+  noti-discord-nightly-and-update-url-readme:
+    needs:
+      [
+        build-macos,
+        build-windows-x64,
+        build-linux-x64,
+        get-update-version,
+        set-public-provider,
+        sync-temp-to-latest,
+      ]
+    secrets: inherit
+    if: github.event_name == 'schedule'
+    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+    with:
+      ref: refs/heads/dev
+      build_reason: Nightly
+      push_to_branch: dev
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+
+  noti-discord-pre-release-and-update-url-readme:
+    needs:
+      [
+        build-macos,
+        build-windows-x64,
+        build-linux-x64,
+        get-update-version,
+        set-public-provider,
+        sync-temp-to-latest,
+      ]
+    secrets: inherit
+    if: github.event_name == 'push'
+    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+    with:
+      ref: refs/heads/dev
+      build_reason: Pre-release
+      push_to_branch: dev
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+
+  noti-discord-manual-and-update-url-readme:
+    needs:
+      [
+        build-macos,
+        build-windows-x64,
+        build-linux-x64,
+        get-update-version,
+        set-public-provider,
+        sync-temp-to-latest,
+      ]
+    secrets: inherit
+    if: github.event_name == 'workflow_dispatch' && github.event.inputs.public_provider == 'aws-s3'
+    uses: ./.github/workflows/template-noti-discord-and-update-url-readme.yml
+    with:
+      ref: refs/heads/dev
+      build_reason: Manual
+      push_to_branch: dev
+      new_version: ${{ needs.get-update-version.outputs.new_version }}
+
+  comment-pr-build-url:
+    needs:
+      [
+        build-macos,
+        build-windows-x64,
+        build-linux-x64,
+        get-update-version,
+        set-public-provider,
+        sync-temp-to-latest,
+      ]
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request_review'
+    steps:
+      - name: Set up GitHub CLI
+        run: |
+          curl -sSL https://github.com/cli/cli/releases/download/v2.33.0/gh_2.33.0_linux_amd64.tar.gz | tar xz
+          sudo cp gh_2.33.0_linux_amd64/bin/gh /usr/local/bin/
+
+      - name: Comment build URL on PR
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_URL=${{ github.event.pull_request.html_url }}
+          RUN_ID=${{ github.run_id }}
+          COMMENT="This is the build for this pull request. You can download it from the Artifacts section here: [Build URL](https://github.com/${{ github.repository }}/actions/runs/${RUN_ID})."
+          gh pr comment $PR_URL --body "$COMMENT"

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -1,0 +1,318 @@
+name: tauri-build-linux-x64
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: 'refs/heads/main'
+      public_provider:
+        required: true
+        type: string
+        default: none
+        description: 'none: build only, github: build and publish to github, aws s3: build and publish to aws s3'
+      new_version:
+        required: true
+        type: string
+        default: ''
+      cortex_api_port:
+        required: false
+        type: string
+        default: ''
+      upload_url:
+        required: false
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: 'nightly'
+        description: 'The channel to use for this job'
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: false
+      TAURI_SIGNING_PUBLIC_KEY:
+        required: false
+    outputs:
+      DEB_SIG:
+        value: ${{ jobs.build-linux-x64.outputs.DEB_SIG }}
+      APPIMAGE_SIG:
+        value: ${{ jobs.build-linux-x64.outputs.APPIMAGE_SIG }}
+      APPIMAGE_FILE_NAME:
+        value: ${{ jobs.build-linux-x64.outputs.APPIMAGE_FILE_NAME }}
+jobs:
+  build-linux-x64:
+    runs-on: ubuntu-22.04
+    outputs:
+      DEB_SIG: ${{ steps.packageinfo.outputs.DEB_SIG }}
+      APPIMAGE_SIG: ${{ steps.packageinfo.outputs.APPIMAGE_SIG }}
+      APPIMAGE_FILE_NAME: ${{ steps.packageinfo.outputs.APPIMAGE_FILE_NAME }}
+    environment: production
+    permissions:
+      contents: write
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Free Disk Space Before Build
+        run: |
+          echo "Disk space before cleanup:"
+          df -h
+          sudo rm -rf /usr/local/.ghcup
+          sudo rm -rf /opt/hostedtoolcache/CodeQL
+          sudo rm -rf /usr/local/lib/android/sdk/ndk
+          sudo rm -rf /usr/share/dotnet
+          sudo rm -rf /opt/ghc
+          sudo rm -rf /usr/local/share/boost
+          sudo apt-get clean
+          echo "Disk space after cleanup:"
+          df -h
+
+      - name: Replace Icons for Beta Build
+        if: inputs.channel != 'stable'
+        shell: bash
+        run: |
+          cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
+
+      - name: Installing node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Install ctoml
+        run: |
+          cargo install ctoml
+
+      - name: Install Tauri dependecies
+        run: |
+          sudo apt update
+          sudo apt install -y libglib2.0-dev libatk1.0-dev libpango1.0-dev libgtk-3-dev libsoup-3.0-dev libwebkit2gtk-4.1-dev librsvg2-dev libfuse2
+
+      - name: Update app version base public_provider
+        run: |
+          echo "Version: ${{ inputs.new_version }}"
+          # Update tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version | .bundle.createUpdaterArtifacts = true | .bundle.resources = ["resources/themes/**/*", "resources/pre-install/**/*"] | .bundle.externalBin = ["binaries/cortex-server", "resources/bin/uv"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json         
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            jq '.bundle.linux.deb.files = {"usr/bin/bun": "resources/bin/bun",
+                                           "usr/lib/Jan-${{ inputs.channel }}/binaries": "binaries/deps",  
+                                           "usr/lib/Jan-${{ inputs.channel }}/binaries/engines": "binaries/engines", 
+                                           "usr/lib/Jan-${{ inputs.channel }}/binaries/libvulkan.so": "binaries/libvulkan.so"}' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          else
+            jq '.bundle.linux.deb.files = {"usr/bin/bun": "resources/bin/bun", 
+                                           "usr/lib/Jan/binaries": "binaries/deps",
+                                           "usr/lib/Jan/binaries/engines": "binaries/engines", 
+                                           "usr/lib/Jan/binaries/libvulkan.so": "binaries/libvulkan.so"}' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          fi
+          mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' web/package.json > /tmp/package.json
+          mv /tmp/package.json web/package.json
+
+          ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          cat ./src-tauri/Cargo.toml
+
+          # Change app name for beta and nightly builds
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+            mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+
+            chmod +x .github/scripts/rename-tauri-app.sh
+            .github/scripts/rename-tauri-app.sh ./src-tauri/tauri.conf.json ${{ inputs.channel }}
+
+            cat ./src-tauri/tauri.conf.json
+            
+            # Update Cargo.toml
+            ctoml ./src-tauri/Cargo.toml package.name "Jan-${{ inputs.channel }}"
+            ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+            echo "------------------"
+            cat ./src-tauri/Cargo.toml
+
+            chmod +x .github/scripts/rename-workspace.sh
+            .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
+            cat ./package.json
+          fi
+      - name: Build app
+        run: |
+          make build-tauri
+          # Copy engines and bun to appimage
+           wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ./appimagetool
+          chmod +x ./appimagetool
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            ls ./src-tauri/target/release/bundle/appimage/
+            cp ./src-tauri/resources/bin/bun ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir/usr/bin/bun
+            mkdir -p ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir/usr/lib/Jan-${{ inputs.channel }}/binaries/engines
+            cp -f ./src-tauri/binaries/deps/*.so* ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir/usr/lib/Jan-${{ inputs.channel }}/binaries/
+            cp -f ./src-tauri/binaries/*.so* ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir/usr/lib/Jan-${{ inputs.channel }}/binaries/
+            cp -rf ./src-tauri/binaries/engines ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir/usr/lib/Jan-${{ inputs.channel }}/binaries/
+            APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep .AppImage | head -1)
+            echo $APP_IMAGE
+            rm -f $APP_IMAGE
+            ./appimagetool ./src-tauri/target/release/bundle/appimage/Jan-${{ inputs.channel }}.AppDir $APP_IMAGE
+          else
+            cp ./src-tauri/resources/bin/bun ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/bin/bun
+            mkdir -p ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/engines
+            cp -f ./src-tauri/binaries/deps/*.so* ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
+            cp -f ./src-tauri/binaries/*.so* ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
+            cp -rf ./src-tauri/binaries/engines ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
+            APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
+            echo $APP_IMAGE
+            rm -f $APP_IMAGE
+            ./appimagetool ./src-tauri/target/release/bundle/appimage/Jan.AppDir $APP_IMAGE
+          fi
+
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          # CORTEX_API_PORT: ${{ inputs.cortex_api_port }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+
+      # Publish app
+
+      ## Artifacts, for dev and test
+      - name: Upload Artifact
+        if: inputs.public_provider != 'github'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jan-linux-amd64-${{ inputs.new_version }}-deb
+          path: ./src-tauri/target/release/bundle/deb/*.deb
+
+      - name: Upload Artifact
+        if: inputs.public_provider != 'github'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
+          path: ./src-tauri/target/release/bundle/appimage/*.AppImage
+
+      ## create zip file and latest-linux.yml for linux electron auto updater
+      - name: Create zip file and latest-linux.yml for linux electron auto updater
+        id: packageinfo
+        run: |
+          cd ./src-tauri/target/release/bundle
+
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            DEB_FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb
+            APPIMAGE_FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage
+            DEB_SIG=$(cat deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig)
+            APPIMAGE_SIG=$(cat appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig)
+          else
+            DEB_FILE_NAME=Jan_${{ inputs.new_version }}_amd64.deb
+            APPIMAGE_FILE_NAME=Jan_${{ inputs.new_version }}_amd64.AppImage
+            DEB_SIG=$(cat deb/Jan_${{ inputs.new_version }}_amd64.deb.sig)
+            APPIMAGE_SIG=$(cat appimage/Jan_${{ inputs.new_version }}_amd64.AppImage.sig)
+          fi
+
+          DEB_FILE_SIZE=$(stat -c%s deb/$DEB_FILE_NAME)
+          APPIMAGE_FILE_SIZE=$(stat -c%s appimage/$APPIMAGE_FILE_NAME)
+          echo "deb file size: $DEB_FILE_SIZE"
+          echo "appimage file size: $APPIMAGE_FILE_SIZE"
+
+          DEB_SH512_CHECKSUM=$(python3 ../../../../.github/scripts/electron-checksum.py deb/$DEB_FILE_NAME)
+          APPIMAGE_SH512_CHECKSUM=$(python3 ../../../../.github/scripts/electron-checksum.py appimage/$APPIMAGE_FILE_NAME)
+          echo "deb sh512 checksum: $DEB_SH512_CHECKSUM"
+          echo "appimage sh512 checksum: $APPIMAGE_SH512_CHECKSUM"
+
+          CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          echo "releaseDate: $CURRENT_TIME"
+
+          # Create latest-linux.yml file
+          echo "version: ${{ inputs.new_version }}" > latest-linux.yml
+          echo "files:" >> latest-linux.yml
+          echo "  - url: $DEB_FILE_NAME" >> latest-linux.yml
+          echo "    sha512: $DEB_SH512_CHECKSUM" >> latest-linux.yml
+          echo "    size: $DEB_FILE_SIZE" >> latest-linux.yml
+          echo "  - url: $APPIMAGE_FILE_NAME" >> latest-linux.yml
+          echo "    sha512: $APPIMAGE_SH512_CHECKSUM" >> latest-linux.yml
+          echo "    size: $APPIMAGE_FILE_SIZE" >> latest-linux.yml
+          echo "path: $APPIMAGE_FILE_NAME" >> latest-linux.yml
+          echo "sha512: $APPIMAGE_SH512_CHECKSUM" >> latest-linux.yml
+          echo "releaseDate: $CURRENT_TIME" >> latest-linux.yml
+
+          cat latest-linux.yml
+          cp latest-linux.yml beta-linux.yml
+
+          echo "DEB_SIG=$DEB_SIG" >> $GITHUB_OUTPUT
+          echo "APPIMAGE_SIG=$APPIMAGE_SIG" >> $GITHUB_OUTPUT
+          echo "DEB_FILE_NAME=$DEB_FILE_NAME" >> $GITHUB_OUTPUT
+          echo "APPIMAGE_FILE_NAME=$APPIMAGE_FILE_NAME" >> $GITHUB_OUTPUT
+
+      ## Upload to s3 for nightly and beta
+      - name: upload to aws s3 if public provider is aws
+        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        run: |
+          cd ./src-tauri/target/release/bundle
+
+          # Upload for electron updater for nightly
+          aws s3 cp ./latest-linux.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/latest-linux.yml
+          aws s3 cp ./beta-linux.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/beta-linux.yml
+
+          # Upload for tauri updater
+          aws s3 cp ./appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage
+          aws s3 cp ./deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb
+          aws s3 cp ./appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig
+          aws s3 cp ./deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'
+
+      ## Upload to github release for stable release
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'stable'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/latest-linux.yml
+          asset_name: latest-linux.yml
+          asset_content_type: text/yaml
+
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'beta'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/beta-linux.yml
+          asset_name: beta-linux.yml
+          asset_content_type: text/yaml
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/appimage/${{ steps.packageinfo.outputs.APPIMAGE_FILE_NAME }}
+          asset_name: ${{ steps.packageinfo.outputs.APPIMAGE_FILE_NAME }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/deb/${{ steps.packageinfo.outputs.DEB_FILE_NAME }}
+          asset_name: ${{ steps.packageinfo.outputs.DEB_FILE_NAME }}
+          asset_content_type: application/octet-stream

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -1,0 +1,312 @@
+name: tauri-build-macos
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: 'refs/heads/main'
+      public_provider:
+        required: true
+        type: string
+        default: none
+        description: 'none: build only, github: build and publish to github, aws s3: build and publish to aws s3'
+      new_version:
+        required: true
+        type: string
+        default: ''
+      cortex_api_port:
+        required: false
+        type: string
+        default: ''
+      upload_url:
+        required: false
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: 'nightly'
+        description: 'The channel to use for this job'
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      CODE_SIGN_P12_BASE64:
+        required: false
+      CODE_SIGN_P12_PASSWORD:
+        required: false
+      APPLE_ID:
+        required: false
+      APPLE_APP_SPECIFIC_PASSWORD:
+        required: false
+      DEVELOPER_ID:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: false
+      TAURI_SIGNING_PUBLIC_KEY:
+        required: false
+    outputs:
+      MAC_UNIVERSAL_SIG:
+        value: ${{ jobs.build-macos.outputs.MAC_UNIVERSAL_SIG }}
+      TAR_NAME:
+        value: ${{ jobs.build-macos.outputs.TAR_NAME }}
+
+jobs:
+  build-macos:
+    runs-on: macos-latest
+    outputs:
+      MAC_UNIVERSAL_SIG: ${{ steps.metadata.outputs.MAC_UNIVERSAL_SIG }}
+      TAR_NAME: ${{ steps.metadata.outputs.TAR_NAME }}
+    environment: production
+    permissions:
+      contents: write
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+      - name: Replace Icons for Beta Build
+        if: inputs.channel != 'stable'
+        shell: bash
+        run: |
+          cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
+
+      - name: Installing node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Install ctoml
+        run: |
+          cargo install ctoml
+
+      - name: Create bun and uv universal
+        run: |
+          mkdir -p ./src-tauri/resources/bin/
+          cd ./src-tauri/resources/bin/
+          curl -L -o bun-darwin-x64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-x64.zip
+          curl -L -o bun-darwin-aarch64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-aarch64.zip
+          unzip bun-darwin-x64.zip
+          unzip bun-darwin-aarch64.zip
+          lipo -create -output bun-universal-apple-darwin bun-darwin-x64/bun bun-darwin-aarch64/bun
+          cp -f bun-darwin-aarch64/bun bun-aarch64-apple-darwin 
+          cp -f bun-darwin-x64/bun bun-x86_64-apple-darwin
+          cp -f bun-universal-apple-darwin bun
+
+          curl -L -o uv-x86_64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-x86_64-apple-darwin.tar.gz
+          curl -L -o uv-arm64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-aarch64-apple-darwin.tar.gz
+          tar -xzf uv-x86_64.tar.gz
+          tar -xzf uv-arm64.tar.gz
+          mv uv-x86_64-apple-darwin uv-x86_64
+          mv uv-aarch64-apple-darwin uv-aarch64
+          lipo -create -output uv-universal-apple-darwin uv-x86_64/uv uv-aarch64/uv
+          cp -f uv-x86_64/uv uv-x86_64-apple-darwin
+          cp -f uv-aarch64/uv uv-aarch64-apple-darwin
+          cp -f uv-universal-apple-darwin uv
+          ls -la
+
+      - name: Update app version based on latest release tag with build number
+        run: |
+          echo "Version: ${{ inputs.new_version }}"
+          # Update tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version | .bundle.createUpdaterArtifacts = true' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' web/package.json > /tmp/package.json
+          mv /tmp/package.json web/package.json
+
+          ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          cat ./src-tauri/Cargo.toml
+
+          # Change app name for beta and nightly builds
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+            mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+
+            chmod +x .github/scripts/rename-tauri-app.sh
+            .github/scripts/rename-tauri-app.sh ./src-tauri/tauri.conf.json ${{ inputs.channel }}
+
+            cat ./src-tauri/tauri.conf.json
+
+            # Update Cargo.toml
+            ctoml ./src-tauri/Cargo.toml package.name "Jan-${{ inputs.channel }}"
+            ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+            echo "------------------"
+            cat ./src-tauri/Cargo.toml
+
+            chmod +x .github/scripts/rename-workspace.sh
+            .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
+            cat ./package.json
+          fi
+      - name: Get key for notarize
+        run: base64 -d <<< "$NOTARIZE_P8_BASE64" > /tmp/notary-key.p8
+        shell: bash
+        env:
+          NOTARIZE_P8_BASE64: ${{ secrets.NOTARIZE_P8_BASE64 }}
+
+      - uses: apple-actions/import-codesign-certs@v2
+        continue-on-error: true
+        with:
+          p12-file-base64: ${{ secrets.CODE_SIGN_P12_BASE64 }}
+          p12-password: ${{ secrets.CODE_SIGN_P12_PASSWORD }}
+
+      - name: Build app
+        run: |
+          rustup target add x86_64-apple-darwin
+          make build-tauri
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          APP_PATH: '.'
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          # CORTEX_API_PORT: ${{ inputs.cortex_api_port }}
+          APPLE_CERTIFICATE: ${{ secrets.CODE_SIGN_P12_BASE64 }}
+          APPLE_CERTIFICATE_PASSWORD: ${{ secrets.CODE_SIGN_P12_PASSWORD }}
+          APPLE_API_ISSUER: ${{ secrets.NOTARY_ISSUER }}
+          APPLE_API_KEY: ${{ secrets.NOTARY_KEY_ID }}
+          APPLE_API_KEY_PATH: /tmp/notary-key.p8
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+
+      # Publish app
+
+      ## Artifacts, for dev and test
+      - name: Upload Artifact
+        if: inputs.public_provider != 'github'
+        uses: actions/upload-artifact@v4
+        with:
+          name: jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.dmg
+          path: |
+            ./src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
+
+      ## create zip file and latest-mac.yml for mac electron auto updater
+      - name: create zip file and latest-mac.yml for mac electron auto updater
+        run: |
+          cd ./src-tauri/target/universal-apple-darwin/release/bundle/macos
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            zip -r jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip Jan-${{ inputs.channel }}.app
+            FILE_NAME=jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip
+            DMG_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_universal.dmg
+            MAC_UNIVERSAL_SIG=$(cat Jan-${{ inputs.channel }}.app.tar.gz.sig)
+            TAR_NAME=Jan-${{ inputs.channel }}.app.tar.gz
+          else
+            zip -r jan-mac-universal-${{ inputs.new_version }}.zip Jan.app
+            FILE_NAME=jan-mac-universal-${{ inputs.new_version }}.zip
+            MAC_UNIVERSAL_SIG=$(cat Jan.app.tar.gz.sig)
+            DMG_NAME=Jan_${{ inputs.new_version }}_universal.dmg
+            TAR_NAME=Jan.app.tar.gz
+          fi
+
+          FILE_SIZE=$(stat -f%z $FILE_NAME)
+          echo "size: $FILE_SIZE"
+
+          SH512_CHECKSUM=$(python3 ../../../../../../.github/scripts/electron-checksum.py $FILE_NAME)
+          echo "sha512: $SH512_CHECKSUM"
+          CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          echo "releaseDate: $CURRENT_TIME"
+
+          # Create latest-mac.yml file
+          echo "version: ${{ inputs.new_version }}" > latest-mac.yml
+          echo "files:" >> latest-mac.yml
+          echo "  - url: $FILE_NAME" >> latest-mac.yml
+          echo "    sha512: $SH512_CHECKSUM" >> latest-mac.yml
+          echo "    size: $FILE_NAME" >> latest-mac.yml
+          echo "path: $FILE_NAME" >> latest-mac.yml
+          echo "sha512: $SH512_CHECKSUM" >> latest-mac.yml
+          echo "releaseDate: $CURRENT_TIME" >> latest-mac.yml
+
+          cat latest-mac.yml
+          cp latest-mac.yml beta-mac.yml
+
+          echo "::set-output name=MAC_UNIVERSAL_SIG::$MAC_UNIVERSAL_SIG"
+          echo "::set-output name=FILE_NAME::$FILE_NAME"
+          echo "::set-output name=DMG_NAME::$DMG_NAME"
+          echo "::set-output name=TAR_NAME::$TAR_NAME"
+        id: metadata
+
+      ## Upload to s3 for nightly and beta
+      - name: upload to aws s3 if public provider is aws
+        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        run: |
+          cd ./src-tauri/target/universal-apple-darwin/release/bundle
+
+          # Upload for electron updater for nightly
+          aws s3 cp ./macos/latest-mac.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/latest-mac.yml
+          aws s3 cp ./macos/beta-mac.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/beta-mac.yml
+          aws s3 cp ./macos/jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip
+          aws s3 cp ./macos/jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip.sig
+
+          # Upload for tauri updater
+          aws s3 cp ./dmg/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_universal.dmg s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_universal.dmg
+          aws s3 cp ./macos/Jan-${{ inputs.channel }}.app.tar.gz s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}.app.tar.gz
+          aws s3 cp ./macos/Jan-${{ inputs.channel }}.app.tar.gz.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/Jan-${{ inputs.channel }}_${{ inputs.new_version }}.app.tar.gz.sig
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'
+
+      ## Upload to github release for stable release
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'stable'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/latest-mac.yml
+          asset_name: latest-mac.yml
+          asset_content_type: text/yaml
+
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'beta'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/beta-mac.yml
+          asset_name: beta-mac.yml
+          asset_content_type: text/yaml
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/${{ steps.metadata.outputs.FILE_NAME }}
+          asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
+          asset_content_type: application/gzip
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/dmg/${{ steps.metadata.outputs.DMG_NAME }}
+          asset_name: ${{ steps.metadata.outputs.DMG_NAME }}
+          asset_content_type: application/octet-stream
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/universal-apple-darwin/release/bundle/macos/${{ steps.metadata.outputs.TAR_NAME }}
+          asset_name: ${{ steps.metadata.outputs.TAR_NAME }}
+          asset_content_type: application/gzip

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -1,0 +1,290 @@
+name: tauri-build-windows-x64
+on:
+  workflow_call:
+    inputs:
+      ref:
+        required: true
+        type: string
+        default: 'refs/heads/main'
+      public_provider:
+        required: true
+        type: string
+        default: none
+        description: 'none: build only, github: build and publish to github, aws s3: build and publish to aws s3'
+      new_version:
+        required: true
+        type: string
+        default: ''
+      cortex_api_port:
+        required: false
+        type: string
+        default: ''
+      upload_url:
+        required: false
+        type: string
+        default: ''
+      channel:
+        required: true
+        type: string
+        default: 'nightly'
+        description: 'The channel to use for this job'
+    secrets:
+      DELTA_AWS_S3_BUCKET_NAME:
+        required: false
+      DELTA_AWS_ACCESS_KEY_ID:
+        required: false
+      DELTA_AWS_SECRET_ACCESS_KEY:
+        required: false
+      AZURE_KEY_VAULT_URI:
+        required: false
+      AZURE_CLIENT_ID:
+        required: false
+      AZURE_TENANT_ID:
+        required: false
+      AZURE_CLIENT_SECRET:
+        required: false
+      AZURE_CERT_NAME:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY:
+        required: false
+      TAURI_SIGNING_PRIVATE_KEY_PASSWORD:
+        required: false
+      TAURI_SIGNING_PUBLIC_KEY:
+        required: false
+    outputs:
+      WIN_SIG:
+        value: ${{ jobs.build-windows-x64.outputs.WIN_SIG }}
+      FILE_NAME:
+        value: ${{ jobs.build-windows-x64.outputs.FILE_NAME }}
+
+jobs:
+  build-windows-x64:
+    runs-on: windows-latest
+    outputs:
+      WIN_SIG: ${{ steps.metadata.outputs.WIN_SIG }}
+      FILE_NAME: ${{ steps.metadata.outputs.FILE_NAME }}
+    permissions:
+      contents: write
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ inputs.ref }}
+
+      - name: Replace Icons for Beta Build
+        if: inputs.channel != 'stable'
+        shell: bash
+        run: |
+          cp .github/scripts/icon-${{ inputs.channel }}.png src-tauri/icons/icon.png
+
+      - name: Installing node
+        uses: actions/setup-node@v1
+        with:
+          node-version: 20
+
+      - name: Install jq
+        uses: dcarbone/install-jq-action@v2.0.1
+
+      - name: Install ctoml
+        run: |
+          cargo install ctoml
+
+      - name: Update app version base on tag
+        id: version_update
+        shell: bash
+        run: |
+          echo "Version: ${{ inputs.new_version }}"
+          # Update tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version | .bundle.createUpdaterArtifacts = true | .bundle.windows.nsis.template = "tauri.bundle.windows.nsis.template"' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' web/package.json > /tmp/package.json
+          mv /tmp/package.json web/package.json
+
+          ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------Cargo.toml---------"
+          cat ./src-tauri/Cargo.toml
+
+          generate_build_version() {
+              ### Examble
+              ### input 0.5.6 output will be 0.5.6 and 0.5.6.0
+              ### input 0.5.6-rc2-beta output will be 0.5.6 and 0.5.6.2
+              ### input 0.5.6-1213 output will be 0.5.6 and and 0.5.6.1213
+              local new_version="$1"
+              local base_version
+              local t_value
+
+              # Check if it has a "-"
+              if [[ "$new_version" == *-* ]]; then
+                  base_version="${new_version%%-*}" # part before -
+                  suffix="${new_version#*-}"         # part after -
+
+                  # Check if it is rcX-beta
+                  if [[ "$suffix" =~ ^rc([0-9]+)-beta$ ]]; then
+                      t_value="${BASH_REMATCH[1]}"
+                  else
+                      t_value="$suffix"
+                  fi
+              else
+                  base_version="$new_version"
+                  t_value="0"
+              fi
+
+              # Export two values
+              new_base_version="$base_version"
+              new_build_version="${base_version}.${t_value}"
+          }
+          generate_build_version ${{ inputs.new_version }}
+          sed -i "s/jan_version/$new_base_version/g" ./src-tauri/tauri.bundle.windows.nsis.template
+          sed -i "s/jan_build/$new_build_version/g" ./src-tauri/tauri.bundle.windows.nsis.template          
+
+          # Change app name for beta and nightly builds
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+            mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
+
+            chmod +x .github/scripts/rename-tauri-app.sh
+            .github/scripts/rename-tauri-app.sh ./src-tauri/tauri.conf.json ${{ inputs.channel }}
+
+            echo "---------tauri.conf.json---------"
+            cat ./src-tauri/tauri.conf.json
+
+            # Update Cargo.toml
+            ctoml ./src-tauri/Cargo.toml package.name "Jan-${{ inputs.channel }}"
+            ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+            echo "------------------"
+            cat ./src-tauri/Cargo.toml
+
+            chmod +x .github/scripts/rename-workspace.sh
+            .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
+            cat ./package.json
+            
+            sed -i "s/jan_productname/Jan-${{ inputs.channel }}/g" ./src-tauri/tauri.bundle.windows.nsis.template
+            sed -i "s/jan_mainbinaryname/jan-${{ inputs.channel }}/g" ./src-tauri/tauri.bundle.windows.nsis.template
+          fi
+          echo "---------nsis.template---------"
+          cat ./src-tauri/tauri.bundle.windows.nsis.template
+
+      - name: Install AzureSignTool
+        run: |
+          dotnet tool install --global --version 6.0.0 AzureSignTool
+
+      - name: Build app
+        shell: bash
+        run: |
+          make build-tauri
+        env:
+          AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
+          AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}
+          AZURE_TENANT_ID: ${{ secrets.AZURE_TENANT_ID }}
+          AZURE_CLIENT_SECRET: ${{ secrets.AZURE_CLIENT_SECRET }}
+          AZURE_CERT_NAME: ${{ secrets.AZURE_CERT_NAME }}
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: auto
+          AWS_EC2_METADATA_DISABLED: 'true'
+          AWS_MAX_ATTEMPTS: '5'
+          POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
+          POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          # CORTEX_API_PORT: ${{ inputs.cortex_api_port }}
+          TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
+          TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+          TAURI_SIGNING_PUBLIC_KEY: ${{ secrets.TAURI_SIGNING_PUBLIC_KEY }}
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: jan-windows-${{ inputs.new_version }}
+          path: |
+            ./src-tauri/target/release/bundle/nsis/*.exe
+
+      ## create zip file and latest.yml for windows electron auto updater
+      - name: create zip file and latest.yml for windows electron auto updater
+        shell: bash
+        run: |
+          cd ./src-tauri/target/release/bundle/nsis
+          if [ "${{ inputs.channel }}" != "stable" ]; then
+            FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe
+            WIN_SIG=$(cat Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe.sig)
+          else
+            FILE_NAME=Jan_${{ inputs.new_version }}_x64-setup.exe
+            WIN_SIG=$(cat Jan_${{ inputs.new_version }}_x64-setup.exe.sig)
+          fi
+
+          FILE_SIZE=$(stat -c %s $FILE_NAME)
+          echo "size: $FILE_SIZE"
+
+          SH512_CHECKSUM=$(python3 ../../../../../.github/scripts/electron-checksum.py $FILE_NAME)
+          echo "sha512: $SH512_CHECKSUM"
+          CURRENT_TIME=$(date -u +"%Y-%m-%dT%H:%M:%S.%3NZ")
+          echo "releaseDate: $CURRENT_TIME"
+
+          # Create latest.yml file
+          echo "version: ${{ inputs.new_version }}" > latest.yml
+          echo "files:" >> latest.yml
+          echo "  - url: $FILE_NAME" >> latest.yml
+          echo "    sha512: $SH512_CHECKSUM" >> latest.yml
+          echo "    size: $FILE_NAME" >> latest.yml
+          echo "path: $FILE_NAME" >> latest.yml
+          echo "sha512: $SH512_CHECKSUM" >> latest.yml
+          echo "releaseDate: $CURRENT_TIME" >> latest.yml
+
+          cat latest.yml
+          cp latest.yml beta.yml
+
+          echo "::set-output name=WIN_SIG::$WIN_SIG"
+          echo "::set-output name=FILE_NAME::$FILE_NAME"
+        id: metadata
+
+      ## Upload to s3 for nightly and beta
+      - name: upload to aws s3 if public provider is aws
+        shell: bash
+        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        run: |
+          cd ./src-tauri/target/release/bundle/nsis
+
+          # Upload for electron updater for nightly
+          aws s3 cp ./latest.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/latest.yml
+          aws s3 cp ./beta.yml s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/beta.yml
+
+          # Upload for tauri updater
+          aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}
+          aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }}.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}.sig
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}
+          AWS_DEFAULT_REGION: ${{ secrets.DELTA_AWS_REGION }}
+          AWS_EC2_METADATA_DISABLED: 'true'
+
+      ## Upload to github release for stable release
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'stable'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/nsis/latest.yml
+          asset_name: latest.yml
+          asset_content_type: text/yaml
+
+      - name: Upload release assert if public provider is github
+        if: inputs.channel == 'beta'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/nsis/beta.yml
+          asset_name: beta.yml
+          asset_content_type: text/yaml
+
+      - name: Upload release assert if public provider is github
+        if: inputs.public_provider == 'github'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: actions/upload-release-asset@v1.0.1
+        with:
+          upload_url: ${{ inputs.upload_url }}
+          asset_path: ./src-tauri/target/release/bundle/nsis/${{ steps.metadata.outputs.FILE_NAME }}
+          asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
+          asset_content_type: application/octet-stream


### PR DESCRIPTION
This pull request introduces new workflows for automating the nightly builds and manual releases of a Tauri application across multiple platforms. The changes include defining a new workflow for nightly builds, creating platform-specific build templates, and implementing logic for version updates and artifact uploads. These workflows aim to streamline the build process and enable flexible deployment options.

### Nightly Build Workflow Enhancements:
* [`.github/workflows/jan-tauri-build-nightly.yaml`](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R1-R225): Added a new workflow to automate nightly builds and manual releases. It includes jobs for setting the public provider, updating the app version, building for macOS, Windows, and Linux, syncing artifacts to AWS S3, and notifying via Discord. The workflow supports scheduled builds, manual triggers, and pre-releases.

### Platform-Specific Build Templates:
* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03R1-R318): Added a template for building the Linux x64 version of the application. It includes steps for cleaning disk space, installing dependencies, updating the app version, building the application, and uploading artifacts to AWS S3 or GitHub based on the specified public provider.