### PR TITLE
chore: add toggle loading sever MCP

### DIFF
--- a/web-app/src/components/ui/switch.tsx
+++ b/web-app/src/components/ui/switch.tsx
@@ -14,7 +14,7 @@ function Switch({ loading, className, ...props }: SwitchProps) {
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'relative peer cursor-pointer data-[state=checked]:bg-accent data-[state=unchecked]:bg-main-view-fg/20 focus-visible:border-none inline-flex h-[18px] w-8.5 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 transition-all',
+        'relative peer cursor-pointer data-[state=checked]:bg-accent data-[state=unchecked]:bg-main-view-fg/20 focus-visible:border-none inline-flex h-[18px] w-8.5 shrink-0 items-center rounded-full border border-transparent shadow-xs outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 transition-all',
         loading && 'w-4.5 pointer-events-none',
         className
       )}

--- a/web-app/src/components/ui/switch.tsx
+++ b/web-app/src/components/ui/switch.tsx
@@ -8,8 +8,6 @@ type SwitchProps = React.ComponentProps<typeof SwitchPrimitive.Root> & {
   loading?: boolean
 }
 function Switch({ loading, className, ...props }: SwitchProps) {
-  console.log(loading)
-
   return (
     <SwitchPrimitive.Root
       data-slot="switch"

--- a/web-app/src/components/ui/switch.tsx
+++ b/web-app/src/components/ui/switch.tsx
@@ -2,20 +2,29 @@ import * as React from 'react'
 import * as SwitchPrimitive from '@radix-ui/react-switch'
 
 import { cn } from '@/lib/utils'
+import { IconLoader2 } from '@tabler/icons-react'
 
-function Switch({
-  className,
-  ...props
-}: React.ComponentProps<typeof SwitchPrimitive.Root>) {
+type SwitchProps = React.ComponentProps<typeof SwitchPrimitive.Root> & {
+  loading?: boolean
+}
+function Switch({ loading, className, ...props }: SwitchProps) {
+  console.log(loading)
+
   return (
     <SwitchPrimitive.Root
       data-slot="switch"
       className={cn(
-        'peer cursor-pointer data-[state=checked]:bg-accent data-[state=unchecked]:bg-main-view-fg/20 focus-visible:border-none inline-flex h-[18px] w-8.5 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50',
+        'relative peer cursor-pointer data-[state=checked]:bg-accent data-[state=unchecked]:bg-main-view-fg/20 focus-visible:border-none inline-flex h-[18px] w-8.5 shrink-0 items-center rounded-full border border-transparent shadow-xs transition-all outline-none focus-visible:ring-0 disabled:cursor-not-allowed disabled:opacity-50 transition-all',
+        loading && 'w-4.5 pointer-events-none',
         className
       )}
       {...props}
     >
+      {loading && (
+        <div className="absolute inset-0 flex items-center justify-center z-10 size-3.5 top-1/2 -translate-y-1/2 left-1/2 -translate-x-1/2">
+          <IconLoader2 className="animate-spin text-main-view-fg/50" />
+        </div>
+      )}
       <SwitchPrimitive.Thumb
         data-slot="switch-thumb"
         className={cn(

--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -216,7 +216,6 @@ const DropdownModelProvider = ({
     // Add the filtered items to their respective groups
     filteredItems.forEach((item) => {
       const providerKey = item.provider.provider
-      console.log(providerKey, 'providerKey')
       if (!groups[providerKey]) {
         groups[providerKey] = []
       }

--- a/web-app/src/hooks/useMCPServers.ts
+++ b/web-app/src/hooks/useMCPServers.ts
@@ -19,6 +19,7 @@ type MCPServerStoreState = {
   mcpServers: MCPServers
   loading: boolean
   deletedServerKeys: string[]
+  getServerConfig: (key: string) => MCPServerConfig | undefined
   setLeftPanel: (value: boolean) => void
   addServer: (key: string, config: MCPServerConfig) => void
   editServer: (key: string, config: MCPServerConfig) => void
@@ -34,7 +35,11 @@ export const useMCPServers = create<MCPServerStoreState>()((set, get) => ({
   loading: false,
   deletedServerKeys: [],
   setLeftPanel: (value) => set({ open: value }),
-
+  getServerConfig: (key) => {
+    const mcpServers = get().mcpServers
+    // Return the server configuration if it exists, otherwise return undefined
+    return mcpServers[key] ? mcpServers[key] : undefined
+  },
   // Add a new MCP server or update if the key already exists
   addServer: (key, config) =>
     set((state) => {

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -56,6 +56,9 @@ function MCPServers() {
     MCPServerConfig | Record<string, MCPServerConfig> | undefined
   >(undefined)
   const [connectedServers, setConnectedServers] = useState<string[]>([])
+  const [loadingServers, setLoadingServers] = useState<{
+    [key: string]: boolean
+  }>({})
 
   const handleOpenDialog = (serverKey?: string) => {
     if (serverKey) {
@@ -142,8 +145,10 @@ function MCPServers() {
   }
 
   const toggleServer = (serverKey: string, active: boolean) => {
-    if (serverKey)
-      if (active)
+    if (serverKey) {
+      setLoadingServers((prev) => ({ ...prev, [serverKey]: true }))
+
+      if (active) {
         invoke('activate_mcp_server', {
           name: serverKey,
           config: {
@@ -169,7 +174,10 @@ function MCPServers() {
                 'Please check the parameters according to the tutorial.',
             })
           })
-      else {
+          .finally(() => {
+            setLoadingServers((prev) => ({ ...prev, [serverKey]: false }))
+          })
+      } else {
         editServer(serverKey, {
           ...(mcpServers[serverKey] as MCPServerConfig),
           active,
@@ -181,8 +189,10 @@ function MCPServers() {
           })
           .finally(() => {
             getConnectedServers().then(setConnectedServers)
+            setLoadingServers((prev) => ({ ...prev, [serverKey]: false }))
           })
       }
+    }
   }
 
   useEffect(() => {
@@ -335,6 +345,7 @@ function MCPServers() {
                         <div className="ml-2">
                           <Switch
                             checked={config.active === false ? false : true}
+                            loading={!!loadingServers[key]}
                             onCheckedChange={(checked) =>
                               toggleServer(key, checked)
                             }


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a loading state feature for the `Switch` component and integrates it into the server toggle functionality in the MCP Servers settings page. The changes enhance user feedback during server activation or deactivation by displaying a loading spinner on the toggle switch.

### Enhancements to the `Switch` component:

* Added a `loading` prop to the `Switch` component, which displays a spinner when the switch is in a loading state. The spinner is styled using the `IconLoader2` component and conditional class names. (`web-app/src/components/ui/switch.tsx`, [web-app/src/components/ui/switch.tsxR5-R27](diffhunk://#diff-c52343474e2a1ee7fc46bda8de540434bb7904774d24c590d11357df169167ddR5-R27))

### Updates to MCP Servers functionality:

* Introduced a `loadingServers` state to track the loading status of each server during activation or deactivation. (`web-app/src/routes/settings/mcp-servers.tsx`, [web-app/src/routes/settings/mcp-servers.tsxR59-R61](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78R59-R61))
* Updated the `toggleServer` function to set the appropriate loading state when activating or deactivating a server. The loading state is reset after the operation completes, regardless of success or failure. (`web-app/src/routes/settings/mcp-servers.tsx`, [[1]](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78L145-R151) [[2]](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78L172-R180) [[3]](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78R192-R196)
* Passed the `loading` prop to the `Switch` component in the MCP Servers list, binding it to the `loadingServers` state for the corresponding server. (`web-app/src/routes/settings/mcp-servers.tsx`, [web-app/src/routes/settings/mcp-servers.tsxR348](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78R348))

## Fixes Issues


https://github.com/user-attachments/assets/d75c1c1d-f75b-4a7b-95c6-1147a31c78f5


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add loading state to `Switch` component and integrate it into MCP Servers settings for better user feedback during server toggling.
> 
>   - **Switch Component**:
>     - Added `loading` prop to display a spinner using `IconLoader2` when in loading state.
>   - **MCP Servers**:
>     - Added `loadingServers` state to track server loading status in `mcp-servers.tsx`.
>     - Updated `toggleServer` to manage loading state during server activation/deactivation.
>     - Passed `loading` prop to `Switch` in MCP Servers list, linked to `loadingServers` state.
>   - **Misc**:
>     - Removed console log in `DropdownModelProvider.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for c060b86d6aa185a3f1703e2d048185fc7f7810a2. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->