### PR TITLE
feat: support per-model overrides in llama.cpp load()

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -759,7 +759,8 @@ export default class llamacpp_extension extends AIEngine {
 
   override async load(
     modelId: string,
-    isEmbedding: boolean = false
+    isEmbedding: boolean = false,
+    overrideSettings?: Partial<LlamacppConfig>,
   ): Promise<SessionInfo> {
     const sInfo = this.findSessionByModel(modelId)
     if (sInfo) {
@@ -773,7 +774,7 @@ export default class llamacpp_extension extends AIEngine {
       )
     }
     const args: string[] = []
-    const cfg = this.config
+    const cfg = { ...this.config, ...(overrideSettings ?? {}) }
     const [version, backend] = cfg.version_backend.split('/')
     if (!version || !backend) {
       throw new Error(

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -759,8 +759,8 @@ export default class llamacpp_extension extends AIEngine {
 
   override async load(
     modelId: string,
-    isEmbedding: boolean = false,
     overrideSettings?: Partial<LlamacppConfig>,
+    isEmbedding: boolean = false
   ): Promise<SessionInfo> {
     const sInfo = this.findSessionByModel(modelId)
     if (sInfo) {


### PR DESCRIPTION
Extend the `load()` method in the llama.cpp extension to accept optional `overrideSettings`, allowing fine-grained per-model configuration.

This enables users to override provider-level settings such as `ctx_size`, `chat_template`, `n_gpu_layers`, etc., when loading a specific model.

Fixes: #5818 (Feature Request - Jan v0.6.6)

Use cases enabled:
- Different context sizes per model (e.g., 4K vs 32K)
- Model-specific chat templates (ChatML, Alpaca, etc.)
- Performance tuning (threads, GPU layers)
- Better memory management per deployment

Maintains full backward compatibility with existing provider config.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Extend `load()` in `index.ts` to support per-model configuration overrides, enabling settings like `ctx_size` and `chat_template` for individual models.
> 
>   - **Behavior**:
>     - Extend `load()` in `index.ts` to accept `overrideSettings` for per-model configuration.
>     - Allows overriding `ctx_size`, `chat_template`, `n_gpu_layers`, etc., for specific models.
>     - Maintains backward compatibility with existing provider config.
>   - **Use Cases**:
>     - Supports different context sizes per model (e.g., 4K vs 32K).
>     - Enables model-specific chat templates (ChatML, Alpaca, etc.).
>     - Allows performance tuning (threads, GPU layers).
>     - Improves memory management per deployment.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a0d5c2445d770e2040585e52be90b1a8403e6209. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->