### PR TITLE
set line number userSelect to none so that code can be copied without line number

### DIFF
--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -79,6 +79,16 @@ function RenderMarkdownComponent({
 
         return !isInline && !isUser ? (
           <div className="relative overflow-hidden border rounded-md border-main-view-fg/2">
+            <style>
+              {`
+              .react-syntax-highlighter-line-number {
+                user-select: none;
+                -webkit-user-select: none;
+                -moz-user-select: none;
+                -ms-user-select: none;
+              }
+            `}
+            </style>
             <div className="flex items-center justify-between px-4 py-2 bg-main-view/10">
               <span className="font-medium text-xs font-sans">
                 {getReadableLanguageName(language)}


### PR DESCRIPTION
## Describe Your Changes

- Add CSS to prevent line numbers from being selected in code markdown blocks
- Couldn't use the react syntax highlighter style property because it's broken https://github.com/react-syntax-highlighter/react-syntax-highlighter/issues/389 and the library seems to currently be unmaintained

## Fixes Issues

- when code block generated, line numbers are part of selected text and so end up in any pasted text

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
