### PR TITLE
🐛fix: llama.cpp default NGL setting does not offload all layers to GPU

### DIFF
--- a/core/src/browser/models/utils.ts
+++ b/core/src/browser/models/utils.ts
@@ -17,7 +17,7 @@ export const validationRules: { [key: string]: (value: any) => boolean } = {
   presence_penalty: (value: any) => typeof value === 'number' && value >= 0 && value <= 1,
 
   ctx_len: (value: any) => Number.isInteger(value) && value >= 0,
-  ngl: (value: any) => Number.isInteger(value) && value >= 0,
+  ngl: (value: any) => Number.isInteger(value),
   embedding: (value: any) => typeof value === 'boolean',
   n_parallel: (value: any) => Number.isInteger(value) && value >= 0,
   cpu_threads: (value: any) => Number.isInteger(value) && value >= 0,

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -282,7 +282,9 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
             ...(this.context_shift === false
               ? { 'no-context-shift': true }
               : {}),
-            ...(model.settings?.ngl === -1 ? { ngl: 100 } : {}),
+            ...(model.settings?.ngl === -1 || model.settings?.ngl === undefined
+              ? { ngl: 100 }
+              : {}),
           },
           timeout: false,
           signal,

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -253,11 +253,12 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
         }
       }
     }
+    const modelSettings = extractModelLoadParams(model.settings)
     return await this.apiInstance().then((api) =>
       api
         .post('v1/models/start', {
           json: {
-            ...extractModelLoadParams(model.settings),
+            ...modelSettings,
             model: model.id,
             engine:
               model.engine === 'nitro' // Legacy model cache
@@ -282,7 +283,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
             ...(this.context_shift === false
               ? { 'no-context-shift': true }
               : {}),
-            ...(model.settings?.ngl === -1 || model.settings?.ngl === undefined
+            ...(modelSettings.ngl === -1 || modelSettings.ngl === undefined
               ? { ngl: 100 }
               : {}),
           },

--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -282,6 +282,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
             ...(this.context_shift === false
               ? { 'no-context-shift': true }
               : {}),
+            ...(model.settings?.ngl === -1 ? { ngl: 100 } : {}),
           },
           timeout: false,
           signal,

--- a/web-app/src/routes/settings/hardware.tsx
+++ b/web-app/src/routes/settings/hardware.tsx
@@ -371,30 +371,34 @@ function Hardware() {
             )}
 
             {/* GPU Information */}
-            <Card title="GPUs">
-              {hardwareData.gpus.length > 0 ? (
-                <DndContext
-                  sensors={sensors}
-                  collisionDetection={closestCenter}
-                  onDragEnd={handleDragEnd}
-                >
-                  <SortableContext
-                    items={hardwareData.gpus.map((gpu) => gpu.id)}
-                    strategy={verticalListSortingStrategy}
+            {!IS_MACOS ? (
+              <Card title="GPUs">
+                {hardwareData.gpus.length > 0 ? (
+                  <DndContext
+                    sensors={sensors}
+                    collisionDetection={closestCenter}
+                    onDragEnd={handleDragEnd}
                   >
-                    {hardwareData.gpus.map((gpu, index) => (
-                      <SortableGPUItem
-                        key={gpu.id || index}
-                        gpu={gpu}
-                        index={index}
-                      />
-                    ))}
-                  </SortableContext>
-                </DndContext>
-              ) : (
-                <CardItem title="No GPUs detected" actions={<></>} />
-              )}
-            </Card>
+                    <SortableContext
+                      items={hardwareData.gpus.map((gpu) => gpu.id)}
+                      strategy={verticalListSortingStrategy}
+                    >
+                      {hardwareData.gpus.map((gpu, index) => (
+                        <SortableGPUItem
+                          key={gpu.id || index}
+                          gpu={gpu}
+                          index={index}
+                        />
+                      ))}
+                    </SortableContext>
+                  </DndContext>
+                ) : (
+                  <CardItem title="No GPUs detected" actions={<></>} />
+                )}
+              </Card>
+            ) : (
+              <></>
+            )}
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Describe Your Changes

Fixed an issue where llama.cpp does not offload all layers to GPU by default. @qnixsynapse is taking a look at this issue. For now Jan will just forward a high NGL number in this case.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes GPU layer offloading in llama.cpp by setting default `ngl` and updates UI to conditionally render GPU info based on OS.
> 
>   - **Behavior**:
>     - In `index.ts`, set default `ngl` to 100 if `ngl` is -1 or undefined.
>     - In `utils.ts`, remove non-negative integer constraint for `ngl` validation.
>   - **UI**:
>     - In `hardware.tsx`, conditionally render GPU information only if not on macOS.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 001d3042d7d068e0f5ac56b5417be983430d621e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->