### PR TITLE
Fix autoqa lib dependencies

### DIFF
--- a/autoqa/requirements.txt
+++ b/autoqa/requirements.txt
@@ -1,18 +1,18 @@
 # Core dependencies
-cua-computer[all]>=0.3.5
-cua-agent[all]>=0.3.0
+cua-computer[all]~=0.3.5
+cua-agent[all]~=0.3.0
 cua-agent @ git+https://github.com/menloresearch/cua.git@compute-agent-0.3.0-patch#subdirectory=libs/python/agent
 
 # ReportPortal integration
-reportportal-client>=5.6.5
+reportportal-client~=5.6.5
 
 # Screen recording and automation
-opencv-python>=4.12.0
-numpy>=2.2.6
-PyAutoGUI>=0.9.54
+opencv-python~=4.10.0
+numpy~=2.2.6
+PyAutoGUI~=0.9.54
 
 # System utilities
-psutil>=7.0.0
+psutil~=7.0.0
 
 # Server component
-cua-computer-server>=0.1.19
+cua-computer-server~=0.1.19

--- a/autoqa/tests/new-user/1-user-start-chatting.txt
+++ b/autoqa/tests/new-user/1-user-start-chatting.txt
@@ -1,13 +1,13 @@
 prompt = """
-You are going to test the Jan application by downloading and chatting with a model (qwen2.5).
+You are going to test the Jan application by downloading and chatting with a model (bitcpm4).
 
 Step-by-step instructions:
 1. Given the Jan application is already opened.
 2. In the **bottom-left corner**, click the **“Hub”** menu item.
-3. Scroll through the model list or use the search bar to find **qwen2.5**.
-4. Click **“Use”** on the qwen2.5 model.
+3. Scroll through the model list or use the search bar to find **bitcpm4**.
+4. Click **“Use”** on the bitcpm4 model.
 5. Wait for the model to finish downloading and become ready.
-6. Once redirected to the chat screen, type any message into the input box (e.g. `Hello qwen2.5`).
+6. Once redirected to the chat screen, type any message into the input box (e.g. `Tell me 5 words about you`).
 7. Press **Enter** to send the message.
 8. Wait for the model’s response.
 

--- a/autoqa/utils.py
+++ b/autoqa/utils.py
@@ -279,8 +279,8 @@ def start_jan_app(jan_app_path=None):
         
         # Wait a bit more after maximizing
         time.sleep(10)
-        logger.info("Jan application should be ready")
-        time.sleep(10)  # Additional wait to ensure everything is ready
+        logger.info("Jan application should be ready, waiting for additional setup...")
+        time.sleep(120)  # Additional wait to ensure everything is ready
         
     except Exception as e:
         logger.error(f"Error starting Jan application: {e}")


### PR DESCRIPTION
This pull request updates the dependency versions in `autoqa/requirements.txt` to use the `~=` operator, ensuring compatibility with minor updates while preventing breaking changes. 

Dependency version updates:

* Updated `cua-computer[all]`, `cua-agent[all]`, `reportportal-client`, `opencv-python`, `numpy`, `PyAutoGUI`, `psutil`, and `cua-computer-server` to use the `~=` operator for version constraints, replacing the previous `>=` operator. This change improves dependency management by allowing updates within the same minor version range.

Issue:
<img width="1492" height="429" alt="image" src="https://github.com/user-attachments/assets/ed08b567-2597-46ae-9042-ed4da7bc91e4" />


Fix:
<img width="1459" height="667" alt="image" src="https://github.com/user-attachments/assets/df6d3905-a220-4d58-8c52-c6d713944967" />

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update `autoqa/requirements.txt` dependencies to use `~=` operator, change model in test script, and extend wait time in `start_jan_app()` logging.
> 
>   - **Dependencies**:
>     - Updated `autoqa/requirements.txt` to use `~=` operator for `cua-computer[all]`, `cua-agent[all]`, `reportportal-client`, `opencv-python`, `numpy`, `PyAutoGUI`, `psutil`, and `cua-computer-server`.
>   - **Tests**:
>     - Changed model from `qwen2.5` to `bitcpm4` in `autoqa/tests/new-user/1-user-start-chatting.txt`.
>   - **Logging**:
>     - Updated log message and increased wait time from 10 to 120 seconds in `start_jan_app()` in `autoqa/utils.py`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9734550355126fd7d545a21944d58a12569c8ba8. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->