### PR TITLE
fix: Legacy threads show on top of new threads (#5696)

### DIFF
--- a/web-app/src/services/__tests__/threads.test.ts
+++ b/web-app/src/services/__tests__/threads.test.ts
@@ -91,20 +91,20 @@ describe('threads service', () => {
 
       const result = await fetchThreads()
 
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toMatchObject({
-        id: '2',
-        title: 'Test Thread 2',
-        updated: 1234567890,
+        id: '1',
+        title: 'Test Thread',
+        updated: 1234567880,
         order: 1,
         isFavorite: true,
         model: { id: 'gpt-4', provider: 'openai' },
         assistants: [{ model: { id: 'gpt-4', engine: 'openai' } }],
       })
       expect(result[1]).toMatchObject({
-        id: '1',
-        title: 'Test Thread',
-        updated: 1234567880000,
+        id: '2',
+        title: 'Test Thread 2',
+        updated: 1234567890,
         order: 1,
         isFavorite: true,
         model: { id: 'gpt-4', provider: 'openai' },
@@ -296,7 +296,7 @@ describe('threads service', () => {
 
       const result = await fetchThreads()
 
-      expect(result).toHaveLength(2)
+      expect(result).toHaveLength(1)
       expect(result[0]).toMatchObject({
         id: '1',
         title: 'Test Thread',

--- a/web-app/src/services/__tests__/threads.test.ts
+++ b/web-app/src/services/__tests__/threads.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
-import { fetchThreads, createThread, updateThread, deleteThread } from '../threads'
+import {
+  fetchThreads,
+  createThread,
+  updateThread,
+  deleteThread,
+} from '../threads'
 import { ExtensionManager } from '@/lib/extension'
 import { ConversationalExtension, ExtensionTypeEnum } from '@janhq/core'
 import { defaultAssistant } from '@/hooks/useAssistant'
@@ -64,6 +69,49 @@ describe('threads service', () => {
       })
     })
 
+    it('should migrate old threads properly', async () => {
+      const mockThreads = [
+        {
+          id: '1',
+          title: 'Test Thread',
+          updated: 1234567880000,
+          metadata: { order: 1, is_favorite: true },
+          assistants: [{ model: { id: 'gpt-4', engine: 'openai' } }],
+        },
+        {
+          id: '2',
+          title: 'Test Thread 2',
+          updated: 1234567890,
+          metadata: { order: 1, is_favorite: true },
+          assistants: [{ model: { id: 'gpt-4', engine: 'openai' } }],
+        },
+      ]
+
+      mockConversationalExtension.listThreads.mockResolvedValue(mockThreads)
+
+      const result = await fetchThreads()
+
+      expect(result).toHaveLength(1)
+      expect(result[0]).toMatchObject({
+        id: '2',
+        title: 'Test Thread 2',
+        updated: 1234567890,
+        order: 1,
+        isFavorite: true,
+        model: { id: 'gpt-4', provider: 'openai' },
+        assistants: [{ model: { id: 'gpt-4', engine: 'openai' } }],
+      })
+      expect(result[1]).toMatchObject({
+        id: '1',
+        title: 'Test Thread',
+        updated: 1234567880000,
+        order: 1,
+        isFavorite: true,
+        model: { id: 'gpt-4', provider: 'openai' },
+        assistants: [{ model: { id: 'gpt-4', engine: 'openai' } }],
+      })
+    })
+
     it('should handle empty threads array', async () => {
       mockConversationalExtension.listThreads.mockResolvedValue([])
 
@@ -73,7 +121,9 @@ describe('threads service', () => {
     })
 
     it('should handle error and return empty array', async () => {
-      mockConversationalExtension.listThreads.mockRejectedValue(new Error('API Error'))
+      mockConversationalExtension.listThreads.mockRejectedValue(
+        new Error('API Error')
+      )
 
       const result = await fetchThreads()
 
@@ -107,7 +157,9 @@ describe('threads service', () => {
         metadata: { order: 1 },
       }
 
-      mockConversationalExtension.createThread.mockResolvedValue(mockCreatedThread)
+      mockConversationalExtension.createThread.mockResolvedValue(
+        mockCreatedThread
+      )
 
       const result = await createThread(inputThread as Thread)
 
@@ -128,7 +180,9 @@ describe('threads service', () => {
         model: { id: 'gpt-4', provider: 'openai' },
       }
 
-      mockConversationalExtension.createThread.mockRejectedValue(new Error('Creation failed'))
+      mockConversationalExtension.createThread.mockRejectedValue(
+        new Error('Creation failed')
+      )
 
       const result = await createThread(inputThread as Thread)
 
@@ -170,14 +224,16 @@ describe('threads service', () => {
 
       deleteThread(threadId)
 
-      expect(mockConversationalExtension.deleteThread).toHaveBeenCalledWith(threadId)
+      expect(mockConversationalExtension.deleteThread).toHaveBeenCalledWith(
+        threadId
+      )
     })
   })
 
   describe('edge cases and error handling', () => {
     it('should handle fetchThreads when extension manager returns null', async () => {
       ;(ExtensionManager.getInstance as any).mockReturnValue({
-        get: vi.fn().mockReturnValue(null)
+        get: vi.fn().mockReturnValue(null),
       })
 
       const result = await fetchThreads()
@@ -187,7 +243,7 @@ describe('threads service', () => {
 
     it('should handle createThread when extension manager returns null', async () => {
       ;(ExtensionManager.getInstance as any).mockReturnValue({
-        get: vi.fn().mockReturnValue(null)
+        get: vi.fn().mockReturnValue(null),
       })
 
       const inputThread = {
@@ -203,7 +259,7 @@ describe('threads service', () => {
 
     it('should handle updateThread when extension manager returns null', () => {
       ;(ExtensionManager.getInstance as any).mockReturnValue({
-        get: vi.fn().mockReturnValue(null)
+        get: vi.fn().mockReturnValue(null),
       })
 
       const thread = {
@@ -219,7 +275,7 @@ describe('threads service', () => {
 
     it('should handle deleteThread when extension manager returns null', () => {
       ;(ExtensionManager.getInstance as any).mockReturnValue({
-        get: vi.fn().mockReturnValue(null)
+        get: vi.fn().mockReturnValue(null),
       })
 
       const result = deleteThread('test-id')
@@ -240,7 +296,7 @@ describe('threads service', () => {
 
       const result = await fetchThreads()
 
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toMatchObject({
         id: '1',
         title: 'Test Thread',
@@ -294,7 +350,9 @@ describe('threads service', () => {
         metadata: { order: 1 },
       }
 
-      mockConversationalExtension.createThread.mockResolvedValue(mockCreatedThread)
+      mockConversationalExtension.createThread.mockResolvedValue(
+        mockCreatedThread
+      )
 
       const result = await createThread(inputThread as Thread)
 
@@ -326,7 +384,9 @@ describe('threads service', () => {
         metadata: { order: 1 },
       }
 
-      mockConversationalExtension.createThread.mockResolvedValue(mockCreatedThread)
+      mockConversationalExtension.createThread.mockResolvedValue(
+        mockCreatedThread
+      )
 
       const result = await createThread(inputThread as Thread)
 
@@ -414,7 +474,9 @@ describe('threads service', () => {
         // missing metadata
       }
 
-      mockConversationalExtension.createThread.mockResolvedValue(mockCreatedThread)
+      mockConversationalExtension.createThread.mockResolvedValue(
+        mockCreatedThread
+      )
 
       const result = await createThread(inputThread as Thread)
 

--- a/web-app/src/services/threads.ts
+++ b/web-app/src/services/threads.ts
@@ -17,7 +17,10 @@ export const fetchThreads = async (): Promise<Thread[]> => {
         return threads.map((e) => {
           return {
             ...e,
-            updated: e.updated ?? 0,
+            updated:
+              typeof e.updated === 'number' && e.updated > 1e12
+                ? Math.floor(e.updated / 1000)
+                : (e.updated ?? 0),
             order: e.metadata?.order,
             isFavorite: e.metadata?.is_favorite,
             model: {


### PR DESCRIPTION
## Summary

  • Fixed timestamp handling for legacy threads that were using millisecond timestamps instead of
  seconds
  • Threads are now properly sorted by creation time with newer threads appearing first• Added
  comprehensive test coverage for the timestamp migration logic
  
The root cause is that Jan's legacy code creates threads with timestamps in milliseconds. The latest UI revamp persists these threads with timestamps in seconds.

Threads 1 and 2 created from Jan 0.5.6, they all on top before the fix.

<img width="2274" height="1826" alt="CleanShot 2025-07-19 at 16 58 08@2x" src="https://github.com/user-attachments/assets/2cb7ddbe-8ea9-4e09-b056-13724e1ab1c9" />


Closes #5696

## Changes

  - web-app/src/services/threads.ts: Added timestamp normalization to convert millisecond
  timestamps to seconds for proper sorting
  - web-app/src/services/__tests__/threads.test.ts: Added test case to verify legacy thread
  migration and updated existing tests

 ## Test plan

  - Verify legacy threads with millisecond timestamps are properly converted
  - Confirm thread sorting displays newest threads first
  - Run existing test suite to ensure no regressions
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes thread sorting by normalizing legacy timestamps in `fetchThreads` and adds test coverage for timestamp migration.
> 
>   - **Behavior**:
>     - Fixes sorting of threads by normalizing timestamps in `fetchThreads` in `threads.ts`.
>     - Legacy threads with millisecond timestamps are converted to seconds.
>   - **Tests**:
>     - Adds test case for legacy thread migration in `threads.test.ts`.
>     - Updates existing tests to cover new timestamp logic.
>   - **Misc**:
>     - Closes issue #5696.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6d6d525a2b2853d53e0b9fc896f2c681055f03f7. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->