### PR TITLE
fix: add missing default host ip

### DIFF
--- a/src-tauri/src/core/server.rs
+++ b/src-tauri/src/core/server.rs
@@ -180,7 +180,7 @@ fn is_valid_host(host: &str, trusted_hosts: &[String]) -> bool {
     } else {
         host.split(':').next().unwrap_or(host)
     };
-    let default_valid_hosts = ["localhost", "127.0.0.1"];
+    let default_valid_hosts = ["localhost", "127.0.0.1", "0.0.0.0"];
 
     if default_valid_hosts
         .iter()


### PR DESCRIPTION
This pull request updates the `is_valid_host` function in `src-tauri/src/core/server.rs` to expand the list of default valid hosts. The change ensures that `0.0.0.0` is now considered a valid host alongside `localhost` and `127.0.0.1`.

Networking update:

* [`src-tauri/src/core/server.rs`](diffhunk://#diff-ca7ce79e8a65cd75fad95c5b801eb8190cbf2f7119063d016f50b982ed9ca42dL183-R183): Added `0.0.0.0` to the `default_valid_hosts` array in the `is_valid_host` function to allow it as a valid host.