### PR TITLE
fix: vitest config - coverage lcov

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -5,9 +5,13 @@ export default defineConfig({
     projects: [
       // Core package - use its own vitest config
       './core',
-      
-      // Web-app package - use its own vitest config  
-      './web-app'
-    ]
-  }
+
+      // Web-app package - use its own vitest config
+      './web-app',
+    ],
+    coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov'],
+    },
+  },
 })


### PR DESCRIPTION
This pull request adds code coverage configuration to the Vitest setup in the `vitest.config.ts` file. The change specifies the coverage provider and output formats.

Testing configuration updates:

* [`vitest.config.ts`](diffhunk://#diff-2ee894bf23aa44ff4ce12a3da8af19ab20180474ebf2176dbe5f2eea3f96dc92L10-R16): Added a `coverage` section to the Vitest configuration, specifying `v8` as the coverage provider and enabling multiple reporters (`text`, `json`, `html`, and `lcov`) for coverage outputs.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds code coverage configuration to `vitest.config.ts` with `v8` provider and multiple reporters.
> 
>   - **Configuration**:
>     - Adds `coverage` section in `vitest.config.ts`.
>     - Sets `v8` as the coverage provider.
>     - Enables `text`, `json`, `html`, and `lcov` reporters for coverage outputs.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 09a45baa5d297d829f2bfd614a81b5ffd999104e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->