### PR TITLE
🐛fix: hide token speed when assistant params stream false

### DIFF
--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -417,17 +417,6 @@ export const ThreadContent = memo(
                               />
                             </div>
                           </div>
-                          <DialogFooter className="mt-2 flex items-center">
-                            <DialogClose asChild>
-                              <Button
-                                variant="link"
-                                size="sm"
-                                className="hover:no-underline"
-                              >
-                                Close
-                              </Button>
-                            </DialogClose>
-                          </DialogFooter>
                         </DialogHeader>
                       </DialogContent>
                     </Dialog>

--- a/web-app/src/containers/TokenSpeedIndicator.tsx
+++ b/web-app/src/containers/TokenSpeedIndicator.tsx
@@ -14,10 +14,19 @@ export const TokenSpeedIndicator = ({
   const persistedTokenSpeed = (metadata?.tokenSpeed as { tokenSpeed: number })
     ?.tokenSpeed
 
+  const nonStreamingAssistantParam =
+    typeof metadata?.assistant === 'object' &&
+    metadata?.assistant !== null &&
+    'parameters' in metadata.assistant
+      ? (metadata.assistant as { parameters?: { stream?: boolean } }).parameters
+          ?.stream === false
+      : undefined
+
+  if (nonStreamingAssistantParam) return
+
   return (
     <div className="flex items-center gap-1 text-main-view-fg/60 text-xs">
       <Gauge size={16} />
-
       <span>
         {Math.round(
           streaming ? Number(tokenSpeed?.tokenSpeed) : persistedTokenSpeed


### PR DESCRIPTION
## Describe Your Changes

This pull request makes adjustments to the user interface and logic in two components, `ThreadContent` and `TokenSpeedIndicator`, to improve functionality and maintainability. The key changes include the removal of an unused dialog footer in `ThreadContent` and the addition of a conditional check in `TokenSpeedIndicator` to handle non-streaming assistant parameters.

### UI adjustments:
* Removed the `DialogFooter` section from the `ThreadContent` component, including the "Close" button, as it was no longer needed. (`web-app/src/containers/ThreadContent.tsx`, [web-app/src/containers/ThreadContent.tsxL420-L430](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L420-L430))

### Logic improvements:
* Added a conditional check in the `TokenSpeedIndicator` component to handle cases where the assistant's parameters indicate non-streaming mode. If this condition is met, the component exits early. (`web-app/src/containers/TokenSpeedIndicator.tsx`, [web-app/src/containers/TokenSpeedIndicator.tsxR17-L20](diffhunk://#diff-9b7ef67bf3eaa1fb2521a3c2cf527dc97621d4eb0e7d52b6ff1507d123eda40eR17-L20))

## Fixes Issues

![Screenshot 2025-06-16 at 20 47 42](https://github.com/user-attachments/assets/d73e20f5-a2e3-4fa1-9280-a563d8dd3cb8)
@david-menloai no need border, just remove close button, since we can `esc` and icon X on top right corner


![Screenshot 2025-06-16 at 20 47 51](https://github.com/user-attachments/assets/5b6f27a5-2486-4bce-94b5-afd755543c9d)

Hidden token speed when assistant have params stream false


- Closes #5300 
- Closes #5299 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
