### PR TITLE
feat: Jan API Server should have API Key setting

### DIFF
--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -1,8 +1,6 @@
-use reqwest::blocking::Client;
 use serde::{Deserialize, Serialize};
 use std::{fs, io, path::PathBuf};
 use tauri::{AppHandle, Manager, Runtime, State};
-use tauri_plugin_updater::UpdaterExt;
 
 use super::{server, setup, state::AppState};
 
@@ -347,10 +345,15 @@ pub async fn start_server(
     host: String,
     port: u16,
     prefix: String,
+    api_key: String,
     trusted_hosts: Vec<String>,
 ) -> Result<bool, String> {
-    let auth_token = app.state::<AppState>().app_token.clone().unwrap_or_default();
-    server::start_server(host, port, prefix, auth_token, trusted_hosts)
+    let auth_token = app
+        .state::<AppState>()
+        .app_token
+        .clone()
+        .unwrap_or_default();
+    server::start_server(host, port, prefix, auth_token, api_key, trusted_hosts)
         .await
         .map_err(|e| e.to_string())?;
     Ok(true)

--- a/src-tauri/src/core/server.rs
+++ b/src-tauri/src/core/server.rs
@@ -91,7 +91,7 @@ async fn proxy_request(
         if let Some(authorization) = req.headers().get(hyper::header::AUTHORIZATION) {
             let auth_str = authorization.to_str().unwrap_or("");
 
-            if !auth_str.starts_with("Bearer ") || auth_str != format!("Bearer {}", config.api_key)
+            if auth_str.strip_prefix("Bearer ") != Some(config.api_key.as_str())
             {
                 return Ok(Response::builder()
                     .status(StatusCode::UNAUTHORIZED)

--- a/src-tauri/src/core/server.rs
+++ b/src-tauri/src/core/server.rs
@@ -20,6 +20,7 @@ struct ProxyConfig {
     prefix: String,
     auth_token: String,
     trusted_hosts: Vec<String>,
+    api_key: String,
 }
 
 /// Removes a prefix from a path, ensuring proper formatting
@@ -86,6 +87,25 @@ async fn proxy_request(
             .unwrap());
     }
 
+    if !config.api_key.is_empty() {
+        if let Some(authorization) = req.headers().get(hyper::header::AUTHORIZATION) {
+            let auth_str = authorization.to_str().unwrap_or("");
+
+            if !auth_str.starts_with("Bearer ") || auth_str != format!("Bearer {}", config.api_key)
+            {
+                return Ok(Response::builder()
+                    .status(StatusCode::UNAUTHORIZED)
+                    .body(Body::from("Invalid or missing authorization token"))
+                    .unwrap());
+            }
+        } else {
+            return Ok(Response::builder()
+                .status(StatusCode::UNAUTHORIZED)
+                .body(Body::from("Missing authorization header"))
+                .unwrap());
+        }
+    }
+
     // Block access to /configs endpoint
     if path.contains("/configs") {
         return Ok(Response::builder()
@@ -102,8 +122,8 @@ async fn proxy_request(
 
     // Copy original headers
     for (name, value) in req.headers() {
-        if name != hyper::header::HOST {
-            // Skip host header
+        // Skip host & authorization header
+        if name != hyper::header::HOST && name != hyper::header::AUTHORIZATION {
             outbound_req = outbound_req.header(name, value);
         }
     }
@@ -152,14 +172,26 @@ fn is_valid_host(host: &str, trusted_hosts: &[String]) -> bool {
         return false;
     }
 
-    let host_without_port = if host.starts_with('[') { host.split(']').next().unwrap_or(host).trim_start_matches('[') } else { host.split(':').next().unwrap_or(host) };
+    let host_without_port = if host.starts_with('[') {
+        host.split(']')
+            .next()
+            .unwrap_or(host)
+            .trim_start_matches('[')
+    } else {
+        host.split(':').next().unwrap_or(host)
+    };
     let default_valid_hosts = ["localhost", "127.0.0.1"];
 
-    if default_valid_hosts.iter().any(|&valid| host_without_port.to_lowercase() == valid.to_lowercase()) {
+    if default_valid_hosts
+        .iter()
+        .any(|&valid| host_without_port.to_lowercase() == valid.to_lowercase())
+    {
         return true;
     }
-    
-    trusted_hosts.iter().any(|valid| host_without_port.to_lowercase() == valid.to_lowercase())
+
+    trusted_hosts
+        .iter()
+        .any(|valid| host_without_port.to_lowercase() == valid.to_lowercase())
 }
 
 /// Starts the proxy server
@@ -168,6 +200,7 @@ pub async fn start_server(
     port: u16,
     prefix: String,
     auth_token: String,
+    api_key: String,
     trusted_hosts: Vec<String>,
 ) -> Result<bool, Box<dyn std::error::Error + Send + Sync>> {
     // Check if server is already running
@@ -186,6 +219,7 @@ pub async fn start_server(
         upstream: "http://127.0.0.1:39291".to_string(),
         prefix,
         auth_token,
+        api_key,
         trusted_hosts,
     };
 

--- a/web-app/src/containers/ApiKeyInput.tsx
+++ b/web-app/src/containers/ApiKeyInput.tsx
@@ -1,10 +1,12 @@
 import { Input } from '@/components/ui/input'
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { useState } from 'react'
+import { Eye, EyeOff } from 'lucide-react'
 
 export function ApiKeyInput() {
   const { apiKey, setApiKey } = useLocalApiServer()
   const [inputValue, setInputValue] = useState(apiKey.toString())
+  const [showPassword, setShowPassword] = useState(false)
 
   const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
     const value = e.target.value
@@ -16,13 +18,24 @@ export function ApiKeyInput() {
   }
 
   return (
-    <Input
-      type="password"
-      value={inputValue}
-      onChange={handleChange}
-      onBlur={handleBlur}
-      className="w-full h-8 text-sm"
-      placeholder="Enter API Key"
-    />
+    <div className="relative w-full">
+      <Input
+        type={showPassword ? 'text' : 'password'}
+        value={inputValue}
+        onChange={handleChange}
+        onBlur={handleBlur}
+        className="w-full h-8 text-sm pr-10"
+        placeholder="Enter API Key"
+      />
+      <div className="absolute right-2 top-1/2 transform -translate-y-1/2 flex items-center gap-1">
+        <button
+          onClick={() => setShowPassword(!showPassword)}
+          className="p-1 rounded hover:bg-main-view-fg/5 text-main-view-fg/70"
+          type="button"
+        >
+          {showPassword ? <EyeOff size={16} /> : <Eye size={16} />}
+        </button>
+      </div>
+    </div>
   )
 }

--- a/web-app/src/containers/ApiKeyInput.tsx
+++ b/web-app/src/containers/ApiKeyInput.tsx
@@ -1,0 +1,28 @@
+import { Input } from '@/components/ui/input'
+import { useLocalApiServer } from '@/hooks/useLocalApiServer'
+import { useState } from 'react'
+
+export function ApiKeyInput() {
+  const { apiKey, setApiKey } = useLocalApiServer()
+  const [inputValue, setInputValue] = useState(apiKey.toString())
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value
+    setInputValue(value)
+  }
+
+  const handleBlur = () => {
+    setApiKey(inputValue)
+  }
+
+  return (
+    <Input
+      type="password"
+      value={inputValue}
+      onChange={handleChange}
+      onBlur={handleBlur}
+      className="w-full h-8 text-sm"
+      placeholder="Enter API Key"
+    />
+  )
+}

--- a/web-app/src/hooks/useLocalApiServer.ts
+++ b/web-app/src/hooks/useLocalApiServer.ts
@@ -21,6 +21,8 @@ type LocalApiServerState = {
   // Verbose server logs
   verboseLogs: boolean
   setVerboseLogs: (value: boolean) => void
+  apiKey: string
+  setApiKey: (value: string) => void
   // Trusted hosts
   trustedHosts: string[]
   addTrustedHost: (host: string) => void
@@ -53,6 +55,8 @@ export const useLocalApiServer = create<LocalApiServerState>()(
           trustedHosts: state.trustedHosts.filter((h) => h !== host),
         })),
       setTrustedHosts: (hosts) => set({ trustedHosts: hosts }),
+      apiKey: '',
+      setApiKey: (value) => set({ apiKey: value }),
     }),
     {
       name: localStorageKey.settingLocalApiServer,

--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -16,6 +16,7 @@ import { useAppState } from '@/hooks/useAppState'
 import { windowKey } from '@/constants/windows'
 import { IconLogs } from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
+import { ApiKeyInput } from '@/containers/ApiKeyInput'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.local_api_server as any)({
@@ -32,6 +33,7 @@ function LocalAPIServer() {
     serverHost,
     serverPort,
     apiPrefix,
+    apiKey,
     trustedHosts,
   } = useLocalApiServer()
 
@@ -45,6 +47,7 @@ function LocalAPIServer() {
           host: serverHost,
           port: serverPort,
           prefix: apiPrefix,
+          apiKey,
           trustedHosts,
           isCorsEnabled: corsEnabled,
           isVerboseEnabled: verboseLogs,
@@ -181,6 +184,14 @@ function LocalAPIServer() {
                   isServerRunning && 'opacity-50 pointer-events-none'
                 )}
                 actions={<ApiPrefixInput />}
+              />
+              <CardItem
+                title="API Key"
+                description="Authenticate requests with an API key"
+                className={cn(
+                  isServerRunning && 'opacity-50 pointer-events-none'
+                )}
+                actions={<ApiKeyInput />}
               />
               <CardItem
                 title="Trusted Hosts"


### PR DESCRIPTION
## Describe Your Changes

Add API Key setting to Jan Local API Server settings

![CleanShot 2025-06-04 at 13 57 53@2x](https://github.com/user-attachments/assets/3d454c4e-9d12-46bd-99f9-549501fe94f4)

![CleanShot 2025-06-04 at 13 57 26@2x](https://github.com/user-attachments/assets/f505b19e-ddd9-4fc3-9f6d-0eb5c40291a8)


![CleanShot 2025-06-04 at 13 55 39@2x](https://github.com/user-attachments/assets/e97bf5df-298d-419b-b50e-df1c33d51072)


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add API key authentication to Jan Local API Server with backend and frontend support for input and validation.
> 
>   - **Backend**:
>     - Add `api_key` parameter to `start_server()` in `cmd.rs` and `server.rs` for API key authentication.
>     - Modify `proxy_request()` in `server.rs` to check `Authorization` header against `api_key`.
>   - **Frontend**:
>     - Add `ApiKeyInput` component in `ApiKeyInput.tsx` for API key input with validation.
>     - Update `useLocalApiServer` in `useLocalApiServer.ts` to include `apiKey` state management.
>     - Modify `local-api-server.tsx` to integrate `ApiKeyInput` and handle API key validation before starting the server.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d4b3b9a9460567183e6ac8a6597b7385ec88311b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->