### PR TITLE
fix: default settings should leave empty

### DIFF
--- a/extensions/inference-cortex-extension/resources/default_settings.json
+++ b/extensions/inference-cortex-extension/resources/default_settings.json
@@ -14,7 +14,7 @@
     "description": "Allows processing prompts in parallel with text generation, which usually improves performance.",
     "controllerType": "checkbox",
     "controllerProps": {
-      "value": true
+      "value": ""
     }
   },
   {
@@ -23,7 +23,7 @@
     "description": "Number of prompts that can be processed simultaneously by the model.",
     "controllerType": "input",
     "controllerProps": {
-      "value": "1",
+      "value": "",
       "placeholder": "1",
       "type": "number",
       "textAlign": "right"
@@ -35,7 +35,7 @@
     "description": "Number of CPU cores used for model processing when running without GPU.",
     "controllerType": "input",
     "controllerProps": {
-      "value": "-1",
+      "value": "",
       "placeholder": "Number of CPU threads",
       "type": "number",
       "textAlign": "right"
@@ -47,7 +47,7 @@
     "description": "Number of threads for batch and prompt processing (default: same as Threads).",
     "controllerType": "input",
     "controllerProps": {
-      "value": -1,
+      "value": "",
       "placeholder": "-1 (same as Threads)",
       "type": "number"
     }
@@ -58,7 +58,7 @@
     "description": "Optimizes memory usage and speeds up model inference using an efficient attention implementation.",
     "controllerType": "checkbox",
     "controllerProps": {
-      "value": false
+      "value": ""
     }
   },
   {
@@ -67,7 +67,7 @@
     "description": "Stores recent prompts and responses to improve speed when similar questions are asked.",
     "controllerType": "checkbox",
     "controllerProps": {
-      "value": true
+      "value": ""
     }
   },
   {

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -8,7 +8,6 @@
 
 import {
   Model,
-  executeOnMain,
   EngineEvent,
   LocalOAIEngine,
   extractModelLoadParams,
@@ -128,7 +127,11 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
     )
     this.flash_attn = await this.getSetting<boolean>(Settings.flash_attn, true)
     this.use_mmap = await this.getSetting<boolean>(Settings.use_mmap, true)
-    this.cache_type = await this.getSetting<string>(Settings.cache_type, 'f16')
+    if (this.caching_enabled)
+      this.cache_type = await this.getSetting<string>(
+        Settings.cache_type,
+        'f16'
+      )
     this.auto_unload_models = await this.getSetting<boolean>(
       Settings.auto_unload_models,
       true

--- a/web-app/src/lib/predefined.ts
+++ b/web-app/src/lib/predefined.ts
@@ -18,20 +18,20 @@ export const modelSettings = {
     controller_type: 'input',
     controller_props: {
       value: 100,
-      placeholder: '-1',
+      placeholder: '100',
       type: 'number',
     },
   },
 
   temperature: {
-    key: 'temp',
+    key: 'temperature',
     title: 'Temperature',
     description:
       'Temperature for sampling (higher = more random). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 0.8,
-      placeholder: '0.8',
+      value: '',
+      placeholder: '0.6',
       type: 'number',
       min: 0,
       step: 0.01,
@@ -44,7 +44,7 @@ export const modelSettings = {
       'Top-K sampling (0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 40,
+      value: '',
       placeholder: '40',
       type: 'number',
     },
@@ -56,7 +56,7 @@ export const modelSettings = {
       'Top-P sampling (1.0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 0.9,
+      value: '',
       placeholder: '0.9',
       type: 'number',
     },
@@ -68,7 +68,7 @@ export const modelSettings = {
       'Min-P sampling (0.0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 0.1,
+      value: '',
       placeholder: '0.1',
       type: 'number',
     },
@@ -80,7 +80,7 @@ export const modelSettings = {
       'Number of tokens to consider for repeat penalty (0 = disabled, -1 = ctx_size). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 64,
+      value: '',
       placeholder: '64',
       type: 'number',
     },
@@ -92,7 +92,7 @@ export const modelSettings = {
       'Penalize repeating token sequences (1.0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 1.0,
+      value: '',
       placeholder: '1.0',
       type: 'number',
     },
@@ -104,7 +104,7 @@ export const modelSettings = {
       'Repeat alpha presence penalty (0.0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 0.0,
+      value: '',
       placeholder: '0.0',
       type: 'number',
     },
@@ -116,7 +116,7 @@ export const modelSettings = {
       'Repeat alpha frequency penalty (0.0 = disabled). This is the default setting on load and can be overridden by the assistant settings.',
     controller_type: 'input',
     controller_props: {
-      value: 0.0,
+      value: '',
       placeholder: '0.0',
       type: 'number',
     },

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -129,12 +129,20 @@ export const getProviders = async (): Promise<ModelProvider[]> => {
         provider: providerName,
         settings: Object.values(modelSettings).reduce(
           (acc, setting) => {
-            let value = model[
-              setting.key as keyof typeof model
-            ] as keyof typeof setting.controller_props.value
+            let value = setting.controller_props.value
             if (setting.key === 'ctx_len') {
-              // @ts-expect-error dynamic type
-              value = 4096 // Default context length for Llama.cpp models
+              value = 8192 // Default context length for Llama.cpp models
+            }
+            // Set temperature to 0.6 for DefaultToolUseSupportedModels
+            if (
+              Object.values(DefaultToolUseSupportedModels).some((v) =>
+                model.id.toLowerCase().includes(v.toLowerCase())
+              )
+            ) {
+              if (setting.key === 'temperature') value = 0.6 // Default temperature for tool-supported models
+              if (setting.key === 'top_k') value = 20 // Default top_k for tool-supported models
+              if (setting.key === 'top_p') value = 0.8 // Default top_p for tool-supported models
+              if (setting.key === 'min_p') value = 0 // Default min_p for tool-supported models
             }
             acc[setting.key] = {
               ...setting,


### PR DESCRIPTION
## Describe Your Changes

Default settings should all blank and not send over via model load request until users change it.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
