### PR TITLE
fix: update base URL for Anthropic provider

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -66,7 +66,7 @@
     "remark-math": "^6.0.0",
     "sonner": "^2.0.3",
     "tailwindcss": "^4.1.4",
-    "token.js": "npm:token.js-fork@0.7.12",
+    "token.js": "npm:token.js-fork@0.7.13",
     "tw-animate-css": "^1.2.7",
     "ulidx": "^2.4.1",
     "unified": "^11.0.5",

--- a/web-app/src/mock/data.ts
+++ b/web-app/src/mock/data.ts
@@ -62,7 +62,7 @@ export const predefinedProviders = [
   {
     active: true,
     api_key: '',
-    base_url: 'https://api.anthropic.com/v1',
+    base_url: 'https://api.anthropic.com',
     provider: 'anthropic',
     explore_models_url:
       'https://docs.anthropic.com/en/docs/about-claude/models',
@@ -87,8 +87,8 @@ export const predefinedProviders = [
           'The base endpoint to use. See the [Anthropic API documentation](https://docs.anthropic.com/en/api/messages) for more information.',
         controller_type: 'input',
         controller_props: {
-          placeholder: 'https://api.anthropic.com/v1',
-          value: 'https://api.anthropic.com/v1',
+          placeholder: 'https://api.anthropic.com',
+          value: 'https://api.anthropic.com',
         },
       },
     ],


### PR DESCRIPTION
## Describe Your Changes

- Follow up with pr #5596 that make anthropic custom base url is enable, update default base url for it 

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update default base URL for Anthropic provider and bump `token.js` version.
> 
>   - **Behavior**:
>     - Update default `base_url` for Anthropic provider in `data.ts` from `https://api.anthropic.com/v1` to `https://api.anthropic.com`.
>     - Update `placeholder` and `value` for Anthropic `base-url` setting in `data.ts` to `https://api.anthropic.com`.
>   - **Dependencies**:
>     - Update `token.js` version in `package.json` from `0.7.12` to `0.7.13`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3c9091c520228eed48bdf6b43aa20bd00a705fcf. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->