### PR TITLE
fix: fetch models from custom provider causes app to crash

### DIFF
--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -36,7 +36,16 @@ export const useModelProvider = create<ModelProviderState>()(
       },
       setProviders: (providers) =>
         set((state) => {
-          const existingProviders = state.providers
+          const existingProviders = state.providers.map((provider) => {
+            return {
+              ...provider,
+              models: provider.models.filter(
+                (e) =>
+                  ('id' in e || 'model' in e) &&
+                  typeof (e.id ?? e.model) === 'string'
+              ),
+            }
+          })
           // Ensure deletedModels is always an array
           const currentDeletedModels = Array.isArray(state.deletedModels)
             ? state.deletedModels
@@ -46,11 +55,17 @@ export const useModelProvider = create<ModelProviderState>()(
             const existingProvider = existingProviders.find(
               (x) => x.provider === provider.provider
             )
-            const models = existingProvider?.models || []
+            const models = (existingProvider?.models || []).filter(
+              (e) =>
+                ('id' in e || 'model' in e) &&
+                typeof (e.id ?? e.model) === 'string'
+            )
             const mergedModels = [
               ...models,
               ...(provider?.models ?? []).filter(
                 (e) =>
+                  ('id' in e || 'model' in e) &&
+                  typeof (e.id ?? e.model) === 'string' &&
                   !models.some((m) => m.id === e.id) &&
                   !currentDeletedModels.includes(e.id)
               ),

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -210,7 +210,9 @@ export const fetchModelsFromProvider = async (
       return data.data.map((model: { id: string }) => model.id).filter(Boolean)
     } else if (Array.isArray(data)) {
       // Direct array format: ["model-id1", "model-id2", ...]
-      return data.filter(Boolean)
+      return data
+        .filter(Boolean)
+        .map((model) => ('id' in model ? model.id : model))
     } else if (data.models && Array.isArray(data.models)) {
       // Alternative format: { models: [...] }
       return data.models


### PR DESCRIPTION
This pull request refines the handling of model data in `useModelProvider` and `fetchModelsFromProvider` to ensure robustness and consistency in filtering and mapping operations. The changes primarily focus on validating model structures and improving data processing logic.

Fixes #5785 

<img width="2272" height="1824" alt="CleanShot 2025-07-16 at 15 37 31@2x" src="https://github.com/user-attachments/assets/2f9178a4-8d26-4b83-9f1e-a06d10266b0f" />


### Enhancements to model filtering and validation:

* [`web-app/src/hooks/useModelProvider.ts`](diffhunk://#diff-5772464d4bc561fb171cab27635acf929619b7a350e0518ecd7a216df993f73fL39-R48): Updated the `setProviders` method to ensure all models in `existingProviders` are filtered based on the presence of valid `id` or `model` properties and their types. This prevents invalid models from being included in the state.
* [`web-app/src/hooks/useModelProvider.ts`](diffhunk://#diff-5772464d4bc561fb171cab27635acf929619b7a350e0518ecd7a216df993f73fL49-R68): Improved the merging logic for models in `setProviders` by applying the same validation checks to both `existingProvider.models` and `provider.models`. This ensures only valid models are merged while avoiding duplicates and respecting deleted models.

### Improvements to data mapping in model fetching:

* [`web-app/src/services/providers.ts`](diffhunk://#diff-0000268145d26670fb69e7dd6741d904ce607b3406f963188b5f5f0f38ce0ff3L213-R215): Enhanced the `fetchModelsFromProvider` function to handle cases where model objects may have an `id` property, mapping them appropriately while maintaining backward compatibility with simpler array formats.