### PR TITLE
chore: disable coverage check for external contributor pr

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -38,6 +38,7 @@ on:
 
 jobs:
   base_branch_cov:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     continue-on-error: true
     steps:
@@ -225,6 +226,7 @@ jobs:
           retention-days: 2
 
   coverage-check:
+    if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository
     runs-on: ubuntu-latest
     needs: base_branch_cov
     continue-on-error: true


### PR DESCRIPTION
This pull request updates the `.github/workflows/jan-linter-and-test.yml` file to add conditional checks for when certain jobs should run, ensuring they only execute for pull requests originating from the same repository.

Workflow condition updates:

* Added an `if` condition to the `base_branch_cov` job to ensure it only runs for pull requests where the source repository matches the target repository (`github.event.pull_request.head.repo.full_name == github.repository`).
* Added an `if` condition to the `coverage-check` job with the same repository matching logic as above, ensuring consistency in job execution criteria.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conditional checks to `jan-linter-and-test.yml` to run `base_branch_cov` and `coverage-check` jobs only for PRs from the same repository.
> 
>   - **Workflow Condition Updates**:
>     - Add `if` condition to `base_branch_cov` job in `jan-linter-and-test.yml` to run only if PR source repo matches target repo.
>     - Add `if` condition to `coverage-check` job with same repo matching logic for consistent execution criteria.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 0c8b3fb12585c0049eda33e94c2e8d0bdc7f3532. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->