### PR TITLE
refactor: simplify proxy settings by removing unused SSL verification options

### DIFF
--- a/src-tauri/src/core/utils/download.rs
+++ b/src-tauri/src/core/utils/download.rs
@@ -23,10 +23,6 @@ pub struct ProxyConfig {
     pub password: Option<String>,
     pub no_proxy: Option<Vec<String>>, // List of domains to bypass proxy
     pub ignore_ssl: Option<bool>,      // Ignore SSL certificate verification
-    pub verify_proxy_ssl: Option<bool>, // Verify proxy SSL certificate
-    pub verify_proxy_host_ssl: Option<bool>, // Verify proxy host SSL certificate
-    pub verify_peer_ssl: Option<bool>, // Verify peer SSL certificate
-    pub verify_host_ssl: Option<bool>, // Verify host SSL certificate
 }
 
 #[derive(serde::Deserialize, Clone, Debug)]
@@ -456,10 +452,6 @@ mod tests {
             password: None,
             no_proxy: None,
             ignore_ssl: None,
-            verify_proxy_ssl: None,
-            verify_proxy_host_ssl: None,
-            verify_peer_ssl: None,
-            verify_host_ssl: None,
         }
     }
 
@@ -472,10 +464,6 @@ mod tests {
             password: Some("pass".to_string()),
             no_proxy: Some(vec!["localhost".to_string(), "*.example.com".to_string()]),
             ignore_ssl: Some(true),
-            verify_proxy_ssl: Some(false),
-            verify_proxy_host_ssl: Some(false),
-            verify_peer_ssl: Some(false),
-            verify_host_ssl: Some(false),
         };
         assert!(validate_proxy_config(&config).is_ok());
 
@@ -486,10 +474,6 @@ mod tests {
             password: None,
             no_proxy: None,
             ignore_ssl: None,
-            verify_proxy_ssl: None,
-            verify_proxy_host_ssl: None,
-            verify_peer_ssl: None,
-            verify_host_ssl: None,
         };
         assert!(validate_proxy_config(&config).is_ok());
 
@@ -500,10 +484,6 @@ mod tests {
             password: None,
             no_proxy: None,
             ignore_ssl: None,
-            verify_proxy_ssl: None,
-            verify_proxy_host_ssl: None,
-            verify_peer_ssl: None,
-            verify_host_ssl: None,
         };
         assert!(validate_proxy_config(&config).is_ok());
 
