### PR TITLE
🐛fix: showing release notes for beta and prod

### DIFF
--- a/web-app/src/containers/dialogs/AppUpdater.tsx
+++ b/web-app/src/containers/dialogs/AppUpdater.tsx
@@ -71,7 +71,7 @@ const DialogAppUpdater = () => {
                   <div className="text-base font-medium">
                     New Version: Jan {updateState.updateInfo?.version}
                   </div>
-                  <div className="mt-1 text-main-view-fg/70 font-normal">
+                  <div className="mt-1 text-main-view-fg/70 font-normal mb-2">
                     There's a new app update available to download.
                   </div>
                 </div>
@@ -79,9 +79,9 @@ const DialogAppUpdater = () => {
             </div>
 
             {showReleaseNotes && (
-              <div className="max-h-[500px] py-2 overflow-y-scroll px-4 text-sm font-normal leading-relaxed">
-                {nightly ? (
-                  <p className="mt-2 text-sm font-normal">
+              <div className="max-h-[500px] p-4 w-[400px] overflow-y-scroll px-4 text-sm font-normal leading-relaxed">
+                {nightly && !beta ? (
+                  <p className="text-sm font-normal">
                     You are using a nightly build. This version is built from
                     the latest development branch and may not have release
                     notes.


### PR DESCRIPTION
## Describe Your Changes
This pull request makes a few adjustments to the `DialogAppUpdater` component in `AppUpdater.tsx` to improve the layout and user experience. The changes include adding spacing between elements and refining the conditions for displaying nightly build messages.

### Layout improvements:

* Added a `mb-2` class to the description `<div>` to create additional spacing below the text, improving visual separation.
* Adjusted the `max-h`, `p`, and `w` properties of the release notes container to improve its size and padding, ensuring better readability and alignment.

### Conditional rendering refinement:

* Updated the condition for displaying the nightly build message to exclude beta builds (`nightly && !beta`), ensuring the message is shown only when appropriate.

## Fixes Issues

<img width="1081" alt="Screenshot 2025-06-16 at 15 32 27" src="https://github.com/user-attachments/assets/24e928b7-5296-4ea5-a4b1-4ffd78f97a4a" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
