### PR TITLE
fix: avoid spamming server restarts

### DIFF
--- a/web-app/src/hooks/useMCPServers.ts
+++ b/web-app/src/hooks/useMCPServers.ts
@@ -24,9 +24,10 @@ type MCPServerStoreState = {
   editServer: (key: string, config: MCPServerConfig) => void
   deleteServer: (key: string) => void
   setServers: (servers: MCPServers) => void
+  syncServers: () => void
 }
 
-export const useMCPServers = create<MCPServerStoreState>()((set) => ({
+export const useMCPServers = create<MCPServerStoreState>()((set, get) => ({
   open: true,
   mcpServers: {}, // Start with empty object
   loading: false,
@@ -37,7 +38,6 @@ export const useMCPServers = create<MCPServerStoreState>()((set) => ({
   addServer: (key, config) =>
     set((state) => {
       const mcpServers = { ...state.mcpServers, [key]: config }
-      updateMCPConfig(JSON.stringify({ mcpServers }))
       return { mcpServers }
     }),
 
@@ -48,13 +48,11 @@ export const useMCPServers = create<MCPServerStoreState>()((set) => ({
       if (!state.mcpServers[key]) return state
 
       const mcpServers = { ...state.mcpServers, [key]: config }
-      updateMCPConfig(JSON.stringify({ mcpServers }))
       return { mcpServers }
     }),
   setServers: (servers) =>
     set((state) => {
       const mcpServers = { ...state.mcpServers, ...servers }
-      updateMCPConfig(JSON.stringify({ mcpServers }))
       return { mcpServers }
     }),
   // Delete an MCP server by key
@@ -67,14 +65,17 @@ export const useMCPServers = create<MCPServerStoreState>()((set) => ({
       if (updatedServers[key]) {
         delete updatedServers[key]
       }
-      updateMCPConfig(
-        JSON.stringify({
-          mcpServers: updatedServers,
-        })
-      )
       return {
         mcpServers: updatedServers,
         deletedServerKeys: [...state.deletedServerKeys, key],
       }
     }),
+  syncServers: async () => {
+    const mcpServers = get().mcpServers
+    await updateMCPConfig(
+      JSON.stringify({
+        mcpServers,
+      })
+    )
+  },
 }))

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -26,7 +26,8 @@ export const Route = createFileRoute(route.settings.mcp_servers as any)({
 })
 
 function MCPServers() {
-  const { mcpServers, addServer, editServer, deleteServer } = useMCPServers()
+  const { mcpServers, addServer, editServer, deleteServer, syncServers } =
+    useMCPServers()
   const { allowAllMCPPermissions, setAllowAllMCPPermissions } =
     useToolApproval()
 
@@ -64,17 +65,19 @@ function MCPServers() {
   const handleSaveServer = (name: string, config: MCPServerConfig) => {
     if (editingKey) {
       // Edit existing server
-      editServer(editingKey, config)
 
       // If server name changed, delete old one and add new one
       if (editingKey !== name) {
         deleteServer(editingKey)
         addServer(name, config)
+      } else {
+        editServer(editingKey, config)
       }
     } else {
       // Add new server
       addServer(name, config)
     }
+    syncServers()
   }
 
   const handleEdit = (serverKey: string) => {
@@ -90,6 +93,7 @@ function MCPServers() {
     if (serverToDelete) {
       deleteServer(serverToDelete)
       setServerToDelete(null)
+      syncServers()
     }
   }
 
@@ -126,6 +130,7 @@ function MCPServers() {
         }
       )
     }
+    syncServers()
   }
 
   const toggleServer = (serverKey: string, active: boolean) => {
@@ -135,6 +140,7 @@ function MCPServers() {
         ...(mcpServers[serverKey] as MCPServerConfig),
         active,
       })
+      syncServers()
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This PR addresses the issue where users editing an MCP server could restart servers multiple times.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidates server configuration updates into a single `syncServers` function to prevent multiple server restarts.
> 
>   - **Behavior**:
>     - Introduces `syncServers` function in `useMCPServers.ts` to batch update server configurations.
>     - Calls `syncServers` after server add, edit, delete, and toggle actions in `mcp-servers.tsx`.
>   - **Functions**:
>     - Removes `updateMCPConfig` calls from `addServer`, `editServer`, `deleteServer`, and `setServers` in `useMCPServers.ts`.
>     - Adds `syncServers` call in `handleSaveServer`, `handleConfirmDelete`, `handleSaveJson`, and `toggleServer` in `mcp-servers.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 318d46137d387259119609653480a7b093a1b124. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->