### PR TITLE
🐛fix: allow script posthog

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -45,7 +45,7 @@
         ],
         "img-src": "'self' asset: http://asset.localhost blob: data: https://cdn.jsdelivr.net",
         "style-src": "'unsafe-inline' 'self' https://fonts.googleapis.com",
-        "script-src": "'self' asset: $APPDATA/**.* http://asset.localhost"
+        "script-src": "'self' asset: $APPDATA/**.* http://asset.localhost https://eu-assets.i.posthog.com https://posthog.com"
       },
       "assetProtocol": {
         "enable": true,


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the `src-tauri/tauri.conf.json` file to expand the list of allowed script sources. The change adds new domains to improve compatibility with external services.

Security configuration update:

* [`src-tauri/tauri.conf.json`](diffhunk://#diff-fa09f1dac39604a735cd6a53957d3c35e0c3298cca9cf4829180f167abbd69b7L48-R48): Added `https://eu-assets.i.posthog.com` and `https://posthog.com` to the `script-src` directive in the Content Security Policy, allowing scripts from these domains to be loaded.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
