### PR TITLE
fix: replace close think tag from text segment

### DIFF
--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -311,7 +311,10 @@ export const ThreadContent = memo(
               />
             )}
 
-            <RenderMarkdown content={textSegment} components={linkComponents} />
+            <RenderMarkdown
+              content={textSegment.replace('</think>', '')}
+              components={linkComponents}
+            />
 
             {isToolCalls && item.metadata?.tool_calls ? (
               <>


### PR DESCRIPTION
## Describe Your Changes

This pull request modifies the `ThreadContent` component in `web-app/src/containers/ThreadContent.tsx` to clean up the `textSegment` content by removing the `'</think>'` string before rendering markdown.

* **Content cleanup in `ThreadContent`**:
  - Updated the `RenderMarkdown` component to preprocess the `textSegment` by replacing `'</think>'` with an empty string, ensuring cleaner rendering of markdown content. (`[web-app/src/containers/ThreadContent.tsxL314-R317](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L314-R317)`)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `'</think>'` from `textSegment` in `ThreadContent.tsx` for cleaner markdown rendering.
> 
>   - **Content cleanup in `ThreadContent.tsx`**:
>     - Updated `RenderMarkdown` to preprocess `textSegment` by removing `'</think>'` for cleaner markdown rendering.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e8816294e613457d8e215d8b0ace8d0445aafdfd. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->