### PR TITLE
fix: remove capitalize class from provider name

### DIFF
--- a/web-app/src/containers/ProvidersMenu.tsx
+++ b/web-app/src/containers/ProvidersMenu.tsx
@@ -87,9 +87,7 @@ const ProvidersMenu = ({
                 }
               >
                 <ProvidersAvatar provider={provider} />
-                <span className="capitalize">
-                  {getProviderTitle(provider.provider)}
-                </span>
+                <span>{getProviderTitle(provider.provider)}</span>
               </div>
             </div>
           )
@@ -99,7 +97,7 @@ const ProvidersMenu = ({
           <DialogTrigger asChild>
             <div className="bg-main-view flex cursor-pointer px-4 my-1.5 items-center gap-1.5  text-main-view-fg/80">
               <IconCirclePlus size={18} />
-              <span className="capitalize">Add Provider</span>
+              <span>Add Provider</span>
             </div>
           </DialogTrigger>
           <DialogContent>


### PR DESCRIPTION
## Describe Your Changes

This pull request includes minor changes to the `ProvidersMenu` component in `web-app/src/containers/ProvidersMenu.tsx`. The changes remove the `capitalize` CSS class from certain `<span>` elements to ensure consistent text styling.

Styling adjustments:

* Removed the `capitalize` class from the `<span>` elements displaying provider titles to prevent automatic capitalization. (`[web-app/src/containers/ProvidersMenu.tsxL90-R90](diffhunk://#diff-db573253ae646febf83887d8c24ddba65b1e0e66f01f40ab1898f1747a279cf0L90-R90)`)
* Removed the `capitalize` class from the `<span>` element for the "Add Provider" text to ensure consistent text rendering. (`[web-app/src/containers/ProvidersMenu.tsxL102-R100](diffhunk://#diff-db573253ae646febf83887d8c24ddba65b1e0e66f01f40ab1898f1747a279cf0L102-R100)`)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
