### PR TITLE
chore: flexible installation path windows installer

### DIFF
--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -33,7 +33,7 @@ ${StrLoc}
 !define VERSION "jan_version"
 !define VERSIONWITHBUILD "jan_build"
 !define HOMEPAGE ""
-!define INSTALLMODE "currentUser"
+!define INSTALLMODE "both"
 !define LICENSE ""
 !define INSTALLERICON "D:\a\jan\jan\src-tauri\icons\icon.ico"
 !define SIDEBARIMAGE ""


### PR DESCRIPTION
This pull request updates the NSIS installer configuration in the `src-tauri/tauri.bundle.windows.nsis.template` file to support installation for both the current user and all users.

Installer configuration change:

* Updated the `INSTALLMODE` definition from `"currentUser"` to `"both"`, enabling the installer to support both per-user and system-wide installations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update NSIS installer to support both per-user and system-wide installations by changing `INSTALLMODE` to `"both"`.
> 
>   - **Installer Configuration**:
>     - Updated `INSTALLMODE` in `tauri.bundle.windows.nsis.template` from `"currentUser"` to `"both"` to support both per-user and system-wide installations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 157c32a976bb621a6947500c82c3e3f6351b4d6a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->