### PR TITLE
🐛fix: remove onboarding local model and hide the edit capabilities model

### DIFF
--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -3,6 +3,7 @@ import { useModelProvider } from '@/hooks/useModelProvider'
 import { Link } from '@tanstack/react-router'
 import { route } from '@/constants/routes'
 import HeaderPage from './HeaderPage'
+import { isProd } from '@/lib/version'
 
 function SetupScreen() {
   const { providers } = useModelProvider()
@@ -19,15 +20,19 @@ function SetupScreen() {
               Welcome to Jan
             </h1>
             <p className="text-main-view-fg/70 text-lg mt-2">
-              To get started, you’ll need to either download a local AI model or
+              To get started, you'll need to either download a local AI model or
               connect to a cloud model using an API key
             </p>
           </div>
           <div className="flex gap-4 flex-col">
             <Card
               header={
-                // Add search query step setup_local_provider to the onboarding local model later
-                <Link to={route.hub}>
+                <Link
+                  to={route.hub}
+                  search={{
+                    ...(!isProd ? { step: 'setup_local_provider' } : {}),
+                  }}
+                >
                   <div>
                     <h1 className="text-main-view-fg font-medium text-base">
                       Set up local model

--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -26,12 +26,8 @@ function SetupScreen() {
           <div className="flex gap-4 flex-col">
             <Card
               header={
-                <Link
-                  to={route.hub}
-                  search={{
-                    step: 'setup_local_provider',
-                  }}
-                >
+                // Add search query step setup_local_provider to the onboarding local model later
+                <Link to={route.hub}>
                   <div>
                     <h1 className="text-main-view-fg font-medium text-base">
                       Set up local model

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -39,6 +39,7 @@ import { toast } from 'sonner'
 import { ActiveModel } from '@/types/models'
 import { useEffect, useState } from 'react'
 import { predefinedProviders } from '@/mock/data'
+import { isProd } from '@/lib/version'
 
 // as route.threadsDetail
 export const Route = createFileRoute('/settings/providers/$providerName')({
@@ -459,10 +460,12 @@ function ProviderDetail() {
                           }
                           actions={
                             <div className="flex items-center gap-1">
-                              <DialogEditModel
-                                provider={provider}
-                                modelId={model.id}
-                              />
+                              {!isProd && (
+                                <DialogEditModel
+                                  provider={provider}
+                                  modelId={model.id}
+                                />
+                              )}
                               {model.settings && (
                                 <ModelSetting
                                   provider={provider}


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces changes to improve the user interface and functionality of the web app by refining navigation and conditionally rendering components based on the environment. The most important updates include modifying a link in the `SetupScreen` component and adding environment-based conditional rendering in the `ProviderDetail` component.

### UI Improvements:
* [`web-app/src/containers/SetupScreen.tsx`](diffhunk://#diff-d892c5ebcde40fcdfb642657b6f87fb36bcd63218c78b644c842a781a9675892L29-R30): Updated the `Link` in the `SetupScreen` component to remove the `search` query for the `step` parameter. A comment was added to indicate that the query will be reintroduced later for onboarding the local model.

### Environment-Based Rendering:
* [`web-app/src/routes/settings/providers/$providerName.tsx`](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5R42): Imported `isProd` from `@/lib/version` to enable environment checks.
* [`web-app/src/routes/settings/providers/$providerName.tsx`](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5R463-R468): Wrapped the `DialogEditModel` component in a conditional check to render it only when the app is not in production (`!isProd`).

## Fixes Issues
![Screenshot 2025-06-16 at 19 52 45](https://github.com/user-attachments/assets/30963286-bf79-4752-8115-c5def44dd54e)
![Screenshot 2025-06-16 at 19 51 53](https://github.com/user-attachments/assets/6a847249-f57b-4fc4-9a22-d3dc045e53fa)

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Refines UI and conditionally renders components based on environment in `SetupScreen.tsx` and `$providerName.tsx`.
> 
>   - **UI Improvements**:
>     - In `SetupScreen.tsx`, updated `Link` to conditionally include `step` query parameter only in non-production environments.
>   - **Environment-Based Rendering**:
>     - In `$providerName.tsx`, imported `isProd` to check environment.
>     - Wrapped `DialogEditModel` in a conditional to render only in non-production environments.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ed9867a6430b372ea2db7cf14d1bcfb453f32614. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->