### PR TITLE
fix: tool call block width code

### DIFF
--- a/web-app/src/containers/ToolCallBlock.tsx
+++ b/web-app/src/containers/ToolCallBlock.tsx
@@ -199,7 +199,7 @@ const ToolCallBlock = ({ id, name, result, loading, args }: Props) => {
             isExpanded ? '' : 'max-h-0 overflow-hidden'
           )}
         >
-          <div className="mt-2 text-main-view-fg/60 max-w-[89%] overflow-hidden">
+          <div className="mt-2 text-main-view-fg/60 overflow-hidden">
             {args && Object.keys(args).length > 3 && (
               <>
                 <p className="mb-3">Arguments:</p>


### PR DESCRIPTION
## Issue
![Screenshot 2025-06-11 at 23 52 15](https://github.com/user-attachments/assets/d1125eec-78cc-4132-bce9-800f7fb12ef9)


## Describe Your Changes
This pull request includes a small change to the `ToolCallBlock` component in `web-app/src/containers/ToolCallBlock.tsx`. The change removes the `max-w-[89%]` class from a `div` element to allow the content to use the full width.

## Fixes Issues
![Screenshot 2025-06-11 at 23 53 27](https://github.com/user-attachments/assets/fff2c70a-f033-4ce0-80d0-d26f4ba66a14)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
