### PR TITLE
feat(local-api-server): add button to open API documentation and improve layout

### DIFF
--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -2,9 +2,13 @@
   "$schema": "../gen/schemas/desktop-schema.json",
   "identifier": "default",
   "description": "enables the default permissions",
-  "windows": ["main"],
+  "windows": [
+    "main"
+  ],
   "remote": {
-    "urls": ["http://*"]
+    "urls": [
+      "http://*"
+    ]
   },
   "permissions": [
     "core:default",
@@ -21,6 +25,7 @@
     "dialog:default",
     "deep-link:default",
     "core:webview:allow-create-webview-window",
+    "opener:allow-open-url",
     {
       "identifier": "http:default",
       "allow": [
@@ -70,6 +75,24 @@
           ],
           "name": "binaries/cortex-server",
           "sidecar": true
+        }
+      ]
+    },
+    {
+      "identifier": "opener:allow-open-url",
+      "description": "opens the default permissions for the core module",
+      "windows": [
+        "*"
+      ],
+      "allow": [
+        {
+          "url": "https://*"
+        },
+        {
+          "url": "http://127.0.0.1:*"
+        },
+        {
+          "url": "http://0.0.0.0:*"
         }
       ]
     },

--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -14,10 +14,11 @@ import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { WebviewWindow } from '@tauri-apps/api/webviewWindow'
 import { useAppState } from '@/hooks/useAppState'
 import { windowKey } from '@/constants/windows'
-import { IconLogs } from '@tabler/icons-react'
+import { IconLogs, IconBook } from '@tabler/icons-react'
 import { cn } from '@/lib/utils'
 import { ApiKeyInput } from '@/containers/ApiKeyInput'
 import { useState } from 'react'
+import { openUrl } from '@tauri-apps/plugin-opener'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.local_api_server as any)({
@@ -130,6 +131,16 @@ function LocalAPIServer() {
     }
   }
 
+  const handleOpenAPIDocs = async () => {
+    const docsUrl = `http://${serverHost}:${serverPort}`
+    try {
+      console.log('Opening API documentation at:', docsUrl)
+      await openUrl(docsUrl)
+    } catch (error) {
+      console.error('Failed to open API documentation:', error)
+    }
+  }
+
   const isServerRunning = serverStatus === 'running'
 
   return (
@@ -151,13 +162,26 @@ function LocalAPIServer() {
                       Start an OpenAI-compatible local HTTP server.
                     </p>
                   </div>
-                  <Button
-                    onClick={toggleAPIServer}
-                    variant={isServerRunning ? 'destructive' : 'default'}
-                    size="sm"
-                  >
-                    {`${isServerRunning ? 'Stop' : 'Start'}`} Server
-                  </Button>
+                  <div className="flex items-center gap-2">
+                    {isServerRunning && (
+                      <Button
+                        onClick={handleOpenAPIDocs}
+                        variant="default"
+                        size="sm"
+                        title="API Documentation"
+                      >
+                        <IconBook size={18} className="text-main-view-fg/50" />
+                        <span>Open Docs</span>
+                      </Button>
+                    )}
+                    <Button
+                      onClick={toggleAPIServer}
+                      variant={isServerRunning ? 'destructive' : 'default'}
+                      size="sm"
+                    >
+                      {`${isServerRunning ? 'Stop' : 'Start'}`} Server
+                    </Button>
+                  </div>
                 </div>
               }
             >


### PR DESCRIPTION

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds button to open API documentation in `local-api-server.tsx` and updates permissions in `default.json`.
> 
>   - **Behavior**:
>     - Adds `handleOpenAPIDocs` function in `local-api-server.tsx` to open API documentation using `openUrl`.
>     - Adds "Open Docs" button in `LocalAPIServer` component, visible only when server is running.
>   - **Permissions**:
>     - Updates `default.json` to include `opener:allow-open-url` permission for URLs `https://*`, `http://127.0.0.1:*`, and `http://0.0.0.0:*`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6f030f720ac4b50dd8fcfdd2d4a6afa60fdcf528. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->