### PR TITLE
chore: deprecate ci environment

### DIFF
--- a/.github/workflows/publish-npm-core.yml
+++ b/.github/workflows/publish-npm-core.yml
@@ -6,7 +6,6 @@ on:
   workflow_dispatch:
 jobs:
   build-and-publish-plugins:
-    environment: production
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/template-electron-build-linux-x64.yml
+++ b/.github/workflows/template-electron-build-linux-x64.yml
@@ -43,7 +43,6 @@ jobs:
   build-linux-x64:
     if: inputs.public_provider == 'github' || inputs.public_provider == 'none'
     runs-on: ubuntu-latest
-    environment: production
     permissions:
       contents: write
     steps:
@@ -75,7 +74,6 @@ jobs:
           cp electron/icons_dev/jan-nightly.png electron/icons/icon.png
           cp electron/icons_dev/jan-nightly-tray@2x.png electron/icons/icon-tray@2x.png
           cp electron/icons_dev/jan-nightly-tray.png electron/icons/icon-tray.png
-
 
       - name: Installing node
         uses: actions/setup-node@v1
@@ -131,7 +129,7 @@ jobs:
         env:
           VERSION_TAG: ${{ inputs.new_version }}
 
-      - name: Build and publish app to aws s3 r2 or github artifactory      
+      - name: Build and publish app to aws s3 r2 or github artifactory
         if: inputs.public_provider != 'github'
         run: |
           # check public_provider is true or not

--- a/.github/workflows/template-electron-build-macos.yml
+++ b/.github/workflows/template-electron-build-macos.yml
@@ -53,7 +53,6 @@ jobs:
   build-macos:
     if: inputs.public_provider == 'github' || inputs.public_provider == 'none'
     runs-on: macos-latest
-    environment: production
     permissions:
       contents: write
     steps:
@@ -61,7 +60,7 @@ jobs:
         uses: actions/checkout@v3
         with:
           ref: ${{ inputs.ref }}
-      
+
       - name: Replace Icons for Beta Build
         if: inputs.beta == true && inputs.nightly != true
         shell: bash
@@ -161,7 +160,7 @@ jobs:
           p12-file-base64: ${{ secrets.CODE_SIGN_P12_BASE64 }}
           p12-password: ${{ secrets.CODE_SIGN_P12_PASSWORD }}
 
-      - name: Build and publish app to aws s3 r2 or github artifactory        
+      - name: Build and publish app to aws s3 r2 or github artifactory
         if: inputs.public_provider != 'github'
         run: |
           # check public_provider is true or not

--- a/.github/workflows/template-get-update-version.yml
+++ b/.github/workflows/template-get-update-version.yml
@@ -9,7 +9,6 @@ on:
 jobs:
   get-update-version:
     runs-on: ubuntu-latest
-    environment: production
     outputs:
       new_version: ${{ steps.version_update.outputs.new_version }}
     steps:

--- a/.github/workflows/template-noti-discord-and-update-url-readme.yml
+++ b/.github/workflows/template-noti-discord-and-update-url-readme.yml
@@ -26,7 +26,6 @@ on:
 
 jobs:
   noti-discord-and-update-url-readme:
-    environment: production
     runs-on: ubuntu-latest
     permissions:
       contents: write

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -55,7 +55,6 @@ jobs:
       DEB_SIG: ${{ steps.packageinfo.outputs.DEB_SIG }}
       APPIMAGE_SIG: ${{ steps.packageinfo.outputs.APPIMAGE_SIG }}
       APPIMAGE_FILE_NAME: ${{ steps.packageinfo.outputs.APPIMAGE_FILE_NAME }}
-    environment: production
     permissions:
       contents: write
     steps:

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -63,7 +63,6 @@ jobs:
     outputs:
       MAC_UNIVERSAL_SIG: ${{ steps.metadata.outputs.MAC_UNIVERSAL_SIG }}
       TAR_NAME: ${{ steps.metadata.outputs.TAR_NAME }}
-    environment: production
     permissions:
       contents: write
     steps:


### PR DESCRIPTION
This pull request removes the `environment: production` setting from several GitHub Actions workflows. These changes simplify the configuration and align the workflows with updated practices.

Workflow configuration updates:

* [`.github/workflows/publish-npm-core.yml`](diffhunk://#diff-18abb68c8fe686c43f00073aa28cff4bd56f0dbc0cc8987b658b3267030477acL9): Removed `environment: production` from the `build-and-publish-plugins` job configuration.
* [`.github/workflows/template-electron-build-linux-x64.yml`](diffhunk://#diff-3cc80a8eaadcba13bef9eda801a302e34d915f041325b84b06e900b994464bb1L46): Removed `environment: production` from the `build-linux-x64` job configuration.
* [`.github/workflows/template-electron-build-macos.yml`](diffhunk://#diff-a752929956acec75a8f7d7e0d4b8647916db1cf4379e95d46ca356a1b27aa385L56): Removed `environment: production` from the `build-macos` job configuration.
* [`.github/workflows/template-get-update-version.yml`](diffhunk://#diff-1214f5e99fbed5de4c13b393226491884e22d1704608f34b7b3f811c3c39b22aL12): Removed `environment: production` from the `get-update-version` job configuration.
* [`.github/workflows/template-noti-discord-and-update-url-readme.yml`](diffhunk://#diff-b89e3a37b47af9b91e32f0e42c83195cf0c1b29e4eb0cfbd253bb649c93d3a3eL29): Removed `environment: production` from the `noti-discord-and-update-url-readme` job configuration.


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `environment: production` from multiple GitHub Actions workflows to simplify configuration.
> 
>   - **Workflow Configuration Updates**:
>     - Removed `environment: production` from `build-and-publish-plugins` in `publish-npm-core.yml`.
>     - Removed `environment: production` from `build-linux-x64` in `template-electron-build-linux-x64.yml`.
>     - Removed `environment: production` from `build-macos` in `template-electron-build-macos.yml`.
>     - Removed `environment: production` from `get-update-version` in `template-get-update-version.yml`.
>     - Removed `environment: production` from `noti-discord-and-update-url-readme` in `template-noti-discord-and-update-url-readme.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a4e8a34a540e0132020a934a6888d20fe7b867cb. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->