### PR TITLE
fix: ci stable version

### DIFF
--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -160,6 +160,9 @@ jobs:
             
             sed -i "s/jan_productname/Jan-${{ inputs.channel }}/g" ./src-tauri/tauri.bundle.windows.nsis.template
             sed -i "s/jan_mainbinaryname/jan-${{ inputs.channel }}/g" ./src-tauri/tauri.bundle.windows.nsis.template
+          else
+            sed -i "s/jan_productname/Jan/g" ./src-tauri/tauri.bundle.windows.nsis.template
+            sed -i "s/jan_mainbinaryname/jan/g" ./src-tauri/tauri.bundle.windows.nsis.template
           fi
           echo "---------nsis.template---------"
           cat ./src-tauri/tauri.bundle.windows.nsis.template


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/template-tauri-build-windows-x64.yml` file. The change adds a fallback case to replace placeholders in the NSIS template with default values (`Jan` and `jan`) when the `inputs.channel` variable is not provided.