### PR TITLE
chore: fix wrong classname color text

### DIFF
--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -219,7 +219,7 @@ export function DownloadManagement() {
                 <p className="text-left-panel-fg/80 font-medium">Downloads</p>
                 <div className="mt-2 flex items-center justify-between space-x-2">
                   <Progress value={overallProgress * 100} />
-                  <span className="text-xs font-medium text-main-view-fg/80 shrink-0">
+                  <span className="text-xs font-medium text-left-panel-fg/80 shrink-0">
                     {Math.round(overallProgress * 100)}%
                   </span>
                 </div>
@@ -228,7 +228,7 @@ export function DownloadManagement() {
               <div className="fixed bottom-4 left-4 z-50 size-10 bg-main-view border-2 border-main-view-fg/10 rounded-full shadow-md cursor-pointer flex items-center justify-center">
                 <div className="relative">
                   <IconDownload
-                    className="text-main-view-fg/50 -mt-1"
+                    className="text-left-panel-fg/50 -mt-1"
                     size={20}
                   />
                   <div className="bg-primary font-bold size-5 rounded-full absolute -top-4 -right-4 flex items-center justify-center text-primary-fg">

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -517,12 +517,12 @@ function ProviderDetail() {
                     })
                   ) : (
                     <div className="-mt-2">
-                      <div className="flex items-center gap-2 text-left-panel-fg/80">
+                      <div className="flex items-center gap-2 text-main-view-fg/80">
                         <h6 className="font-medium text-base">
                           No model found
                         </h6>
                       </div>
-                      <p className="text-left-panel-fg/60 mt-1 text-xs leading-relaxed">
+                      <p className="text-main-view-fg/70 mt-1 text-xs leading-relaxed">
                         Available models will be listed here. If you don't have
                         any models yet, visit the&nbsp;
                         <Link to={route.hub}>Hub</Link>


### PR DESCRIPTION
## Issue
https://discord.com/channels/1107178041848909847/1382444209780424734/1382444209780424734

![image](https://github.com/user-attachments/assets/f206c691-c40e-43bc-90ed-391ec0071abc)
![image](https://github.com/user-attachments/assets/96c63b61-e855-451d-861a-30ba7ae4fad0)


## Describe Your Changes

This pull request updates the color scheme in several components of the `web-app` to improve consistency between the `left-panel` and `main-view`. The changes primarily involve swapping color classes to align with the intended design.

### Color Scheme Updates:

* [`web-app/src/containers/DownloadManegement.tsx`](diffhunk://#diff-3f20b1fc2c81e2b1ad736c8382f24d27627a894a8f7ddd6483a5df7acf3d494dL222-R222): Updated the progress percentage text and the download icon color from `text-main-view-fg` to `text-left-panel-fg` for better alignment with the `left-panel` color scheme. [[1]](diffhunk://#diff-3f20b1fc2c81e2b1ad736c8382f24d27627a894a8f7ddd6483a5df7acf3d494dL222-R222) [[2]](diffhunk://#diff-3f20b1fc2c81e2b1ad736c8382f24d27627a894a8f7ddd6483a5df7acf3d494dL231-R231)

* [`web-app/src/routes/settings/providers/$providerName.tsx`](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5L520-R525): Changed the color of the "No model found" message and its description text from `text-left-panel-fg` to `text-main-view-fg` to match the `main-view` design.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
