### PR TITLE
🐛fix: render streaming token speed based on thread ID & assistant metadata

### DIFF
--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -363,7 +363,10 @@ export const ThreadContent = memo(
                   <div
                     className={cn(
                       'flex items-center gap-2',
-                      item.isLastMessage && streamingContent && 'hidden'
+                      item.isLastMessage &&
+                        streamingContent &&
+                        streamingContent.thread_id === item.thread_id &&
+                        'hidden'
                     )}
                   >
                     <CopyButton text={item.content?.[0]?.text.value || ''} />
@@ -439,7 +442,11 @@ export const ThreadContent = memo(
                   </div>
 
                   <TokenSpeedIndicator
-                    streaming={Boolean(item.isLastMessage && streamingContent)}
+                    streaming={Boolean(
+                      item.isLastMessage &&
+                        streamingContent &&
+                        streamingContent.thread_id === item.thread_id
+                    )}
                     metadata={item.metadata}
                   />
                 </div>
@@ -447,6 +454,7 @@ export const ThreadContent = memo(
             )}
           </>
         )}
+
         {item.type === 'image_url' && image && (
           <div>
             <img

--- a/web-app/src/hooks/useMessages.ts
+++ b/web-app/src/hooks/useMessages.ts
@@ -34,7 +34,12 @@ export const useMessages = create<MessageState>()((set, get) => ({
       created_at: message.created_at || Date.now(),
       metadata: {
         ...message.metadata,
-        assistant: currentAssistant,
+        assistant: {
+          id: currentAssistant?.id || '',
+          name: currentAssistant?.name || '',
+          avatar: currentAssistant?.avatar || '',
+          instructions: currentAssistant?.instructions || '',
+        },
       },
     }
     createMessage(newMessage).then((createdMessage) => {


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces updates to improve conditional rendering and state management in the `ThreadContent` component and refines the structure of the `assistant` metadata in the `useMessages` hook. The changes enhance functionality and ensure more precise handling of data.

### Updates to `ThreadContent` component:

* Improved conditional rendering logic to ensure the `hidden` class is applied only when `streamingContent.thread_id` matches `item.thread_id`, enhancing accuracy in UI behavior. (`web-app/src/containers/ThreadContent.tsx`, [web-app/src/containers/ThreadContent.tsxL366-R369](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L366-R369))
* Updated the `streaming` prop in the `TokenSpeedIndicator` component to include a thread ID match check, ensuring proper streaming indication. (`web-app/src/containers/ThreadContent.tsx`, [web-app/src/containers/ThreadContent.tsxL442-R457](diffhunk://#diff-4ce0228019e3fd7b3b4f414c7fb8f5906ff86fb8c333841826df78ae8decc461L442-R457))

### Refinements in `useMessages` hook:

* Expanded the `assistant` metadata structure by adding explicit fields (`id`, `name`, `avatar`, and `instructions`) with default values, improving data integrity and clarity. (`web-app/src/hooks/useMessages.ts`, [web-app/src/hooks/useMessages.tsL37-R42](diffhunk://#diff-a29b4836b0ab40a86f342205c7e2afd3dc079c6ca08db225656f18e716fc625cL37-R42))

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
