### PR TITLE
fix: change installationmode in nsis template

### DIFF
--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -33,7 +33,7 @@ ${StrLoc}
 !define VERSION "jan_version"
 !define VERSIONWITHBUILD "jan_build"
 !define HOMEPAGE ""
-!define INSTALLMODE "both"
+!define INSTALLMODE "currentUser"
 !define LICENSE ""
 !define INSTALLERICON "D:\a\jan\jan\src-tauri\icons\icon.ico"
 !define SIDEBARIMAGE ""


### PR DESCRIPTION
This pull request includes a small change to the `src-tauri/tauri.bundle.windows.nsis.template` file. The `INSTALLMODE` has been updated to use "currentUser" instead of "both" to modify the installation mode.