### PR TITLE
fix: thread update after chat

### DIFF
--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -49,7 +49,7 @@ export const useChat = () => {
   const { getProviderByName, selectedModel, selectedProvider } =
     useModelProvider()
 
-  const { getCurrentThread: retrieveThread, createThread } = useThreads()
+  const { getCurrentThread: retrieveThread, createThread, updateThreadTimestamp } = useThreads()
   const { getMessages, addMessage } = useMessages()
   const router = useRouter()
 
@@ -65,7 +65,7 @@ export const useChat = () => {
     }
     setTools()
 
-    let unsubscribe = () => {}
+    let unsubscribe = () => { }
     listen(SystemEvent.MCP_UPDATE, setTools).then((unsub) => {
       // Unsubscribe from the event when the component unmounts
       unsubscribe = unsub
@@ -111,6 +111,7 @@ export const useChat = () => {
       setAbortController(activeThread.id, abortController)
       updateStreamingContent(emptyThreadContent)
       addMessage(newUserThreadContent(activeThread.id, message))
+      updateThreadTimestamp(activeThread.id)
       setPrompt('')
       try {
         if (selectedModel?.id) {
@@ -133,11 +134,11 @@ export const useChat = () => {
         // Filter tools based on model capabilities and available tools for this thread
         let availableTools = selectedModel?.capabilities?.includes('tools')
           ? tools.filter((tool) => {
-              const availableToolNames = getAvailableToolsForThread(
-                activeThread.id
-              )
-              return availableToolNames.includes(tool.name)
-            })
+            const availableToolNames = getAvailableToolsForThread(
+              activeThread.id
+            )
+            return availableToolNames.includes(tool.name)
+          })
           : []
 
         // TODO: Later replaced by Agent setup?
@@ -213,6 +214,7 @@ export const useChat = () => {
             allowAllMCPPermissions
           )
           addMessage(updatedMessage ?? finalContent)
+          updateThreadTimestamp(activeThread.id)
 
           isCompleted = !toolCalls.length
           // Do not create agent loop if there is no need for it
@@ -236,6 +238,7 @@ export const useChat = () => {
       setAbortController,
       updateStreamingContent,
       addMessage,
+      updateThreadTimestamp,
       setPrompt,
       selectedModel,
       currentAssistant,


### PR DESCRIPTION
## Describe Your Changes

## Overview
This PR introduces automatic thread ordering based on activity, ensuring the most recently active threads appear at the top of the thread list.

## What's Changed

### New Features
- **Thread Timestamp Updates**: Automatically update thread timestamps when new messages are added

### Implementation Details

#### `useThreads.ts`
- Added `updateThreadTimestamp(threadId: string)` function to the ThreadState interface
- Implemented smart ordering logic:
  - If thread is already at order 1: only update timestamp
  - If thread is not at top: move to order 1 and increment all other threads' order by 1
- Ensures both local state and backend storage are updated
- Maintains search index consistency after reordering

#### `useChat.ts`
- Integrated `updateThreadTimestamp` calls at key interaction points:
  - When user sends a message
  - When assistant responds with a message
- Ensures threads stay current based on conversation activity

## Files Modified
- `web-app/src/hooks/useChat.ts` - Added timestamp update calls
- `web-app/src/hooks/useThreads.ts` - Implemented core ordering logic


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
