### PR TITLE
feat: add streamable-http transport support

### DIFF
--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,8 +19,10 @@ tauri-build = { version = "2.0.2", features = [] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
 log = "0.4"
-tauri = { version = "2.5.0", features = [ "protocol-asset", "macos-private-api",
-    "test"
+tauri = { version = "2.5.0", features = [
+    "protocol-asset",
+    "macos-private-api",
+    "test",
 ] }
 tauri-plugin-log = "2.0.0-rc"
 tauri-plugin-shell = "2.2.0"
@@ -34,8 +36,9 @@ tauri-plugin-store = "2"
 hyper = { version = "0.14", features = ["server"] }
 reqwest = { version = "0.11", features = ["json", "blocking", "stream"] }
 tokio = { version = "1", features = ["full"] }
-rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", rev = "3196c95f1dfafbffbdcdd6d365c94969ac975e6a", features = [
+rmcp = { git = "https://github.com/modelcontextprotocol/rust-sdk", branch = "main", features = [
     "client",
+    "transport-streamable-http-client",
     "transport-sse-client",
     "transport-child-process",
     "tower",
@@ -65,7 +68,7 @@ libc = "0.2.172"
 windows-sys = { version = "0.60.2", features = [
     "Win32_Foundation",
     "Win32_System_Console",
-    "Win32_System_Threading" # for using CreateProcess flags like CREATE_NEW_PROCESS_GROUP
+    "Win32_System_Threading", # for using CreateProcess flags like CREATE_NEW_PROCESS_GROUP
 ] }
 
 [target.'cfg(not(any(target_os = "android", target_os = "ios")))'.dependencies]


### PR DESCRIPTION
# Streamable-HTTP Transport for MCP in Jan

## Overview

The **Streamable-HTTP Transport** is a new transport support added to Jan's MCP (Model Context Protocol) implementation that enables connecting to remote MCP servers over HTTP/HTTPS. This transport extends Jan's existing process-based MCP support to include network-based MCP servers, allowing for more flexible and scalable integrations.

## What is Streamable-HTTP?

Streamable-HTTP is a transport protocol that allows MCP clients to communicate with MCP servers over HTTP connections. Unlike traditional request-response HTTP patterns, it supports streaming communication, making it ideal for real-time tool interactions and long-running operations.

### Key Features

- **HTTP/HTTPS Support**: Connect to MCP servers hosted anywhere on the internet
- **Custom Headers**: Support for authentication and custom HTTP headers
- **Streaming Communication**: Efficient real-time data exchange
- **Automatic Connection Management**: Built-in health monitoring and reconnection
- **Seamless Integration**: Works alongside existing process-based MCP servers

## Architecture Overview

```
┌─────────────────┐    HTTP/HTTPS   ┌──────────────────┐
│                 │ ◄─────────────► │                  │
│   Jan Client    │                 │   Remote MCP     │
│                 │   Streamable    │     Server       │
│                 │     HTTP        │                  │
└─────────────────┘                 └──────────────────┘
```

Jan's MCP system supports two transport types:

1. **Process-based (stdio)** (`TokioChildProcess`) - For local MCP servers
2. **HTTP-based** (`StreamableHttpClientTransport`) - For remote MCP servers

## Implementation Details

### Transport Detection

The system automatically detects the transport type based on the `command` field in the MCP configuration:

```rust
if command.starts_with("http://") || command.starts_with("https://") {
    // Use StreamableHttpClientTransport
    let transport = StreamableHttpClientTransport::with_client(/* ... */);
} else {
    // Use TokioChildProcess for local commands
    let process = TokioChildProcess::new(cmd);
}
```

### HTTP Client Configuration

The transport uses a customized `reqwest` HTTP client with header support:

```rust
let transport = StreamableHttpClientTransport::with_client(
    reqwest::Client::builder()
        .default_headers({
            let mut headers = reqwest::header::HeaderMap::new();
            // Map environment variables to HTTP headers
            for (key, value) in envs.iter() {
                if let Some(v_str) = value.as_str() {
                    let header_name = reqwest::header::HeaderName::from_bytes(key.as_bytes());
                    if let Ok(header_name) = header_name {
                        if let Ok(header_value) = reqwest::header::HeaderValue::from_str(v_str) {
                            headers.insert(header_name, header_value);
                        }
                    }
                }
            }
            headers
        })
        .build()
        .unwrap(),
    StreamableHttpClientTransportConfig {
        uri: command.into(),
        ..Default::default()
    },
);
```

### Service Initialization

HTTP-based MCP servers require initialization with client information:

```rust
let client_info = ClientInfo {
    protocol_version: Default::default(),
    capabilities: ClientCapabilities::default(),
    client_info: Implementation {
        name: "Jan Streamable Client".to_string(),
        version: "0.0.1".to_string(),
    },
};
let client = client_info.serve(transport).await?;
```

### Service Management

The implementation uses `RunningServiceEnum` to handle both transport types:

```rust
pub enum RunningServiceEnum {
    NoInit(RunningService<RoleClient, ()>),           // Process-based
    WithInit(RunningService<RoleClient, InitializeRequestParam>), // HTTP-based
}
```

## Configuration

### Basic HTTP Server Configuration

```json
{
  "mcpServers": {
    "my-http-server": {
      "command": "https://my-mcp-server.com/mcp",
      "args": [],
      "env": {
        "Authorization": "Bearer token123",
        "X-Custom-Header": "value"
      },
      "active": true
    }
  }
}
```

<img width="2272" height="1824" alt="CleanShot 2025-07-14 at 17 40 01@2x" src="https://github.com/user-attachments/assets/6a5a11ce-505d-4410-bb2e-7e2ef8db65d2" />


### Local Development Server

```json
{
  "mcpServers": {
    "local-dev": {
      "command": "http://localhost:8080/mcp",
      "args": [],
      "env": {
        "X-API-Key": "dev-key-123"
      },
      "active": true
    }
  }
}
```

## Headers and Authentication

Environment variables in the MCP configuration are automatically mapped to HTTP headers:

- **Key**: Environment variable name becomes the HTTP header name
- **Value**: Environment variable value becomes the HTTP header value
- **Case Handling**: Header names are processed case-insensitively
- **Authentication**: Common patterns like `Authorization: Bearer token` are supported

## Monitoring and Health Checks

HTTP-based MCP servers benefit from the same health monitoring as process-based servers:

- **Health Check Interval**: 5 seconds
- **Automatic Restart**: Exponential backoff (500ms to 30s)
- **Maximum Restarts**: 5 attempts (configurable)
- **Connection Verification**: Server must pass verification after connection

## Error Handling

```rust
match client {
    Ok(client) => {
        log::info!("Connected to server: {:?}", client.peer_info());
        servers.lock().await.insert(name.clone(), RunningServiceEnum::WithInit(client));
        
        // Mark as successfully connected
        let mut connected = app_state.mcp_successfully_connected.lock().await;
        connected.insert(name.clone(), true);
    }
    Err(e) => {
        log::error!("Failed to connect to server: {}", e);
        return Err(format!("Failed to connect to server: {}", e));
    }
}
```

## Architecture Diagram

```
┌─────────────────────────────────────────────────────────────────┐
│                          Jan Application                         │
├─────────────────────────────────────────────────────────────────┤
│                       MCP Manager                               │
│  ┌─────────────────┐  ┌─────────────────┐  ┌─────────────────┐ │
│  │  Server State   │  │ Health Monitor  │  │  Config Manager │ │
│  │   Management    │  │   & Restart     │  │                 │ │
│  └─────────────────┘  └─────────────────┘  └─────────────────┘ │
├─────────────────────────────────────────────────────────────────┤
│                    RunningServiceEnum                           │
│  ┌─────────────────┐                    ┌─────────────────┐    │
│  │     NoInit      │                    │    WithInit     │    │
│  │   (Process)     │                    │    (HTTP)       │    │
│  └─────────────────┘                    └─────────────────┘    │
├─────────────────────────────────────────────────────────────────┤
│                    Transport Layer                              │
│  ┌─────────────────┐                    ┌─────────────────┐    │
│  │TokioChildProcess│                    │StreamableHttp   │    │
│  │    Transport    │                    │ClientTransport  │    │
│  └─────────────────┘                    └─────────────────┘    │
├─────────────────────────────────────────────────────────────────┤
│                      Connection                                 │
│  ┌─────────────────┐                    ┌─────────────────┐    │
│  │   Local MCP     │                    │   Remote MCP    │    │
│  │    Process      │                    │  HTTP Server    │    │
│  │                 │                    │                 │    │
│  │ ┌─────────────┐ │                    │ ┌─────────────┐ │    │
│  │ │ filesystem  │ │                    │ │   Custom    │ │    │
│  │ │    tools    │ │                    │ │   API Tools │ │    │
│  │ └─────────────┘ │                    │ └─────────────┘ │    │
│  └─────────────────┘                    └─────────────────┘    │
└─────────────────────────────────────────────────────────────────┘
```

## Usage Examples

### Setting up a Remote MCP Server

1. **Add Server Configuration**:
   ```json
   {
     "command": "https://api.example.com/mcp",
     "env": {
       "Authorization": "Bearer your-token-here",
       "X-Client-Version": "1.0.0"
     }
   }
   ```

2. **Server Activation**: Jan automatically detects the HTTP URL and uses the streamable-HTTP transport

3. **Tool Discovery**: The client lists available tools from the remote server

4. **Tool Execution**: Tools are called with streaming support for real-time responses

### Comparison with Process-based MCP

| Feature | Process-based | HTTP-based |
|---------|---------------|------------|
| **Location** | Local machine | Remote server |
| **Startup** | Spawn process | HTTP connection |
| **Authentication** | ❌ | HTTP headers |

## Security Considerations

- **HTTPS**: Always use HTTPS in production
- **Authentication**: Implement proper token-based authentication
- **Headers**: Sensitive data in headers is transmitted securely
- **Rate Limiting**: Consider implementing rate limiting on server side
- **Input Validation**: Validate all tool parameters on server side

## Issues
- Closes #5754 

## Action Items
- [x] Add tests
- [ ] Enhance configuration dialog