### PR TITLE
fix: recheck tools approval state

### DIFF
--- a/web-app/src/hooks/useToolApproval.ts
+++ b/web-app/src/hooks/useToolApproval.ts
@@ -54,6 +54,13 @@ export const useToolApproval = create<ToolApprovalState>()(
 
       showApprovalModal: (toolName: string, threadId: string) => {
         return new Promise<boolean>((resolve) => {
+          // Check if tool is already approved for this thread
+          const state = get()
+          if (state.isToolApproved(threadId, toolName)) {
+            resolve(true)
+            return
+          }
+
           set({
             isModalOpen: true,
             modalProps: {


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a small enhancement to the `useToolApproval` hook in `web-app/src/hooks/useToolApproval.ts`. The change ensures that the tool approval modal is not shown if the tool is already approved for the given thread.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances `showApprovalModal` in `useToolApproval.ts` to skip modal if tool is already approved for a thread.
> 
>   - **Behavior**:
>     - In `useToolApproval.ts`, `showApprovalModal` now checks if a tool is already approved for a thread using `isToolApproved` before opening the modal.
>     - If the tool is approved, resolves the promise with `true` immediately, skipping modal display.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for cf53a04224d36eb7afed661805edee46f7449a10. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->