### PR TITLE
ci: enable devtool on prod build

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -122,6 +122,10 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
+          # Temporarily enable devtool on prod build
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          cat ./src-tauri/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           cat ./src-tauri/Cargo.toml
 

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -146,6 +146,8 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
             cat ./package.json
           fi
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          cat ./src-tauri/Cargo.toml
       - name: Get key for notarize
         run: base64 -d <<< "$NOTARIZE_P8_BASE64" > /tmp/notary-key.p8
         shell: bash

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -126,6 +126,10 @@ jobs:
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           cat ./src-tauri/Cargo.toml
 
+          # Temporarily enable devtool on prod build
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          cat ./src-tauri/Cargo.toml
+
           # Change app name for beta and nightly builds
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
@@ -146,8 +150,6 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
             cat ./package.json
           fi
-          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
-          cat ./src-tauri/Cargo.toml
       - name: Get key for notarize
         run: base64 -d <<< "$NOTARIZE_P8_BASE64" > /tmp/notary-key.p8
         shell: bash

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -139,7 +139,7 @@ jobs:
 
           # Temporarily enable devtool on prod build
           ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
-          cat ./src-tauri/Cargo.tom
+          cat ./src-tauri/Cargo.toml
 
           # Change app name for beta and nightly builds
           if [ "${{ inputs.channel }}" != "stable" ]; then

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -137,6 +137,10 @@ jobs:
           sed -i "s/jan_version/$new_base_version/g" ./src-tauri/tauri.bundle.windows.nsis.template
           sed -i "s/jan_build/$new_build_version/g" ./src-tauri/tauri.bundle.windows.nsis.template          
 
+          # Temporarily enable devtool on prod build
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          cat ./src-tauri/Cargo.tom
+
           # Change app name for beta and nightly builds
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json


### PR DESCRIPTION
This pull request temporarily enables the `devtools` feature in production builds across Linux, macOS, and Windows workflows. The change is applied to the `Cargo.toml` file in the `src-tauri` directory for each platform-specific build process.

Temporary enabling of `devtools` in production builds:

* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03R125-R128): Added a command to enable the `devtools` feature in the `Cargo.toml` file for Linux builds.
* [`.github/workflows/template-tauri-build-macos.yml`](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383R149-R150): Added a command to enable the `devtools` feature in the `Cargo.toml` file for macOS builds.
* [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8R140-R143): Added a command to enable the `devtools` feature in the `Cargo.toml` file for Windows builds.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Temporarily enables `devtools` feature in production builds for Linux, macOS, and Windows by modifying `Cargo.toml` in `src-tauri`.
> 
>   - **Behavior**:
>     - Temporarily enables `devtools` feature in production builds by modifying `Cargo.toml` in `src-tauri`.
>     - Applied to Linux, macOS, and Windows workflows.
>   - **Workflows**:
>     - `.github/workflows/template-tauri-build-linux-x64.yml`: Adds command to enable `devtools` for Linux builds.
>     - `.github/workflows/template-tauri-build-macos.yml`: Adds command to enable `devtools` for macOS builds.
>     - `.github/workflows/template-tauri-build-windows-x64.yml`: Adds command to enable `devtools` for Windows builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6d3d178d0cac8ce20d1afbc65423f46ddb0367ed. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->