### PR TITLE
🐛fix: download icon when left panel close

### DIFF
--- a/src-tauri/binaries/download.bat
+++ b/src-tauri/binaries/download.bat
@@ -1,7 +1,7 @@
 @echo off
 
 set CORTEX_VERSION=1.0.14
-set ENGINE_VERSION=b5509
+set ENGINE_VERSION=b5857
 set ENGINE_DOWNLOAD_URL=https://github.com/menloresearch/llama.cpp/releases/download/%ENGINE_VERSION%/llama-%ENGINE_VERSION%-bin-win
 set ENGINE_DOWNLOAD_GGML_URL=https://github.com/ggml-org/llama.cpp/releases/download/%ENGINE_VERSION%/llama-%ENGINE_VERSION%-bin-win
 set CUDA_DOWNLOAD_URL=https://github.com/menloresearch/llama.cpp/releases/download/%ENGINE_VERSION%
@@ -35,7 +35,7 @@ for %%F in (%SUBFOLDERS%) do (
 
     @REM Move cu*.dll files
     for %%D in (.\engines\engines\llama.cpp\%%F\%ENGINE_VERSION%\cu*.dll) do (
-        move "%%D" "%BIN_PATH%"        
+        move "%%D" "%BIN_PATH%"
     )
 )
 

--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -258,7 +258,7 @@ export function DownloadManagement() {
               <div className="fixed bottom-4 left-4 z-50 size-10 bg-main-view border-2 border-main-view-fg/10 rounded-full shadow-md cursor-pointer flex items-center justify-center">
                 <div className="relative">
                   <IconDownload
-                    className="text-left-panel-fg/50 -mt-1"
+                    className="text-main-view-fg/50 -mt-1"
                     size={20}
                   />
                   <div className="bg-primary font-bold size-5 rounded-full absolute -top-4 -right-4 flex items-center justify-center text-primary-fg">

--- a/web-app/src/containers/dialogs/ToolApproval.tsx
+++ b/web-app/src/containers/dialogs/ToolApproval.tsx
@@ -10,7 +10,6 @@ import { Button } from '@/components/ui/button'
 import { useToolApproval } from '@/hooks/useToolApproval'
 import { AlertTriangle } from 'lucide-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
-import { Trans } from 'react-i18next'
 
 export default function ToolApproval() {
   const { t } = useTranslation()
@@ -52,11 +51,8 @@ export default function ToolApproval() {
             <div>
               <DialogTitle>{t('tools:toolApproval.title')}</DialogTitle>
               <DialogDescription className="mt-1 text-main-view-fg/70">
-                <Trans
-                  i18nKey="tools:toolApproval.description"
-                  values={{ toolName }}
-                  components={{ strong: <strong className="font-semibold" /> }}
-                />
+                {t('tools:toolApproval.description')}{' '}
+                <span className="font-semibold">{toolName}</span>
               </DialogDescription>
             </div>
           </div>

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -1,7 +1,7 @@
 {
   "assistants": "Assistants",
   "hardware": "Hardware",
-  "mcp-servers": "Mcp Servers",
+  "mcp-servers": "MCP Servers",
   "local_api_server": "Local API Server",
   "https_proxy": "HTTPS Proxy",
   "extensions": "Extensions",

--- a/web-app/src/locales/en/tools.json
+++ b/web-app/src/locales/en/tools.json
@@ -1,8 +1,8 @@
 {
   "toolApproval": {
     "title": "Tool Approval Required",
-    "description": "The assistant wants to use <strong>{{toolName}}</strong>",
-    "securityNotice": "This tool wants to perform an action. Please review and approve.",
+    "description": "The assistant wants to use",
+    "securityNotice": "Malicious tools or conversation content could potentially trick the assistant into attempting harmful actions. Review each tool call carefully before approving.",
     "deny": "Deny",
     "allowOnce": "Allow Once",
     "alwaysAllow": "Always Allow"

--- a/web-app/src/locales/id/tool-approval.json
+++ b/web-app/src/locales/id/tool-approval.json
@@ -1,7 +1,7 @@
 {
   "title": "Permintaan Panggilan Alat",
   "description": "Asisten ingin menggunakan alat: <strong>{{toolName}}</strong>",
-  "securityNotice": "<strong>Pemberitahuan Keamanan:</strong> Alat berbahaya atau konten percakapan berpotensi menipu asisten untuk mencoba tindakan berbahaya. Tinjau setiap panggilan alat dengan cermat sebelum menyetujui.",
+  "securityNotice": "<strong>Pemberitahuan Keamanan:</strong> Alat berbahaya atau konten percakapan dapat menipu asisten untuk mencoba melakukan tindakan yang merugikan. Tinjau setiap permintaan penggunaan alat dengan cermat sebelum menyetujui.",
   "deny": "Tolak",
   "allowOnce": "Izinkan Sekali",
   "alwaysAllow": "Selalu Izinkan",

--- a/web-app/src/locales/vn/common.json
+++ b/web-app/src/locales/vn/common.json
@@ -1,7 +1,7 @@
 {
   "assistants": "Trợ lý",
   "hardware": "Phần cứng",
-  "mcp-servers": "Máy chủ Mcp",
+  "mcp-servers": "Máy chủ MCP",
   "local_api_server": "Máy chủ API cục bộ",
   "https_proxy": "Proxy HTTPS",
   "extensions": "Tiện ích mở rộng",

--- a/web-app/src/routes/settings/general.tsx
+++ b/web-app/src/routes/settings/general.tsx
@@ -5,7 +5,6 @@ import HeaderPage from '@/containers/HeaderPage'
 import { Switch } from '@/components/ui/switch'
 import { Button } from '@/components/ui/button'
 import { Card, CardItem } from '@/containers/Card'
-import LanguageSwitcher from '@/containers/LanguageSwitcher'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 import { useAppUpdater } from '@/hooks/useAppUpdater'
@@ -239,10 +238,10 @@ function General() {
                   </Button>
                 }
               />
-              <CardItem
+              {/* <CardItem
                 title={t('common:language')}
                 actions={<LanguageSwitcher />}
-              />
+              /> */}
             </Card>
 
             {/* Advanced */}


### PR DESCRIPTION
## Describe Your Changes

<img width="116" height="153" alt="Screenshot 2025-07-15 at 09 37 40" src="https://github.com/user-attachments/assets/d5abd084-991f-4919-a549-3ef52d55363b" />


The current icon color will follow the left panel foreground color is incorrect. The correct behavior is that the icon color should follow the main view foreground color, because the download icon floats on top of the main view color when the left panel is collapsed.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix download icon color in `DownloadManagement.tsx` and update `ENGINE_VERSION` in `download.bat`, with minor localization and code cleanup.
> 
>   - **UI Fix**:
>     - In `DownloadManagement.tsx`, change download icon color from `text-left-panel-fg/50` to `text-main-view-fg/50` when the left panel is closed.
>   - **Script Update**:
>     - Update `ENGINE_VERSION` in `download.bat` from `b5509` to `b5857`.
>   - **Localization**:
>     - Remove unused import `Trans` in `ToolApproval.tsx`.
>     - Update `toolApproval.description` in `tools.json` and `tool-approval.json`.
>     - Fix capitalization in `common.json` for `mcp-servers` in English and Vietnamese locales.
>   - **Miscellaneous**:
>     - Comment out `LanguageSwitcher` in `general.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 08fe2c27fd4c6f540250f3aefdb70b3564d05df0. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->