### PR TITLE
fix: extension settings are not retained in new sessions

### DIFF
--- a/core/src/browser/extension.ts
+++ b/core/src/browser/extension.ts
@@ -118,9 +118,10 @@ export abstract class BaseExtension implements ExtensionType {
       setting.extensionName = this.name
     })
     try {
-      const oldSettings = localStorage.getItem(this.name)
+      const oldSettingsJson = localStorage.getItem(this.name)
       // Persists new settings
-      if (oldSettings) {
+      if (oldSettingsJson) {
+        const oldSettings = JSON.parse(oldSettingsJson)
         settings.forEach((setting) => {
           // Keep setting value
           if (setting.controllerProps && Array.isArray(oldSettings))
@@ -169,13 +170,13 @@ export abstract class BaseExtension implements ExtensionType {
     if (!this.name) return []
 
     try {
-      const settingsString = localStorage.getItem(this.name);
-      if (!settingsString) return [];
-      const settings: SettingComponentProps[] = JSON.parse(settingsString);
-      return settings;
+      const settingsString = localStorage.getItem(this.name)
+      if (!settingsString) return []
+      const settings: SettingComponentProps[] = JSON.parse(settingsString)
+      return settings
     } catch (err) {
-      console.warn(err);
-      return [];
+      console.warn(err)
+      return []
     }
   }
 
@@ -201,8 +202,8 @@ export abstract class BaseExtension implements ExtensionType {
 
     if (!updatedSettings.length) updatedSettings = componentProps as SettingComponentProps[]
 
-    localStorage.setItem(this.name, JSON.stringify(updatedSettings));
-    
+    localStorage.setItem(this.name, JSON.stringify(updatedSettings))
+
     updatedSettings.forEach((setting) => {
       this.onSettingUpdate<typeof setting.controllerProps.value>(
         setting.key,

--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -49,6 +49,12 @@ pub fn install_extensions(app: tauri::AppHandle, force: bool) -> Result<(), Stri
     if std::env::var("CLEAN").is_ok() {
         clean_up = true;
     }
+    log::info!(
+        "Installing extensions. Clean up: {}, Stored version: {}, App version: {}",
+        clean_up,
+        stored_version,
+        app_version
+    );
     if !clean_up && stored_version == app_version && extensions_path.exists() {
         return Ok(());
     }

--- a/web-app/src/containers/ProvidersMenu.tsx
+++ b/web-app/src/containers/ProvidersMenu.tsx
@@ -97,10 +97,7 @@ const ProvidersMenu = ({
 
         <Dialog>
           <DialogTrigger asChild>
-            <div
-              className="bg-main-view flex cursor-pointer px-4 my-1.5 items-center gap-1.5  text-main-view-fg/80"
-              onClick={() => {}}
-            >
+            <div className="bg-main-view flex cursor-pointer px-4 my-1.5 items-center gap-1.5  text-main-view-fg/80">
               <IconCirclePlus size={18} />
               <span className="capitalize">Add Provider</span>
             </div>


### PR DESCRIPTION
## Describe Your Changes

This is a minor PR to fix the issue of persistent extension settings. There is a case where settings are not kept when refreshing the sesions.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes extension settings persistence in `BaseExtension` and improves logging in `install_extensions()` with minor UI cleanup in `ProvidersMenu.tsx`.
> 
>   - **Behavior**:
>     - Fixes issue in `BaseExtension` in `extension.ts` where settings were not retained across sessions by parsing JSON from `localStorage`.
>   - **Logging**:
>     - Adds logging in `install_extensions()` in `setup.rs` to indicate extension installation status.
>   - **UI**:
>     - Removes unused `onClick` handler in `ProvidersMenu.tsx` for the "Add Provider" button.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 8cdfb1fede76db84afba8e856fc6ad520647084e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->