### PR TITLE
refactor: move thinking toggle to runtime settings for dynamic control

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -98,6 +98,11 @@ export interface chatCompletionRequest {
   samplers?: string[] | null
   timings_per_token?: boolean | null
   post_sampling_probs?: boolean | null
+  chat_template_kwargs?: chat_template_kdict | null
+}
+
+export interface chat_template_kdict {
+  enable_thinking: false
 }
 
 export interface chatCompletionChunkChoiceDelta {

--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -492,18 +492,5 @@
       "placeholder": "path/to/schema.json",
       "type": "text"
     }
-  },
-  {
-    "key": "reasoning_budget",
-    "title": "controls the amount of thinking allowed; currently only one of: -1 for unrestricted thinking budget, or 0 to disable thinking (default: -1)",
-    "description": "Mirostat target entropy (tau).",
-    "controllerType": "input",
-    "controllerProps": {
-      "value": 0,
-      "options": [
-        { "value": -1, "name": "unrestricted thinking budget" },
-        { "value": 0, "name": "disable thinking" }
-      ]
-    }
   }
 ]

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -853,7 +853,6 @@ export default class llamacpp_extension extends AIEngine {
       args.push('--rope-scale', String(cfg.rope_scale))
       args.push('--rope-freq-base', String(cfg.rope_freq_base))
       args.push('--rope-freq-scale', String(cfg.rope_freq_scale))
-      args.push('--reasoning-budget', String(cfg.reasoning_budget))
     }
 
     console.log('Calling Tauri command llama_load with args:', args)

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -25,7 +25,6 @@ import {
   downloadBackend,
   isBackendInstalled,
   getBackendExePath,
-  getBackendDir,
 } from './backend'
 import { invoke } from '@tauri-apps/api/core'
 
@@ -56,7 +55,6 @@ type LlamacppConfig = {
   rope_scale: number
   rope_freq_base: number
   rope_freq_scale: number
-  reasoning_budget: number
   ctx_shift: boolean
 }
 


### PR DESCRIPTION
### 📝 **Pull Request Description**

This PR refactors the way "thinking mode" is controlled in compatible models (e.g., **Jan-nano**, **Qwen3**) by making it part of the runtime request payload.

### ✅ What’s Changed:

* ❌ Removed static `reasoning_budget` from `settings.json` and `LlamacppConfig`.
* ✅ Introduced `chat_template_kwargs.enable_thinking` inside `chatCompletionRequest`, allowing per-request toggling.
* ✂️ Cleaned up unused backend config reference (`getBackendDir`).

### 🧠 Why It Matters:

Previously, enabling or disabling **thinking mode** was only possible at engine startup via a static setting. With this change it enables **dynamically toggle thinking mode mid-conversation** by attaching `chat_template_kwargs` to the payload.

Requires a UI update!
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor thinking mode control to be dynamic per request by adding `chat_template_kwargs.enable_thinking` and removing static `reasoning_budget`.
> 
>   - **Behavior**:
>     - Removed static `reasoning_budget` from `settings.json` and `LlamacppConfig`.
>     - Added `chat_template_kwargs.enable_thinking` to `chatCompletionRequest` in `AIEngine.ts` for per-request control.
>   - **Code Cleanup**:
>     - Removed unused `getBackendDir` reference in `index.ts`.
>   - **Impact**:
>     - Enables dynamic toggling of thinking mode during runtime, requiring a UI update.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d1ec1c503aa699731503ddeeba8b29bccec2604a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->