### PR TITLE
docs: Add Instruction for Toggling Experimental Features Before Toggling MCP Servers

### DIFF
--- a/docs/src/pages/docs/mcp.mdx
+++ b/docs/src/pages/docs/mcp.mdx
@@ -124,7 +124,7 @@ you will need to wait for a response). Efficient management of tools and their o
 
 To illustrate how MCPs can be used within Jan, we will walk through an example using the [Browser MCP](https://browsermcp.io/).
 
-Before we begin, you will need to enable Jan's MCP functionality at `Settings` > `MCP Servers`, and toggle
+Before we begin, you will need to enable experimental features at `General` > `Advanced`. Next, go to `Settings` > `MCP Servers`, and toggle
 the `Allow All MCP Tool Permission` switch ON.
 
 ![Turn on the MCP Host](./_assets/mcp-on.png)


### PR DESCRIPTION
## Describe Your Changes
I added an instruction that tells users to toggle experimental features first. t. Without it, the MCP Servers tab won't appear.

## Fixes Issues
N/A

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
