### PR TITLE
✨ enhancement: Add custom Jinja chat template option

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -17,6 +17,18 @@
     "controllerProps": { "value": true }
   },
   {
+      "key": "chat_template",
+      "title": "Custom Jinja Chat template",
+      "description": "Custom Jinja chat_template to be used for the model",
+      "controllerType": "input",
+      "controllerProps": {
+          "value": "",
+          "placeholder": "e.g., {% for message in messages %}...{% endfor %} (default is read from GGUF)",
+          "type": "text",
+          "textAlign": "right"
+      }
+  },
+  {
     "key": "threads",
     "title": "Threads",
     "description": "Number of threads to use during generation (-1 for logical cores).",

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -31,6 +31,7 @@ import { invoke } from '@tauri-apps/api/core'
 type LlamacppConfig = {
   version_backend: string
   auto_unload: boolean
+  chat_template: string
   n_gpu_layers: number
   ctx_size: number
   threads: number
@@ -483,6 +484,7 @@ export default class llamacpp_extension extends AIEngine {
     }
 
     // Add remaining options from the interface
+    if (cfg.chat_template) args.push('--chat-template', cfg.chat_template)
     args.push('-ngl', String(cfg.n_gpu_layers > 0 ? cfg.n_gpu_layers : 100))
     if (cfg.threads > 0) args.push('--threads', String(cfg.threads))
     if (cfg.threads_batch > 0)


### PR DESCRIPTION
## Describe Your Changes
Adds a new configuration option `chat_template` to the Llama.cpp extension, allowing users to define a custom Jinja chat template for the model.

The template can be provided via a new input field in the settings, and if set, it will be passed to the Llama.cpp backend using the `--chat-template` argument. This enhances flexibility for users who require specific chat formatting beyond the GGUF default.

The `chat_template` is added to the `LlamacppConfig` type and conditionally pushed to the command arguments if it's provided. The placeholder text provides an example of a Jinja template structure.

## Fixes Issues

- Closes #5668

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
