### PR TITLE
ci: update tauri build template macos

### DIFF
--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -219,7 +219,7 @@ jobs:
           echo "files:" >> latest-mac.yml
           echo "  - url: $FILE_NAME" >> latest-mac.yml
           echo "    sha512: $SH512_CHECKSUM" >> latest-mac.yml
-          echo "    size: $FILE_NAME" >> latest-mac.yml
+          echo "    size: $FILE_SIZE" >> latest-mac.yml
           echo "path: $FILE_NAME" >> latest-mac.yml
           echo "sha512: $SH512_CHECKSUM" >> latest-mac.yml
           echo "releaseDate: $CURRENT_TIME" >> latest-mac.yml

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -74,7 +74,7 @@
   "bundle": {
     "active": true,
     "targets": ["nsis", "app", "dmg", "deb", "appimage"],
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
This pull request includes two changes related to build configuration and artifact generation. The changes update a workflow file and a configuration file to correct a variable reference and disable updater artifact creation.

### Workflow file update:

* [`.github/workflows/template-tauri-build-macos.yml`](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L222-R222): Corrected the variable used for file size in the `latest-mac.yml` generation process, changing from `$FILE_NAME` to `$FILE_SIZE`.

### Configuration file update:

* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L77-R77): Disabled the creation of updater artifacts by setting `createUpdaterArtifacts` to `false`.