### PR TITLE
fix: load threads from api instead of states

### DIFF
--- a/web-app/src/providers/DataProvider.tsx
+++ b/web-app/src/providers/DataProvider.tsx
@@ -18,6 +18,7 @@ import {
 } from '@tauri-apps/plugin-deep-link'
 import { useNavigate } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
+import { useThreads } from '@/hooks/useThreads'
 
 export function DataProvider() {
   const { setProviders } = useModelProvider()
@@ -26,6 +27,7 @@ export function DataProvider() {
   const { checkForUpdate } = useAppUpdater()
   const { setServers } = useMCPServers()
   const { setAssistants } = useAssistant()
+  const { setThreads } = useThreads()
   const navigate = useNavigate()
 
   useEffect(() => {
@@ -51,6 +53,7 @@ export function DataProvider() {
 
   useEffect(() => {
     fetchThreads().then((threads) => {
+      setThreads(threads)
       threads.forEach((thread) =>
         fetchMessages(thread.id).then((messages) =>
           setMessages(thread.id, messages)


### PR DESCRIPTION
## Describe Your Changes

Threads should be loaded from API, in case there are different instances of app sharing the same data folder. Currently read from states

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Modify `DataProvider` to load threads from API for consistency across app instances.
> 
>   - **Behavior**:
>     - Modify `DataProvider` to load threads from API using `fetchThreads()` and set them with `setThreads()`.
>     - Ensures consistency across app instances sharing the same data folder.
>   - **Functions**:
>     - Add `setThreads` from `useThreads` hook in `DataProvider.tsx`.
>     - Use `fetchThreads()` to retrieve threads and `setThreads()` to update state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 22d5eda56979e83412b066b839064006dc4fc963. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->