### PR TITLE
🐛 fix: should not pop shell window on MCP run

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,7 @@ tauri-plugin-store = "2"
 hyper = { version = "0.14", features = ["server"] }
 reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
 tokio = { version = "1", features = ["full"] }
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "c1c4c9a0c9afbfbbf9eb42d6f8b00d8546fbdc2c", features = [
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "3196c95f1dfafbffbdcdd6d365c94969ac975e6a", features = [
     "client",
     "transport-sse-client",
     "transport-child-process",

--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -578,8 +578,8 @@ async fn schedule_mcp_start_task<R: Runtime>(
         let server_info = service.peer_info();
         log::trace!("Connected to server: {server_info:#?}");
         (
-            server_info.server_info.name.clone(),
-            server_info.server_info.version.clone(),
+            server_info.unwrap().server_info.name.clone(),
+            server_info.unwrap().server_info.version.clone(),
         )
     };
 


### PR DESCRIPTION
## Describe Your Changes

The Shell Window should not pop up when MCP is running on Window

## Fixes Issues

- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `rmcp` dependency to prevent shell window pop-up on Windows during MCP run.
> 
>   - **Dependencies**:
>     - Update `rmcp` dependency in `Cargo.toml` to revision `3196c95f1dfafbffbdcdd6d365c94969ac975e6a` to prevent shell window pop-up on Windows during MCP run.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ecbe5555dd83081cc332adeac99cd8c1974236cb. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->