### PR TITLE
Refactor tauri conf json

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -104,20 +104,15 @@ jobs:
         run: |
           echo "Version: ${{ inputs.new_version }}"
           # Update tauri.conf.json
-          jq --arg version "${{ inputs.new_version }}" '.version = $version | .bundle.createUpdaterArtifacts = true | .bundle.resources = ["resources/pre-install/**/*"] | .bundle.externalBin = ["binaries/cortex-server", "resources/bin/uv"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version | .bundle.createUpdaterArtifacts = true' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
           mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json         
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.bundle.linux.deb.files = {"usr/bin/bun": "resources/bin/bun",
                                            "usr/lib/Jan-${{ inputs.channel }}/binaries": "binaries/deps",  
                                            "usr/lib/Jan-${{ inputs.channel }}/binaries/engines": "binaries/engines", 
-                                           "usr/lib/Jan-${{ inputs.channel }}/binaries/libvulkan.so": "binaries/libvulkan.so"}' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
-          else
-            jq '.bundle.linux.deb.files = {"usr/bin/bun": "resources/bin/bun", 
-                                           "usr/lib/Jan/binaries": "binaries/deps",
-                                           "usr/lib/Jan/binaries/engines": "binaries/engines", 
-                                           "usr/lib/Jan/binaries/libvulkan.so": "binaries/libvulkan.so"}' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
+                                           "usr/lib/Jan-${{ inputs.channel }}/binaries/libvulkan.so": "binaries/libvulkan.so"}' ./src-tauri/tauri.linux.conf.json > /tmp/tauri.linux.conf.json
+            mv /tmp/tauri.linux.conf.json ./src-tauri/tauri.linux.conf.json
           fi
-          mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -73,43 +73,5 @@
       }
     },
     "deep-link": { "schemes": ["jan"] }
-  },
-  "bundle": {
-    "active": true,
-    "targets": ["nsis", "app", "dmg", "deb", "appimage"],
-    "createUpdaterArtifacts": false,
-    "icon": [
-      "icons/32x32.png",
-      "icons/128x128.png",
-      "icons/128x128@2x.png",
-      "icons/icon.icns",
-      "icons/icon.ico"
-    ],
-    "resources": [
-      "resources/pre-install/**/*",
-      "resources/lib/",
-      "binaries/**/*"
-    ],
-    "externalBin": [
-      "binaries/cortex-server",
-      "resources/bin/bun",
-      "resources/bin/uv"
-    ],
-    "linux": {
-      "appimage": {
-        "bundleMediaFramework": false,
-        "files": {}
-      },
-      "deb": {
-        "files": {
-          "usr/bin/bun": "resources/bin/bun",
-          "usr/lib/Jan/binaries": "binaries/deps",
-          "usr/lib/Jan/binaries/engines": "binaries/engines"
-        }
-      }
-    },
-    "windows": {
-      "signCommand": "powershell -ExecutionPolicy Bypass -File ./sign.ps1 %1"
-    }
   }
 }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -1,0 +1,37 @@
+{
+  "bundle": {
+    "active": true,
+    "targets": ["deb", "appimage"],
+    "createUpdaterArtifacts": false,
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/pre-install/**/*",
+      "resources/lib/",
+      "binaries/**/*"
+    ],
+    "externalBin": [
+      "binaries/cortex-server",
+      "resources/bin/bun",
+      "resources/bin/uv"
+    ],
+    "linux": {
+      "appimage": {
+        "bundleMediaFramework": false,
+        "files": {}
+      },
+      "deb": {
+        "files": {
+          "usr/bin/bun": "resources/bin/bun",
+          "usr/lib/Jan/binaries": "binaries/deps",
+          "usr/lib/Jan/binaries/engines": "binaries/engines"
+        }
+      }
+    }
+  }
+}

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -11,13 +11,10 @@
       "icons/icon.ico"
     ],
     "resources": [
-      "resources/pre-install/**/*",
-      "resources/lib/",
-      "binaries/**/*"
+      "resources/pre-install/**/*"
     ],
     "externalBin": [
       "binaries/cortex-server",
-      "resources/bin/bun",
       "resources/bin/uv"
     ],
     "linux": {
@@ -29,7 +26,8 @@
         "files": {
           "usr/bin/bun": "resources/bin/bun",
           "usr/lib/Jan/binaries": "binaries/deps",
-          "usr/lib/Jan/binaries/engines": "binaries/engines"
+          "usr/lib/Jan/binaries/engines": "binaries/engines",
+          "usr/lib/Jan/binaries/libvulkan.so": "binaries/libvulkan.so"
         }
       }
     }

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -1,0 +1,24 @@
+{
+  "bundle": {
+    "active": true,
+    "targets": ["app", "dmg"],
+    "createUpdaterArtifacts": false,
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/pre-install/**/*",
+      "resources/lib/",
+      "binaries/**/*"
+    ],
+    "externalBin": [
+      "binaries/cortex-server",
+      "resources/bin/bun",
+      "resources/bin/uv"
+    ]
+  }
+}

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,0 +1,27 @@
+{
+  "bundle": {
+    "active": true,
+    "targets": ["nsis"],
+    "createUpdaterArtifacts": false,
+    "icon": [
+      "icons/32x32.png",
+      "icons/128x128.png",
+      "icons/128x128@2x.png",
+      "icons/icon.icns",
+      "icons/icon.ico"
+    ],
+    "resources": [
+      "resources/pre-install/**/*",
+      "resources/lib/",
+      "binaries/**/*"
+    ],
+    "externalBin": [
+      "binaries/cortex-server",
+      "resources/bin/bun",
+      "resources/bin/uv"
+    ],
+    "windows": {
+      "signCommand": "powershell -ExecutionPolicy Bypass -File ./sign.ps1 %1"
+    }
+  }
+}


### PR DESCRIPTION
## Describe Your Changes

Part of #5641,  Allows for better per platform default config. Currently the default serves windows/macos fine while it has to be tweaked in order to build for linux. Specifically, the default values for resource bundling causes `make build-tauri` to choke because it wants to pull in dependencies which release builds do not ship and may not exist on the build system. This PR splits platform specific config out of tauri.conf.json in per platform conf files, updates tauri.linux.conf.json with better defaults which reflect how releases are actually packaged, and simplifies the github workflow to reflect the improved defaults.

## Self Checklist

- [X] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