@@ -613,20 +593,12 @@ mod tests {
         // Test proxy config with SSL verification settings
         let mut config = create_test_proxy_config("https://proxy.example.com:8080");
         config.ignore_ssl = Some(true);
-        config.verify_proxy_ssl = Some(false);
-        config.verify_proxy_host_ssl = Some(false);
-        config.verify_peer_ssl = Some(true);
-        config.verify_host_ssl = Some(true);
 
         // Should validate successfully
         assert!(validate_proxy_config(&config).is_ok());
 
         // Test with all SSL settings as false
         config.ignore_ssl = Some(false);
-        config.verify_proxy_ssl = Some(false);
-        config.verify_proxy_host_ssl = Some(false);
-        config.verify_peer_ssl = Some(false);
-        config.verify_host_ssl = Some(false);
 
         // Should still validate successfully
         assert!(validate_proxy_config(&config).is_ok());
@@ -637,10 +609,6 @@ mod tests {
         // Test with mixed SSL settings - ignore_ssl true, others false
         let mut config = create_test_proxy_config("https://proxy.example.com:8080");
         config.ignore_ssl = Some(true);
-        config.verify_proxy_ssl = Some(false);
-        config.verify_proxy_host_ssl = Some(true);
-        config.verify_peer_ssl = Some(false);
-        config.verify_host_ssl = Some(true);
 
         assert!(validate_proxy_config(&config).is_ok());
         assert!(create_proxy_from_config(&config).is_ok());
@@ -652,10 +620,6 @@ mod tests {
         let config = create_test_proxy_config("https://proxy.example.com:8080");
 
         assert_eq!(config.ignore_ssl, None);
-        assert_eq!(config.verify_proxy_ssl, None);
-        assert_eq!(config.verify_proxy_host_ssl, None);
-        assert_eq!(config.verify_peer_ssl, None);
-        assert_eq!(config.verify_host_ssl, None);
 
         assert!(validate_proxy_config(&config).is_ok());
         assert!(create_proxy_from_config(&config).is_ok());
@@ -666,7 +630,6 @@ mod tests {
         // Test that DownloadItem can be created with SSL proxy configuration
         let mut proxy_config = create_test_proxy_config("https://proxy.example.com:8080");
         proxy_config.ignore_ssl = Some(true);
-        proxy_config.verify_proxy_ssl = Some(false);
 
         let download_item = DownloadItem {
             url: "https://example.com/file.zip".to_string(),
@@ -677,7 +640,6 @@ mod tests {
         assert!(download_item.proxy.is_some());
         let proxy = download_item.proxy.unwrap();
         assert_eq!(proxy.ignore_ssl, Some(true));
-        assert_eq!(proxy.verify_proxy_ssl, Some(false));
     }
 
     #[test]
@@ -704,7 +666,6 @@ mod tests {
         // Test that SSL settings work with HTTP proxy (though not typically used)
         let mut config = create_test_proxy_config("http://proxy.example.com:8080");
         config.ignore_ssl = Some(true);
-        config.verify_proxy_ssl = Some(false);
 
         assert!(validate_proxy_config(&config).is_ok());
         assert!(create_proxy_from_config(&config).is_ok());
@@ -715,8 +676,6 @@ mod tests {
         // Test that SSL settings work with SOCKS proxy
         let mut config = create_test_proxy_config("socks5://proxy.example.com:1080");
         config.ignore_ssl = Some(false);
-        config.verify_peer_ssl = Some(true);
-        config.verify_host_ssl = Some(true);
 
         assert!(validate_proxy_config(&config).is_ok());
         assert!(create_proxy_from_config(&config).is_ok());

--- a/web-app/src/routes/settings/https-proxy.tsx
+++ b/web-app/src/routes/settings/https-proxy.tsx
@@ -24,19 +24,11 @@ function HTTPSProxy() {
     proxyUsername,
     proxyPassword,
     proxyIgnoreSSL,
-    verifyProxySSL,
-    verifyProxyHostSSL,
-    verifyPeerSSL,
-    verifyHostSSL,
     noProxy,
     setProxyEnabled,
     setProxyUsername,
     setProxyPassword,
     setProxyIgnoreSSL,
-    setVerifyProxySSL,
-    setVerifyProxyHostSSL,
-    setVerifyPeerSSL,
-    setVerifyHostSSL,
     setNoProxy,
     setProxyUrl,
   } = useProxyConfig()
@@ -137,10 +129,6 @@ function HTTPSProxy() {
                   </div>
                 }
               />
-            </Card>
-
-            {/* SSL Verification */}
-            <Card title={t('settings:httpsProxy.sslVerification')}>
               <CardItem
                 title={t('settings:httpsProxy.ignoreSsl')}
                 description={t('settings:httpsProxy.ignoreSslDesc')}
@@ -148,48 +136,6 @@ function HTTPSProxy() {
                   <Switch
                     checked={proxyIgnoreSSL}
                     onCheckedChange={(checked) => setProxyIgnoreSSL(checked)}
-                  />
-                }
-              />
-              <CardItem
-                title={t('settings:httpsProxy.proxySsl')}
-                description={t('settings:httpsProxy.proxySslDesc')}
-                actions={
-                  <Switch
-                    checked={verifyProxySSL}
-                    onCheckedChange={(checked) => setVerifyProxySSL(checked)}
-                  />
-                }
-              />
-              <CardItem
-                title={t('settings:httpsProxy.proxyHostSsl')}
-                description={t('settings:httpsProxy.proxyHostSslDesc')}
-                actions={
-                  <Switch
-                    checked={verifyProxyHostSSL}
-                    onCheckedChange={(checked) =>
-                      setVerifyProxyHostSSL(checked)
-                    }
-                  />
-                }
-              />
-              <CardItem
-                title={t('settings:httpsProxy.peerSsl')}
-                description={t('settings:httpsProxy.peerSslDesc')}
-                actions={
-                  <Switch
-                    checked={verifyPeerSSL}
-                    onCheckedChange={(checked) => setVerifyPeerSSL(checked)}
-                  />
-                }
-              />
-              <CardItem
-                title={t('settings:httpsProxy.hostSsl')}
-                description={t('settings:httpsProxy.hostSslDesc')}
-                actions={
-                  <Switch
-                    checked={verifyHostSSL}
-                    onCheckedChange={(checked) => setVerifyHostSSL(checked)}
                   />
                 }
               />


### PR DESCRIPTION
## Summary
- Removed unused fine-grained SSL verification options from proxy configuration
- Simplified proxy settings UI by removing complex SSL verification controls
- Retained the basic `ignore_ssl` option for backwards compatibility

## Changes
- Removed `verify_proxy_ssl`, `verify_proxy_host_ssl`, `verify_peer_ssl`, and `verify_host_ssl` fields from `ProxyConfig`
- Updated proxy settings UI to only show the essential `ignore_ssl` toggle
- Cleaned up related test cases to match simplified configuration

## Test plan
- [x] Verify proxy configuration still works with basic SSL ignore option
- [x] Confirm UI no longer shows complex SSL verification options
- [x] Test that existing proxy functionality remains intact

🤖 Generated with [Claude Code](https://claude.ai/code)