### PR TITLE
🐛 Fix: window path name with a space lead to cannot find correct path to Jan datafolder

### DIFF
--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -247,7 +247,10 @@ pub fn setup_sidecar(app: &App) -> Result<(), String> {
                 ]);
             #[cfg(target_os = "windows")]
             {
-                cmd = cmd.current_dir(app_handle_for_spawn.path().resource_dir().unwrap());
+                let resource_dir = app_handle_for_spawn.path().resource_dir().unwrap();
+                let normalized_path = resource_dir.to_string_lossy().replace(r"\\?\", "");
+                let normalized_pathbuf = PathBuf::from(normalized_path);
+                cmd = cmd.current_dir(normalized_pathbuf);
             }
 
             #[cfg(not(target_os = "windows"))]


### PR DESCRIPTION
## Describe Your Changes

Changed to Tauri path getter function in the case the OS window. Sanitise the path and get rid of the extended-path lenght `\\?` when it encounters one.

## Fixes Issues

- Closes #5341

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [x] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes path handling in `setup_sidecar()` in `setup.rs` for Windows by removing `\\?\` prefix to support paths with spaces.
> 
>   - **Behavior**:
>     - Fixes path handling in `setup_sidecar()` in `setup.rs` for Windows by removing `\\?\` prefix from paths.
>     - Ensures compatibility with paths containing spaces.
>   - **Misc**:
>     - Closes issue #5341.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a075debb0538e8319377d3ba32961773f67e985e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->