### PR TITLE
🐛fix: setting provider hide model capabilities

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -16,6 +16,7 @@ import { ModelSetting } from '@/containers/ModelSetting'
 import ProvidersAvatar from '@/containers/ProvidersAvatar'
 import { Fzf } from 'fzf'
 import { localStorageKey } from '@/constants/localStorage'
+import { isProd } from '@/lib/version'
 
 type DropdownModelProviderProps = {
   model?: ThreadModel
@@ -400,7 +401,7 @@ const DropdownModelProvider = ({
                                 />
 
                                 <div className="flex-1"></div>
-                                {capabilities.length > 0 && (
+                                {!isProd && capabilities.length > 0 && (
                                   <div className="flex-shrink-0 -mr-1.5">
                                     <Capabilities capabilities={capabilities} />
                                   </div>

--- a/web-app/src/index.css
+++ b/web-app/src/index.css
@@ -79,6 +79,15 @@
   ::-ms-reveal {
     display: none;
   }
+
+  .reset-heading {
+    :is(h1, h2, h3, h4, h5, h6) {
+      font-weight: 600;
+      font-size: 14px !important;
+      margin-top: 0 !important;
+      margin-bottom: 0.5em;
+    }
+  }
 }
 
 @layer utilities {

--- a/web-app/src/routes/__root.tsx
+++ b/web-app/src/routes/__root.tsx
@@ -18,6 +18,7 @@ import { AnalyticProvider } from '@/providers/AnalyticProvider'
 import { useLeftPanel } from '@/hooks/useLeftPanel'
 import { cn } from '@/lib/utils'
 import ToolApproval from '@/containers/dialogs/ToolApproval'
+import { useEffect } from 'react'
 
 export const Route = createRootRoute({
   component: RootLayout,
@@ -81,6 +82,13 @@ function RootLayout() {
     router.location.pathname === route.localApiServerlogs ||
     router.location.pathname === route.systemMonitor ||
     router.location.pathname === route.appLogs
+
+  useEffect(() => {
+    return () => {
+      // This is to attempt to stop the local API server when the app is closed or reloaded.
+      window.core?.api?.stopServer()
+    }
+  }, [])
 
   return (
     <Fragment>

--- a/web-app/src/routes/hub.tsx
+++ b/web-app/src/routes/hub.tsx
@@ -495,7 +495,7 @@ function Hub() {
                         <div className="line-clamp-2 mt-3 text-main-view-fg/60">
                           <RenderMarkdown
                             enableRawHtml={true}
-                            className="select-none"
+                            className="select-none reset-heading"
                             components={{
                               a: ({ ...props }) => (
                                 <a

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -455,7 +455,9 @@ function ProviderDetail() {
                           title={
                             <div className="flex items-center gap-2">
                               <h1 className="font-medium">{model.id}</h1>
-                              <Capabilities capabilities={capabilities} />
+                              {!isProd && (
+                                <Capabilities capabilities={capabilities} />
+                              )}
                             </div>
                           }
                           actions={

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -13,7 +13,6 @@ import {
 import { modelSettings } from '@/lib/predefined'
 import { fetchModels } from './models'
 import { ExtensionManager } from '@/lib/extension'
-import { isProd } from '@/lib/version'
 
 export const getProviders = async (): Promise<ModelProvider[]> => {
   const engines = !localStorage.getItem('migration_completed')
@@ -66,7 +65,7 @@ export const getProviders = async (): Promise<ModelProvider[]> => {
           ].filter(Boolean) as string[]
           return {
             ...(modelManifest ?? { id: model, name: model }),
-            ...(!isProd ? { capabilities } : {}),
+            capabilities,
           } as Model
         })
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a minor conditional rendering improvement in the `ProviderDetail` function. The change ensures that the `Capabilities` component is only displayed when the application is not in production mode.

Changes in conditional rendering:

* [`web-app/src/routes/settings/providers/$providerName.tsx`](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5R458-R460): Updated the `title` property to conditionally render the `Capabilities` component based on the `isProd` flag, improving clarity and relevance of the UI in non-production environments.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Conditional rendering of `Capabilities` component based on `isProd` flag in `DropdownModelProvider.tsx` and `$providerName.tsx`.
> 
>   - **Behavior**:
>     - `Capabilities` component in `DropdownModelProvider.tsx` and `$providerName.tsx` now conditionally rendered based on `isProd` flag.
>     - In production, `Capabilities` and `DialogEditModel` components are hidden.
>   - **CSS**:
>     - Added `.reset-heading` class in `index.css` to standardize heading styles.
>   - **Effects**:
>     - Added `useEffect` in `__root.tsx` to stop local API server on app close or reload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 0e220ef319e9025e403aa4c5e1d4d73fe133c51d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->