### PR TITLE
🐛fix: think tag auto expand like tool tag behavior

### DIFF
--- a/web-app/src/containers/ThinkingBlock.tsx
+++ b/web-app/src/containers/ThinkingBlock.tsx
@@ -12,27 +12,30 @@ interface Props {
 // Zustand store for thinking block state
 type ThinkingBlockState = {
   thinkingState: { [id: string]: boolean }
-  toggleState: (id: string) => void
+  setThinkingState: (id: string, expanded: boolean) => void
 }
 
 const useThinkingStore = create<ThinkingBlockState>((set) => ({
   thinkingState: {},
-  toggleState: (id) =>
+  setThinkingState: (id, expanded) =>
     set((state) => ({
       thinkingState: {
         ...state.thinkingState,
-        [id]: !state.thinkingState[id],
+        [id]: expanded,
       },
     })),
 }))
 
 const ThinkingBlock = ({ id, text }: Props) => {
-  const { thinkingState, toggleState } = useThinkingStore()
+  const { thinkingState, setThinkingState } = useThinkingStore()
   const { streamingContent } = useAppState()
   const { t } = useTranslation()
   const loading = !text.includes('</think>') && streamingContent
-  const isExpanded = thinkingState[id] ?? false
-  const handleClick = () => toggleState(id)
+  const isExpanded = thinkingState[id] ?? (loading ? true : false)
+  const handleClick = () => {
+    const newExpandedState = !isExpanded
+    setThinkingState(id, newExpandedState)
+  }
 
   if (!text.replace(/<\/?think>/g, '').trim()) return null
 


### PR DESCRIPTION
## Describe Your Changes
Auto expand Think block like tools block

## Fixes Issues

https://github.com/user-attachments/assets/a91e60ad-ee1b-430e-b5b5-0fae1d5e82b1

- Closes #5725 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> `ThinkingBlock` now auto-expands when loading, using `setThinkingState` for explicit state control.
> 
>   - **Behavior**:
>     - `ThinkingBlock` auto-expands when loading, similar to tools block behavior.
>     - Replaces `toggleState` with `setThinkingState` in `useThinkingStore` to control expanded state explicitly.
>     - `isExpanded` now defaults to `true` if loading, otherwise `false`.
>   - **Functions**:
>     - `setThinkingState(id, expanded)` replaces `toggleState(id)` in `useThinkingStore`.
>     - `handleClick` in `ThinkingBlock` toggles expanded state using `setThinkingState`.
>   - **Misc**:
>     - Closes #5725.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 93227f32888e7cb649a4c262325d50025bf31087. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->