### PR TITLE
ci: add issues to project board

### DIFF
--- a/.github/workflows/issues.yaml
+++ b/.github/workflows/issues.yaml
@@ -1,0 +1,16 @@
+name: Adds all issues to project board
+
+on:
+  issues:
+    types:
+      - opened
+
+jobs:
+  add-to-project:
+    name: Add issue to project
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/add-to-project@v1.0.2
+        with:
+          project-url: https://github.com/orgs/${{ vars.ORG_NAME }}/projects/${{ vars.JAN_PROJECT_NUMBER }}
+          github-token: ${{ secrets.AUTO_ADD_TICKET_PAT }}


### PR DESCRIPTION
This pull request introduces a GitHub Actions workflow to automatically add newly opened issues to a specific project board. 

Automation for issue management:

* [`.github/workflows/issues.yaml`](diffhunk://#diff-fe198ee6d6945e09ccefa6351febac68b4b18f3ebc3503e720a8c7fee65ea5c7R1-R16): Added a new workflow named "Adds all issues to project board" that triggers on the `opened` event for issues. It uses the `actions/add-to-project@v1.0.2` action to add the issue to a project board specified by organization and project number variables. The workflow also utilizes a GitHub token stored in secrets for authentication.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds a GitHub Actions workflow to automatically add new issues to a project board on issue creation.
> 
>   - **Automation**:
>     - Adds `.github/workflows/issues.yaml` to automate adding new issues to a project board.
>     - Triggers on `opened` event for issues using `actions/add-to-project@v1.0.2`.
>     - Uses organization and project number variables for project board identification.
>     - Utilizes GitHub token from secrets for authentication.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 5fb160155a774ac7842858613a2a79ef7098dead. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->