### PR TITLE
✨enhancement: add setting chat width container

### DIFF
--- a/web-app/src/components/ui/skeleton.tsx
+++ b/web-app/src/components/ui/skeleton.tsx
@@ -1,0 +1,13 @@
+import { cn } from '@/lib/utils'
+
+function Skeleton({ className, ...props }: React.ComponentProps<'div'>) {
+  return (
+    <div
+      data-slot="skeleton"
+      className={cn('bg-main-view-fg/10', className)}
+      {...props}
+    />
+  )
+}
+
+export { Skeleton }

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -21,7 +21,6 @@ import {
   IconTool,
   IconCodeCircle2,
   IconPlayerStopFilled,
-  IconBrandSpeedtest,
   IconX,
 } from '@tabler/icons-react'
 import { useTranslation } from 'react-i18next'
@@ -45,12 +44,7 @@ type ChatInputProps = {
   initialMessage?: boolean
 }
 
-const ChatInput = ({
-  model,
-  className,
-  showSpeedToken = true,
-  initialMessage,
-}: ChatInputProps) => {
+const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [isFocused, setIsFocused] = useState(false)
   const [rows, setRows] = useState(1)
@@ -60,7 +54,7 @@ const ChatInput = ({
   const { currentThreadId } = useThreads()
   const { t } = useTranslation()
   const { spellCheckChatInput } = useGeneralSetting()
-  const { tokenSpeed } = useAppState()
+
   const { showModal, PromiseModal: OutOfContextModal } =
     useOutOfContextPromiseModal()
   const maxRows = 10
@@ -559,15 +553,6 @@ const ChatInput = ({
                   </TooltipProvider>
                 )}
               </div>
-
-              {showSpeedToken && (
-                <div className="flex items-center gap-1 text-main-view-fg/60 text-xs">
-                  <IconBrandSpeedtest size={18} />
-                  <span>
-                    {Math.round(tokenSpeed?.tokenSpeed ?? 0)} tokens/sec
-                  </span>
-                </div>
-              )}
             </div>
 
             {streamingContent ? (

--- a/web-app/src/containers/ChatWidthSwitcher.tsx
+++ b/web-app/src/containers/ChatWidthSwitcher.tsx
@@ -1,0 +1,61 @@
+import { Skeleton } from '@/components/ui/skeleton'
+import { useAppearance } from '@/hooks/useAppearance'
+import { cn } from '@/lib/utils'
+import { IconCircleCheckFilled } from '@tabler/icons-react'
+
+export function ChatWidthSwitcher() {
+  const { chatWidth, setChatWidth } = useAppearance()
+
+  return (
+    <div className="flex gap-4">
+      <div
+        className={cn(
+          'w-full overflow-hidden border border-main-view-fg/10 rounded-md my-2 pb-2 cursor-pointer',
+          chatWidth === 'compact' && 'border-accent'
+        )}
+        onClick={() => setChatWidth('compact')}
+      >
+        <div className="flex items-center justify-between px-4 py-2 bg-main-view-fg/10">
+          <span className="font-medium text-xs font-sans">Compact Width</span>
+          {chatWidth === 'compact' && (
+            <IconCircleCheckFilled className="size-4 text-accent" />
+          )}
+        </div>
+        <div className="overflow-auto p-2">
+          <div className="flex flex-col px-10 gap-2 mt-2">
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <div className="bg-main-view-fg/10 h-8 px-4 w-full flex-shrink-0 border-none resize-none outline-0 rounded-2xl flex items-center">
+              <span className="text-main-view-fg/50">Ask me anything...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+      <div
+        className={cn(
+          'w-full overflow-hidden border border-main-view-fg/10 rounded-md my-2 pb-2 cursor-pointer',
+          chatWidth === 'full' && 'border-accent'
+        )}
+        onClick={() => setChatWidth('full')}
+      >
+        <div className="flex items-center justify-between px-4 py-2 bg-main-view-fg/10">
+          <span className="font-medium text-xs font-sans">Full Width</span>
+          {chatWidth === 'full' && (
+            <IconCircleCheckFilled className="size-4 text-accent" />
+          )}
+        </div>
+        <div className="overflow-auto p-2">
+          <div className="flex flex-col gap-2 mt-2">
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <Skeleton className="h-2 w-full rounded-full" />
+            <div className="bg-main-view-fg/10 h-8 px-4 w-full flex-shrink-0 border-none resize-none outline-0 rounded-2xl flex items-center">
+              <span className="text-main-view-fg/50">Ask me anything...</span>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -359,97 +359,98 @@ export const ThreadContent = memo(
 
             {!isToolCalls && (
               <div className="flex items-center gap-2 mt-2 text-main-view-fg/60 text-xs">
-                <div
-                  className={cn(
-                    'flex items-center gap-2',
-                    item.isLastMessage &&
-                    streamingContent &&
-                    'opacity-0 visibility-hidden pointer-events-none'
-                  )}
-                >
-                  <CopyButton text={item.content?.[0]?.text.value || ''} />
-                  <Tooltip>
-                    <TooltipTrigger asChild>
-                      <button
-                        className="flex items-center gap-1 hover:text-accent transition-colors cursor-pointer group relative"
-                        onClick={() => {
-                          removeMessage()
-                        }}
-                      >
-                        <IconTrash size={16} />
-                      </button>
-                    </TooltipTrigger>
-                    <TooltipContent>
-                      <p>Delete</p>
-                    </TooltipContent>
-                  </Tooltip>
-                  <Dialog>
-                    <DialogTrigger>
-                      <Tooltip>
-                        <TooltipTrigger asChild>
-                          <div className="outline-0 focus:outline-0 flex items-center gap-1 hover:text-accent transition-colors cursor-pointer group relative">
-                            <IconInfoCircle size={16} />
-                          </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                          <p>Metadata</p>
-                        </TooltipContent>
-                      </Tooltip>
-                    </DialogTrigger>
-                    <DialogContent>
-                      <DialogHeader>
-                        <DialogTitle>Message Metadata</DialogTitle>
-                        <div className="space-y-2">
-                          <div className="border border-main-view-fg/10 rounded-md overflow-hidden">
-                            <CodeEditor
-                              value={JSON.stringify(
-                                item.metadata || {},
-                                null,
-                                2
-                              )}
-                              language="json"
-                              readOnly
-                              style={{
-                                fontFamily: 'ui-monospace',
-                                backgroundColor: 'transparent',
-                                height: '100%',
-                              }}
-                              className="w-full h-full !text-sm"
-                            />
-                          </div>
-                        </div>
-                        <DialogFooter className="mt-2 flex items-center">
-                          <DialogClose asChild>
-                            <Button
-                              variant="link"
-                              size="sm"
-                              className="hover:no-underline"
-                            >
-                              Close
-                            </Button>
-                          </DialogClose>
-                        </DialogFooter>
-                      </DialogHeader>
-                    </DialogContent>
-                  </Dialog>
-
-                  {item.isLastMessage && (
+                <div className={cn('flex items-center gap-2')}>
+                  <div
+                    className={cn(
+                      'flex items-center gap-2',
+                      item.isLastMessage && streamingContent && 'hidden'
+                    )}
+                  >
+                    <CopyButton text={item.content?.[0]?.text.value || ''} />
                     <Tooltip>
                       <TooltipTrigger asChild>
                         <button
                           className="flex items-center gap-1 hover:text-accent transition-colors cursor-pointer group relative"
-                          onClick={regenerate}
+                          onClick={() => {
+                            removeMessage()
+                          }}
                         >
-                          <IconRefresh size={16} />
+                          <IconTrash size={16} />
                         </button>
                       </TooltipTrigger>
                       <TooltipContent>
-                        <p>Regenerate</p>
+                        <p>Delete</p>
                       </TooltipContent>
                     </Tooltip>
-                  )}
+                    <Dialog>
+                      <DialogTrigger>
+                        <Tooltip>
+                          <TooltipTrigger asChild>
+                            <div className="outline-0 focus:outline-0 flex items-center gap-1 hover:text-accent transition-colors cursor-pointer group relative">
+                              <IconInfoCircle size={16} />
+                            </div>
+                          </TooltipTrigger>
+                          <TooltipContent>
+                            <p>Metadata</p>
+                          </TooltipContent>
+                        </Tooltip>
+                      </DialogTrigger>
+                      <DialogContent>
+                        <DialogHeader>
+                          <DialogTitle>Message Metadata</DialogTitle>
+                          <div className="space-y-2">
+                            <div className="border border-main-view-fg/10 rounded-md overflow-hidden">
+                              <CodeEditor
+                                value={JSON.stringify(
+                                  item.metadata || {},
+                                  null,
+                                  2
+                                )}
+                                language="json"
+                                readOnly
+                                style={{
+                                  fontFamily: 'ui-monospace',
+                                  backgroundColor: 'transparent',
+                                  height: '100%',
+                                }}
+                                className="w-full h-full !text-sm"
+                              />
+                            </div>
+                          </div>
+                          <DialogFooter className="mt-2 flex items-center">
+                            <DialogClose asChild>
+                              <Button
+                                variant="link"
+                                size="sm"
+                                className="hover:no-underline"
+                              >
+                                Close
+                              </Button>
+                            </DialogClose>
+                          </DialogFooter>
+                        </DialogHeader>
+                      </DialogContent>
+                    </Dialog>
+
+                    {item.isLastMessage && (
+                      <Tooltip>
+                        <TooltipTrigger asChild>
+                          <button
+                            className="flex items-center gap-1 hover:text-accent transition-colors cursor-pointer group relative"
+                            onClick={regenerate}
+                          >
+                            <IconRefresh size={16} />
+                          </button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                          <p>Regenerate</p>
+                        </TooltipContent>
+                      </Tooltip>
+                    )}
+                  </div>
 
                   <TokenSpeedIndicator
+                    streaming={Boolean(item.isLastMessage && streamingContent)}
                     metadata={item.metadata}
                   />
                 </div>

--- a/web-app/src/containers/TokenSpeedIndicator.tsx
+++ b/web-app/src/containers/TokenSpeedIndicator.tsx
@@ -1,19 +1,31 @@
-import { IconBrandSpeedtest } from '@tabler/icons-react'
+import { useAppState } from '@/hooks/useAppState'
+import { Gauge } from 'lucide-react'
 
 interface TokenSpeedIndicatorProps {
   metadata?: Record<string, unknown>
+  streaming?: boolean
 }
 
 export const TokenSpeedIndicator = ({
-  metadata
+  metadata,
+  streaming,
 }: TokenSpeedIndicatorProps) => {
-  const persistedTokenSpeed = (metadata?.tokenSpeed as { tokenSpeed: number })?.tokenSpeed
+  const { tokenSpeed } = useAppState()
+  const persistedTokenSpeed = (metadata?.tokenSpeed as { tokenSpeed: number })
+    ?.tokenSpeed
+
+  console.log(streaming, 'streaming')
+  console.log(tokenSpeed, 'tokenSpeed')
 
   return (
     <div className="flex items-center gap-1 text-main-view-fg/60 text-xs">
-      <IconBrandSpeedtest size={16} />
+      <Gauge size={16} />
+
       <span>
-        {Math.round(persistedTokenSpeed)} tokens/sec
+        {Math.round(
+          streaming ? Number(tokenSpeed?.tokenSpeed) : persistedTokenSpeed
+        )}
+        &nbsp;tokens/sec
       </span>
     </div>
   )

--- a/web-app/src/hooks/useAppearance.ts
+++ b/web-app/src/hooks/useAppearance.ts
@@ -6,8 +6,10 @@ import { rgb, oklch, formatCss } from 'culori'
 import { useTheme } from './useTheme'
 
 export type FontSize = '14px' | '15px' | '16px' | '18px'
+export type ChatWidth = 'full' | 'compact'
 
 interface AppearanceState {
+  chatWidth: ChatWidth
   fontSize: FontSize
   appBgColor: RgbaColor
   appMainViewBgColor: RgbaColor
@@ -19,6 +21,7 @@ interface AppearanceState {
   appAccentTextColor: string
   appDestructiveTextColor: string
   appLeftPanelTextColor: string
+  setChatWidth: (size: ChatWidth) => void
   setFontSize: (size: FontSize) => void
   setAppBgColor: (color: RgbaColor) => void
   setAppMainViewBgColor: (color: RgbaColor) => void
@@ -129,6 +132,7 @@ export const useAppearance = create<AppearanceState>()(
   persist(
     (set) => {
       return {
+        chatWidth: 'compact',
         fontSize: defaultFontSize,
         appBgColor: defaultAppBgColor,
         appMainViewBgColor: defaultAppMainViewBgColor,
@@ -268,6 +272,10 @@ export const useAppearance = create<AppearanceState>()(
             appDestructiveBgColor: defaultDestructive,
             appDestructiveTextColor: '#FFF',
           })
+        },
+
+        setChatWidth: (value: ChatWidth) => {
+          set({ chatWidth: value })
         },
 
         setFontSize: (size: FontSize) => {

--- a/web-app/src/routes/settings/appearance.tsx
+++ b/web-app/src/routes/settings/appearance.tsx
@@ -18,6 +18,7 @@ import CodeBlockStyleSwitcher from '@/containers/CodeBlockStyleSwitcher'
 import { LineNumbersSwitcher } from '@/containers/LineNumbersSwitcher'
 import { CodeBlockExample } from '@/containers/CodeBlockExample'
 import { toast } from 'sonner'
+import { ChatWidthSwitcher } from '@/containers/ChatWidthSwitcher'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.appearance as any)({
@@ -96,6 +97,15 @@ function Appareances() {
                   </Button>
                 }
               />
+            </Card>
+
+            {/* Chat Message */}
+            <Card>
+              <CardItem
+                title="Chat Width"
+                description="Choose the width of the chat area to customize your conversation view."
+              />
+              <ChatWidthSwitcher />
             </Card>
 
             {/* Codeblock */}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -35,7 +35,7 @@ function ThreadDetail() {
   const { setCurrentAssistant, assistants } = useAssistant()
   const { setMessages } = useMessages()
   const { streamingContent } = useAppState()
-  const { appMainViewBgColor } = useAppearance()
+  const { appMainViewBgColor, chatWidth } = useAppearance()
 
   const { messages } = useMessages(
     useShallow((state) => ({
@@ -213,7 +213,12 @@ function ThreadDetail() {
             'flex flex-col h-full w-full overflow-auto px-4 pt-4 pb-3'
           )}
         >
-          <div className="w-4/6 mx-auto flex max-w-full flex-col grow">
+          <div
+            className={cn(
+              'w-4/6 mx-auto flex max-w-full flex-col grow',
+              chatWidth === 'compact' ? 'w-4/6' : 'w-full'
+            )}
+          >
             {messages &&
               messages.map((item, index) => {
                 // Only pass isLastMessage to the last message in the array
@@ -247,7 +252,12 @@ function ThreadDetail() {
             <StreamingContent threadId={threadId} />
           </div>
         </div>
-        <div className="w-4/6 mx-auto pt-2 pb-3 shrink-0 relative">
+        <div
+          className={cn(
+            ' mx-auto pt-2 pb-3 shrink-0 relative',
+            chatWidth === 'compact' ? 'w-4/6' : 'w-full px-3'
+          )}
+        >
           <div
             className={cn(
               'absolute z-0 -top-6 h-8 py-1 flex w-full justify-center pointer-events-none opacity-0 visibility-hidden',


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a new feature for customizing the chat width, refactors the token speed indicator, and simplifies the `ChatInput` component by removing unused functionality. Additionally, it includes the creation of a reusable `Skeleton` component and updates to the appearance settings interface. Below is a breakdown of the most important changes:

### New Feature: Chat Width Customization
* Added a `ChatWidthSwitcher` component to allow users to toggle between "compact" and "full" chat widths. This includes corresponding updates to the `useAppearance` hook to manage the `chatWidth` state. (`web-app/src/containers/ChatWidthSwitcher.tsx` - [[1]](diffhunk://#diff-3d41025e1c0c44f3767c267c6e3a9364223fce45d8059d8874564bf800f2af63R1-R61) `web-app/src/hooks/useAppearance.ts` - [[2]](diffhunk://#diff-b3a596905019c5a1b08c73f84b4214bef88030db1785f9ee82df0fad34fab8fdR9-R12) [[3]](diffhunk://#diff-b3a596905019c5a1b08c73f84b4214bef88030db1785f9ee82df0fad34fab8fdR24) [[4]](diffhunk://#diff-b3a596905019c5a1b08c73f84b4214bef88030db1785f9ee82df0fad34fab8fdR135) [[5]](diffhunk://#diff-b3a596905019c5a1b08c73f84b4214bef88030db1785f9ee82df0fad34fab8fdR277-R280)
* Integrated the `ChatWidthSwitcher` into the appearance settings page and updated the `ThreadDetail` component to dynamically adjust the chat layout based on the selected width. (`web-app/src/routes/settings/appearance.tsx` - [[1]](diffhunk://#diff-764cf267a55b82f7523824fda48b4d8994286f75120703d736e2de78a774c67dR21) [[2]](diffhunk://#diff-764cf267a55b82f7523824fda48b4d8994286f75120703d736e2de78a774c67dR102-R110); `web-app/src/routes/threads/$threadId.tsx` - [[3]](diffhunk://#diff-bfcfadc1ba1eb61eb68741d61cc9626423144789e607bf7d475dfe1a3a95d389L38-R38) [[4]](diffhunk://#diff-bfcfadc1ba1eb61eb68741d61cc9626423144789e607bf7d475dfe1a3a95d389L216-R221) [[5]](diffhunk://#diff-bfcfadc1ba1eb61eb68741d61cc9626423144789e607bf7d475dfe1a3a95d389L250-R260)

### Refactor: Token Speed Indicator
* Moved the token speed indicator logic into a dedicated `TokenSpeedIndicator` component, replacing the `IconBrandSpeedtest` with a `Gauge` icon and adding support for live token speed updates during streaming. (`web-app/src/containers/TokenSpeedIndicator.tsx` - [web-app/src/containers/TokenSpeedIndicator.tsxL1-R28](diffhunk://#diff-9b7ef67bf3eaa1fb2521a3c2cf527dc97621d4eb0e7d52b6ff1507d123eda40eL1-R28))
* Updated the `ThreadContent` component to use the new `TokenSpeedIndicator` and streamline its structure. (`web-app/src/containers/ThreadContent.tsx` - [[1]](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461R362-R366) [[2]](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461R450-R453)

### Simplification: `ChatInput` Component
* Removed the unused `showSpeedToken` prop and its associated logic from the `ChatInput` component, simplifying its structure. (`web-app/src/containers/ChatInput.tsx` - [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L24) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L48-R47) [[3]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L63-R57) [[4]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L562-L570)

### Reusable Component: `Skeleton`
* Created a reusable `Skeleton` component for displaying placeholder content, which is now used in the `ChatWidthSwitcher` component. (`web-app/src/components/ui/skeleton.tsx` - [web-app/src/components/ui/skeleton.tsxR1-R13](diffhunk://#diff-48cdc30a3260fb483d57544c53d31f7e713ed7661b43197decc57eae5308971cR1-R13))

These changes enhance the user interface by providing more customization options, improving code modularity, and simplifying components for better maintainability.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
