### PR TITLE
chore: add coverage report comment

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -42,6 +42,8 @@ jobs:
     continue-on-error: true
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.base_ref }}
       - name: Use Node.js 20.x
         uses: actions/setup-node@v3
         with:
@@ -65,17 +67,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: ref-lcov.info
-          path: ./coverage/merged/lcov.info
-
-      - name: Generate Code Coverage report
-        id: code-coverage
-        uses: barecheck/code-coverage-action@v1
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          lcov-file: './coverage/merged/lcov.info'
-          base-lcov-file: './coverage/merged/lcov.info'
-          send-summary-comment: true
-          show-annotations: 'warning'
+          path: coverage/merged/lcov.info
 
   test-on-macos:
     runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'macos-latest' || 'macos-selfhosted-12-arm64' }}
@@ -231,3 +223,45 @@ jobs:
           name: playwright-report
           path: electron/playwright-report/
           retention-days: 2
+
+  coverage-check:
+    runs-on: ubuntu-latest
+    needs: base_branch_cov
+    continue-on-error: true
+    steps:
+      - name: Getting the repo
+        uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
+
+      - name: Installing node
+        uses: actions/setup-node@v3
+        with:
+          node-version: 20
+      - name: 'Cleanup cache'
+        continue-on-error: true
+        run: |
+          rm -rf ~/jan
+          make clean
+
+      - name: Install dependencies
+        run: |
+          make lint
+
+      - name: Run test coverage
+        run: |
+          yarn test:coverage
+
+      - name: Download code coverage report from base branch
+        uses: actions/download-artifact@v4
+        with:
+          name: ref-lcov.info
+      - name: Generate Code Coverage report
+        id: code-coverage
+        uses: barecheck/code-coverage-action@v1
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          lcov-file: './coverage/merged/lcov.info'
+          base-lcov-file: './lcov.info'
+          send-summary-comment: true
+          show-annotations: 'warning'


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for linting, testing, and code coverage. The changes include improvements to how the repository is checked out, adjustments to artifact paths, and the addition of a new job to handle code coverage checks.

### Workflow improvements:

* [`.github/workflows/jan-linter-and-test.yml`](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3R45-R46): Updated the `actions/checkout` step to use the base branch reference (`github.base_ref`) for more accurate context during pull request builds.

* [`.github/workflows/jan-linter-and-test.yml`](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L68-R70): Adjusted the artifact upload path for the code coverage report to `coverage/merged/lcov.info` for consistency.

### Code coverage enhancements:

* [`.github/workflows/jan-linter-and-test.yml`](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3L68-R70): Removed the inline code coverage report generation from the base workflow to streamline the main process.

* [`.github/workflows/jan-linter-and-test.yml`](diffhunk://#diff-ae1c9bf4040629dc6730513192796061ca97b703eeeda939ca59dfa912c39af3R226-R267): Added a new `coverage-check` job that runs independently to generate and compare code coverage reports. This job includes steps for repository checkout, dependency installation, and using the `barecheck/code-coverage-action` to provide detailed coverage feedback.