### PR TITLE
fix: handle context shift setting from old app versions

### DIFF
--- a/extensions/inference-cortex-extension/src/index.ts
+++ b/extensions/inference-cortex-extension/src/index.ts
@@ -280,7 +280,7 @@ export default class JanInferenceCortexExtension extends LocalOAIEngine {
             ...(model.id.toLowerCase().includes('jan-nano')
               ? { reasoning_budget: 0 }
               : { reasoning_budget: this.reasoning_budget }),
-            ...(this.context_shift === false
+            ...(this.context_shift !== true
               ? { 'no-context-shift': true }
               : {}),
             ...(modelSettings.ngl === -1 || modelSettings.ngl === undefined


### PR DESCRIPTION
## Describe Your Changes

This also disables context shifting when it’s undefined (migrated from an older version). Otherwise, it may cause unexpected output for some models in certain cases

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
