### PR TITLE
chore: update .devcontainer to provide a reproducible build environment

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,4 +1,20 @@
 {
-  "name": "jan",
-  "image": "node:20"
+	"name": "Jan",
+	"image": "mcr.microsoft.com/devcontainers/base:jammy",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "20"
+		},
+		"ghcr.io/devcontainers/features/rust:1": {},
+		"ghcr.io/devcontainers-extra/features/corepack:1": {}
+	},
+
+	"postCreateCommand": "./.devcontainer/postCreateCommand.sh",
+
+	// appimagekit requires fuse to package appimage, to use fuse in the container you need to enable it on the host
+	"runArgs": [
+    	"--device", "/dev/fuse",
+    	"--cap-add=SYS_ADMIN",
+    	"--security-opt", "apparmor:unconfined"
+  	]
 }

--- a/.devcontainer/postCreateCommand.sh
+++ b/.devcontainer/postCreateCommand.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+# install tauri prerequisites + xdg-utils for xdg-open + libfuse2 for using appimagekit
+
+sudo apt update
+sudo apt install -yqq libwebkit2gtk-4.1-dev \
+    build-essential \
+    curl \
+    wget \
+    file \
+    libxdo-dev \
+    libssl-dev \
+    libayatana-appindicator3-dev \
+    librsvg2-dev \
+    xdg-utils \
+    libfuse2
+
+sudo mkdir -p /opt/bin
+sudo wget https://github.com/AppImage/AppImageKit/releases/download/continuous/appimagetool-x86_64.AppImage -O /opt/bin/appimagetool
+sudo chmod +x /opt/bin/appimagetool


### PR DESCRIPTION
The current dev container is far from reproducing the linux build env. The github workflow uses Ubuntu 22.04 as a base, so I chose microsoft's jammy dev container as the base image. Tauri requires node and rust as dev dependencies, and we've opted into yarn + corepak. I've added those features to the dev container accordingly. Tauri also requires some system packages to build, + some implicit dependencies that come preinstalled in the github runner/host systems. In postCreateCommand.sh, I've added tauri's explicit dependencies + xdg-utils for xdg-open (used by linuxdeploy) + libfuse2 (used when manually packing an appimage with appimagekit). I've also added the docker run args to enable fuse in the devcontainer, it requires fuse be setup on the host.

## Describe Your Changes

- update devcontainer to mirror build environment used in github release workflow 

This only reproduces the build environment. This does not make builds reproducible. As noted in #5463, there's a extra builds steps in the github release workflow which are necessary to successfully build the appimage. I'll work on a separate PR to make the local the github release process uniform.

To build appimages:

<details>
<summary>./buildAppImage.sh</summary>

```
#!/usr/bin/env bash

make clean

# # To reproduce https://github.com/menloresearch/jan/pull/5463
# TAURI_TOOLKIT_PATH="${XDG_CACHE_HOME:-$HOME/.cache}/tauri"
# mkdir -p "$TAURI_TOOLKIT_PATH"
# wget https://github.com/linuxdeploy/linuxdeploy/releases/download/1-alpha-20250213-2/linuxdeploy-x86_64.AppImage -O "$TAURI_TOOLKIT_PATH/linuxdeploy-x86_64.AppImage"
# chmod +x "$TAURI_TOOLKIT_PATH/linuxdeploy-x86_64.AppImage"

jq '.bundle.resources = ["resources/pre-install/**/*"] | .bundle.externalBin = ["binaries/cortex-server", "resources/bin/uv"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json         

make build-tauri

cp ./src-tauri/resources/bin/bun ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/bin/bun
mkdir -p ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/engines
cp -f ./src-tauri/binaries/deps/*.so* ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
cp -f ./src-tauri/binaries/*.so* ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
cp -rf ./src-tauri/binaries/engines ./src-tauri/target/release/bundle/appimage/Jan.AppDir/usr/lib/Jan/binaries/
APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
echo $APP_IMAGE
rm -f $APP_IMAGE
/opt/bin/appimagetool ./src-tauri/target/release/bundle/appimage/Jan.AppDir $APP_IMAGE
```

</details>

If you uncomment the block at the top, you should have no problem reproducing #5463 @Minh141120 

## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

Edit: typos + inlined `make clean` in the sample build script so there's no question it's building from a clean slate.
