### PR TITLE
🐛fix: Tauri AppImage failing to render on wayland + mesa

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -151,6 +151,12 @@ jobs:
           fi
       - name: Build app
         run: |
+          # Pin linuxdeploy version to prevent @tauri-apps/cli-linux-x64-gnu from pulling in an outdated version
+          TAURI_TOOLKIT_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
+          mkdir -p "$TAURI_TOOLKIT_PATH"
+          wget https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage -O "$TAURI_TOOLKIT_PATH/linuxdeploy-x86_64.AppImage"
+          chmod +x "$TAURI_TOOLKIT_PATH/linuxdeploy-x86_64.AppImage"
+
           make build-tauri
           # Copy engines and bun to appimage
            wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O ./appimagetool


### PR DESCRIPTION
AppImages built with Tauri fail to render with EGL_BAD_PARAMETER on wayland + mesa. This is a [side effect of binary stripping in older linuxdeploy builds](https://github.com/kanriapp/kanri/issues/805). Tauri cli pulls in [an outdated build of linuxdeploy](https://github.com/tauri-apps/binary-releases/releases/tag/linuxdeploy). This can be fixed by opting out of binary stripping, or by upgrading linuxdeploy. Tauri cli is well behaved in that [it doesn't fetch linuxdeploy if it already exists in the cache](https://github.com/tauri-apps/tauri/blob/594822aa55eede86530a0b24dc68bb7d1fc1da67/crates/tauri-bundler/src/bundle/linux/appimage.rs#L232). This behavior allows us to pin linuxdeploy to any version of our choosing by prepopulating the toolsdirectory with a linuxdeploy binary before calling Tauri cli.

## Describe Your Changes

- Pins linuxdeploy version to prevent @tauri-apps/cli-linux-x64-gnu from pulling in an outdated version

## Fixes Issues

- Fixes #5305
- Fixes #5367

## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Pins `linuxdeploy` version in GitHub workflow to fix Tauri AppImage rendering issues on Wayland + Mesa.
> 
>   - **Behavior**:
>     - Pins `linuxdeploy` version in `.github/workflows/template-tauri-build-linux-x64.yml` to prevent outdated versions causing rendering issues on Wayland + Mesa.
>     - Downloads specific `linuxdeploy-x86_64.AppImage` and sets executable permissions before Tauri CLI execution.
>   - **Fixes**:
>     - Closes issues #5305 and #5367 related to rendering failures on Wayland + Mesa.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1f1a6fb2e19eea1212e14b0f35ba9a69ae155acf. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

Edit: correct github keyword from closes to fixes, added some hyperlinks to issue desc for improved context.