### PR TITLE
fix: Add --reasoning-format none to support rendering of reasoning content

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -799,6 +799,7 @@ export default class llamacpp_extension extends AIEngine {
       modelConfig.model_path,
     ])
     args.push('--jinja')
+    args.push('--reasoning-format', 'none')
     args.push('-m', modelPath)
     args.push('-a', modelId)
     args.push('--port', String(port))


### PR DESCRIPTION
This change enables Jan to render reasoning content which it normally parses using non deepseek style <think></think> tags.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `--reasoning-format none` argument in `index.ts` to disable reasoning content rendering.
> 
>   - **Behavior**:
>     - Adds `--reasoning-format none` argument in `load()` method in `index.ts` to disable reasoning content rendering.
>   - **Misc**:
>     - No other files or functions are affected by this change.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a8d1d2bce65db23a52ab2854dc651ee816ff856b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->