### PR TITLE
fix: dependabot should just update security patch

### DIFF
--- a/.github/dependabot.yaml
+++ b/.github/dependabot.yaml
@@ -1,17 +1,19 @@
 # https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#package-ecosystem-
 version: 2
 updates:
-  - package-ecosystem: "cargo"
-    directory: "src-tauri"
+  - package-ecosystem: 'cargo'
+    directory: 'src-tauri'
     schedule:
-      interval: "weekly"
-  - package-ecosystem: "npm"
+      interval: 'weekly'
+    open-pull-requests-limit: 0
+  - package-ecosystem: 'npm'
     directories:
-      - "/"
-      - "core"
-      - "docs"
-      - "extensions"
-      - "extensions/*"
-      - "web-app"
+      - '/'
+      - 'core'
+      - 'docs'
+      - 'extensions'
+      - 'extensions/*'
+      - 'web-app'
     schedule:
-      interval: "weekly"
+      interval: 'weekly'
+    open-pull-requests-limit: 0


### PR DESCRIPTION
## Description
Restricts Dependabot updates to only include security patches, reducing noise and preventing unnecessary version bumps for non-critical dependencies.

## Reasoning:
We want to ensure the PRs generated by Dependabot are high-value and focused on security. This minimizes CI load, avoids needless changes, and simplifies dependency management.

## Impact:
- Dependabot will no longer submit PRs for regular version updates
- Only PRs for vulnerabilities flagged by GitHub will be created

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Restricts Dependabot updates to security patches only by setting `open-pull-requests-limit: 0` for `cargo` and `npm` in `.github/dependabot.yaml`.
> 
>   - **Behavior**:
>     - Sets `open-pull-requests-limit: 0` for `cargo` and `npm` in `.github/dependabot.yaml` to restrict updates to security patches only.
>     - Dependabot will no longer create PRs for regular version updates, only for security vulnerabilities flagged by GitHub.
>   - **Impact**:
>     - Reduces CI load and unnecessary version bumps.
>     - Simplifies dependency management by focusing on security.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 6b2315a5482188a0ca9d7f32c0aa594544fcf81d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->