### PR TITLE
chore: trim all mcp server configs before saving

### DIFF
--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -203,22 +203,23 @@ export default function AddEditMCPServer({
     // Convert env arrays to object
     const envObj: Record<string, string> = {}
     envKeys.forEach((key, index) => {
-      if (key.trim() !== '') {
-        envObj[key] = envValues[index] || ''
+      const keyName = key.trim()
+      if (keyName !== '') {
+        envObj[keyName] = envValues[index]?.trim() || ''
       }
     })
 
     // Filter out empty args
-    const filteredArgs = args.filter((arg) => arg.trim() !== '')
+    const filteredArgs = args.map((arg) => arg.trim()).filter((arg) => arg)
 
     const config: MCPServerConfig = {
-      command,
+      command: command.trim(),
       args: filteredArgs,
       env: envObj,
     }
 
     if (serverName.trim() !== '') {
-      onSave(serverName, config)
+      onSave(serverName.trim(), config)
       onOpenChange(false)
       resetForm()
     }


### PR DESCRIPTION
## Describe Your Changes

MCP server configs should be trimmed before saving. It's now quite hard to handle syntax errors so better gate these cases.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
