### PR TITLE
Fix: mcp server file system missing param

### DIFF
--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -9,7 +9,7 @@ use tokio::{process::Command, sync::Mutex, time::timeout};
 
 use super::{cmd::get_jan_data_folder_path, state::AppState};
 
-const DEFAULT_MCP_CONFIG: &str = r#"{"mcpServers":{"browsermcp":{"command":"npx","args":["@browsermcp/mcp"],"env":{},"active":false},"fetch":{"command":"uvx","args":["mcp-server-fetch"],"env":{},"active":false},"filesystem":{"command":"npx","args":["-y","/path/to/other/allowed/dir"],"env":{},"active":false},"playwright":{"command":"npx","args":["@playwright/mcp","--isolated"],"env":{},"active":false},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"],"env":{},"active":false},"tavily":{"command":"npx","args":["-y","tavily-mcp"],"env":{"TAVILY_API_KEY": "tvly-YOUR_API_KEY-here"},"active":false}}}"#;
+const DEFAULT_MCP_CONFIG: &str = r#"{"mcpServers":{"browsermcp":{"command":"npx","args":["@browsermcp/mcp"],"env":{},"active":false},"fetch":{"command":"uvx","args":["mcp-server-fetch"],"env":{},"active":false},"filesystem":{"command":"npx","args":["-y","@modelcontextprotocol/server-filesystem","/path/to/other/allowed/dir"],"env":{},"active":false},"playwright":{"command":"npx","args":["@playwright/mcp","--isolated"],"env":{},"active":false},"sequential-thinking":{"command":"npx","args":["-y","@modelcontextprotocol/server-sequential-thinking"],"env":{},"active":false},"tavily":{"command":"npx","args":["-y","tavily-mcp"],"env":{"TAVILY_API_KEY": "tvly-YOUR_API_KEY-here"},"active":false}}}"#;
 
 // Timeout for MCP tool calls (30 seconds)
 const MCP_TOOL_CALL_TIMEOUT: Duration = Duration::from_secs(30);


### PR DESCRIPTION
This pull request modifies the default configuration for MCP servers in the `DEFAULT_MCP_CONFIG` constant within `src-tauri/src/core/mcp.rs`. The most significant change updates the arguments for the `filesystem` server to include a new package path.

Configuration updates:

* [`src-tauri/src/core/mcp.rs`](diffhunk://#diff-cb908bb8bc1f2ea25b48faa227f523e42f7f6b3d904fb4175f8969971e8c1160L12-R12): Updated the `filesystem` server's arguments in the `DEFAULT_MCP_CONFIG` constant to include the package `@modelcontextprotocol/server-filesystem` alongside the directory path.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `DEFAULT_MCP_CONFIG` in `mcp.rs` to include `@modelcontextprotocol/server-filesystem` package path for `filesystem` server.
> 
>   - **Configuration Update**:
>     - In `src-tauri/src/core/mcp.rs`, updated `DEFAULT_MCP_CONFIG` to include `@modelcontextprotocol/server-filesystem` package path in `filesystem` server's arguments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3cdbff53ebaac7819cf555bc21a4ce0447dd1039. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->