### PR TITLE
Fix: sorted thread not stable

### DIFF
--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -32,11 +32,6 @@ export const useThreads = create<ThreadState>()((set, get) => ({
   threads: {},
   searchIndex: null,
   setThreads: (threads) => {
-    threads.forEach((thread) => {
-      updateThread({
-        ...thread,
-      })
-    })
     const threadMap = threads.reduce(
       (acc: Record<string, Thread>, thread) => {
         acc[thread.id] = thread


### PR DESCRIPTION
## Describe Your Changes

- This code block make when fetching threads data updated again to the backend, that leads to all threads have the same updated field

## Fixes Issues

- Closes #5334 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
