### PR TITLE
fix: handle undefined search index in getFilteredThreads

### DIFF
--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -66,7 +66,7 @@ export const useThreads = create<ThreadState>()(
         }
 
         let currentIndex = searchIndex
-        if (!currentIndex) {
+        if (!currentIndex?.find) {
           currentIndex = new Fzf<Thread[]>(Object.values(threads), {
             selector: (item: Thread) => item.title,
           })


### PR DESCRIPTION
## Describe Your Changes

- fix error when currentIndex is broken

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes error in `getFilteredThreads` in `useThreads.ts` when `searchIndex` is undefined or lacks `find` method by initializing a new `Fzf` instance.
> 
>   - **Behavior**:
>     - Fixes error in `getFilteredThreads` in `useThreads.ts` when `searchIndex` is undefined or lacks `find` method by initializing a new `Fzf` instance.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 02e8b2066373e116ffcc51bcce3ad8a9217a7827. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->