### PR TITLE
fix: set timeout windows download recommend model

### DIFF
--- a/web-app/src/routes/hub.tsx
+++ b/web-app/src/routes/hub.tsx
@@ -290,8 +290,9 @@ function Hub() {
         isRecommendedModel(model.metadata?.id)
       )
       if (recommendedModel && recommendedModel.models[0]?.id) {
-        downloadModel(recommendedModel.models[0].id)
-
+        setTimeout(() => {
+          downloadModel(recommendedModel.models[0].id)
+        }, 100)
         return
       }
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a minor change to the `Hub` function in the `web-app/src/routes/hub.tsx` file. The change adds a `setTimeout` with a delay of 100 milliseconds before calling the `downloadModel` function, ensuring smoother execution timing.

(Change reference: [web-app/src/routes/hub.tsxR293-R295](diffhunk://#diff-7f7702064072b91f4194cb9a5bc9d882860c9435f64e6de050be591d397874e3R293-R295))

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a 100ms `setTimeout` before `downloadModel` call in `Hub` function in `hub.tsx` for smoother execution timing.
> 
>   - **Behavior**:
>     - Adds `setTimeout` with 100ms delay before `downloadModel` call in `Hub` function in `hub.tsx` to ensure smoother execution timing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for bce163a92b45bf42923cac2cb0d627c36d480ab0. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->