### PR TITLE
fix: prettify json when pasting content

### DIFF
--- a/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
+++ b/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
@@ -41,6 +41,21 @@ export default function EditJsonMCPserver({
     }
   }, [open, initialData])
 
+  const handlePaste = (e: React.ClipboardEvent) => {
+    const pastedText = e.clipboardData.getData('text')
+    try {
+      const parsedJson = JSON.parse(pastedText)
+      const prettifiedJson = JSON.stringify(parsedJson, null, 2)
+      e.preventDefault()
+      setJsonContent(prettifiedJson)
+      setError(null)
+    } catch (error) {
+      e.preventDefault()
+      setError('Invalid JSON format in pasted content')
+      console.error('Paste error:', error)
+    }
+  }
+
   const handleSave = () => {
     try {
       const parsedData = JSON.parse(jsonContent)
@@ -69,6 +84,7 @@ export default function EditJsonMCPserver({
               language="json"
               placeholder="Enter JSON configuration"
               onChange={(e) => setJsonContent(e.target.value)}
+              onPaste={handlePaste}
               style={{
                 fontFamily: 'ui-monospace',
                 backgroundColor: 'transparent',


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces functionality to handle pasted JSON content in the `EditJsonMCPserver` component. It ensures that pasted JSON is validated, prettified, and safely handled, improving user experience and error feedback.

### New functionality for handling pasted JSON:
* Added a `handlePaste` function to validate and prettify pasted JSON content. If the pasted content is invalid, an error message is displayed, and the error is logged to the console. (`web-app/src/containers/dialogs/EditJsonMCPserver.tsx`, [web-app/src/containers/dialogs/EditJsonMCPserver.tsxR44-R58](diffhunk://#diff-9c06695caca8dee21bc5cf3a5428819f2d07b02931951251f2abf865f54c1860R44-R58))
* Integrated the `handlePaste` function with the `onPaste` event of the JSON input field to trigger the validation and formatting logic when users paste content. (`web-app/src/containers/dialogs/EditJsonMCPserver.tsx`, [web-app/src/containers/dialogs/EditJsonMCPserver.tsxR87](diffhunk://#diff-9c06695caca8dee21bc5cf3a5428819f2d07b02931951251f2abf865f54c1860R87))

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
