### PR TITLE
fix: llama.cpp integration model load and chat experience 

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -23,37 +23,37 @@ export interface InputAudio {
 }
 
 export interface ToolFunction {
-  name: string; // Required: a-z, A-Z, 0-9, _, -, max length 64
-  description?: string;
-  parameters?: Record<string, unknown>; // JSON Schema object
-  strict?: boolean | null; // Defaults to false
+  name: string // Required: a-z, A-Z, 0-9, _, -, max length 64
+  description?: string
+  parameters?: Record<string, unknown> // JSON Schema object
+  strict?: boolean | null // Defaults to false
 }
 
 export interface Tool {
-  type: 'function'; // Currently, only 'function' is supported
-  function: ToolFunction;
+  type: 'function' // Currently, only 'function' is supported
+  function: ToolFunction
 }
 
 export interface ToolCallOptions {
-  tools?: Tool[];
+  tools?: Tool[]
 }
 
 // A specific tool choice to force the model to call
 export interface ToolCallSpec {
-  type: 'function';
+  type: 'function'
   function: {
-    name: string;
-  };
+    name: string
+  }
 }
 
 // tool_choice may be one of several modes or a specific call
-export type ToolChoice = 'none' | 'auto' | 'required' | ToolCallSpec;
+export type ToolChoice = 'none' | 'auto' | 'required' | ToolCallSpec
 
 export interface chatCompletionRequest {
-  model: string; // Model ID, though for local it might be implicit via sessionInfo
-  messages: chatCompletionRequestMessage[];
-  tools?:  Tool[];
-  tool_choice?: ToolChoice;
+  model: string // Model ID, though for local it might be implicit via sessionInfo
+  messages: chatCompletionRequestMessage[]
+  tools?: Tool[]
+  tool_choice?: ToolChoice
   // Core sampling parameters
   temperature?: number | null
   dynatemp_range?: number | null
@@ -168,7 +168,7 @@ export type listResult = modelInfo[]
 export interface SessionInfo {
   pid: number // opaque handle for unload/chat
   port: number // llama-server output port (corrected from portid)
-  model_id: string, //name of the model
+  model_id: string //name of the model
   model_path: string // path of the loaded model
   api_key: string
 }
@@ -242,7 +242,8 @@ export abstract class AIEngine extends BaseExtension {
    * Sends a chat request to the model
    */
   abstract chat(
-    opts: chatCompletionRequest
+    opts: chatCompletionRequest,
+    abortController?: AbortController
   ): Promise<chatCompletion | AsyncIterable<chatCompletionChunk>>
 
   /**
@@ -261,8 +262,8 @@ export abstract class AIEngine extends BaseExtension {
   abstract abortImport(modelId: string): Promise<void>
 
   /**
-    * Get currently loaded models
-  */
+   * Get currently loaded models
+   */
   abstract getLoadedModels(): Promise<string[]>
 
   /**

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -926,12 +926,14 @@ export default class llamacpp_extension extends AIEngine {
   private async *handleStreamingResponse(
     url: string,
     headers: HeadersInit,
-    body: string
+    body: string,
+    abortController?: AbortController
   ): AsyncIterable<chatCompletionChunk> {
     const response = await fetch(url, {
       method: 'POST',
       headers,
       body,
+      signal: abortController?.signal,
     })
     if (!response.ok) {
       const errorData = await response.json().catch(() => null)
@@ -1035,7 +1037,7 @@ export default class llamacpp_extension extends AIEngine {
 
     const body = JSON.stringify(opts)
     if (opts.stream) {
-      return this.handleStreamingResponse(url, headers, body)
+      return this.handleStreamingResponse(url, headers, body, abortController)
     }
     // Handle non-streaming response
     const response = await fetch(url, {

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -34,7 +34,6 @@ import DropdownModelProvider from '@/containers/DropdownModelProvider'
 import { ModelLoader } from '@/containers/loaders/ModelLoader'
 import DropdownToolsAvailable from '@/containers/DropdownToolsAvailable'
 import { getConnectedServers } from '@/services/mcp'
-import { stopAllModels } from '@/services/models'
 
 type ChatInputProps = {
   className?: string
@@ -162,7 +161,6 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
   const stopStreaming = useCallback(
     (threadId: string) => {
       abortControllers[threadId]?.abort()
-      stopAllModels()
     },
     [abortControllers]
   )

--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -183,7 +183,7 @@ export function DownloadManagement() {
       toast.success(t('common:toast.downloadComplete.title'), {
         id: 'download-complete',
         description: t('common:toast.downloadComplete.description', {
-          modelId: state.modelId,
+          item: state.modelId,
         }),
       })
     },

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -399,11 +399,13 @@ export const useChat = () => {
           if (!followUpWithToolUse) availableTools = []
         }
       } catch (error) {
-        const errorMessage =
-          error && typeof error === 'object' && 'message' in error
-            ? error.message
-            : error
-        setModelLoadError(`${errorMessage}`)
+        if (!abortController.signal.aborted) {
+          const errorMessage =
+            error && typeof error === 'object' && 'message' in error
+              ? error.message
+              : error
+          setModelLoadError(`${errorMessage}`)
+        }
       } finally {
         updateLoadingModel(false)
         updateStreamingContent(undefined)

--- a/web-app/src/lib/completion.ts
+++ b/web-app/src/lib/completion.ts
@@ -185,14 +185,17 @@ export const sendCompletion = async (
   const engine = ExtensionManager.getInstance().getEngine(provider.provider)
 
   const completion = engine
-    ? await engine.chat({
-        messages: messages as chatCompletionRequestMessage[],
-        model: thread.model?.id,
-        tools: normalizeTools(tools),
-        tool_choice: tools.length ? 'auto' : undefined,
-        stream: true,
-        ...params,
-      })
+    ? await engine.chat(
+        {
+          messages: messages as chatCompletionRequestMessage[],
+          model: thread.model?.id,
+          tools: normalizeTools(tools),
+          tool_choice: tools.length ? 'auto' : undefined,
+          stream: true,
+          ...params,
+        },
+        abortController
+      )
     : stream
       ? await tokenJS.chat.completions.create(
           {

--- a/web-app/src/locales/de-DE/common.json
+++ b/web-app/src/locales/de-DE/common.json
@@ -251,7 +251,7 @@
     },
     "downloadComplete": {
       "title": "Download abgeschlossen",
-      "description": "Das Modell {{modelId}} wurde heruntergeladen"
+      "description": "{{item}} wurde heruntergeladen"
     },
     "downloadCancelled": {
       "title": "Download abgebrochen",

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -251,7 +251,7 @@
     },
     "downloadComplete": {
       "title": "Download Complete",
-      "description": "The model {{modelId}} has been downloaded"
+      "description": "{{item}} has been downloaded"
     },
     "downloadCancelled": {
       "title": "Download Cancelled",

--- a/web-app/src/locales/id/common.json
+++ b/web-app/src/locales/id/common.json
@@ -244,7 +244,7 @@
     },
     "downloadComplete": {
       "title": "Unduhan Selesai",
-      "description": "Model {{modelId}} telah diunduh"
+      "description": "{{item}} telah diunduh"
     },
     "downloadCancelled": {
       "title": "Unduhan Dibatalkan",

--- a/web-app/src/locales/vn/common.json
+++ b/web-app/src/locales/vn/common.json
@@ -244,7 +244,7 @@
     },
     "downloadComplete": {
       "title": "Tải xuống hoàn tất",
-      "description": "Mô hình {{modelId}} đã được tải xuống"
+      "description": "{{item}} đã được tải xuống"
     },
     "downloadCancelled": {
       "title": "Đã hủy tải xuống",

--- a/web-app/src/locales/zh-CN/common.json
+++ b/web-app/src/locales/zh-CN/common.json
@@ -244,7 +244,7 @@
     },
     "downloadComplete": {
       "title": "下载完成",
-      "description": "模型 {{modelId}} 已下载"
+      "description": "{{item}} 已下载"
     },
     "downloadCancelled": {
       "title": "下载已取消",

--- a/web-app/src/locales/zh-TW/common.json
+++ b/web-app/src/locales/zh-TW/common.json
@@ -244,7 +244,7 @@
     },
     "downloadComplete": {
       "title": "下載完成",
-      "description": "模型 {{modelId}} 已下載"
+      "description": "{{item}} 已下載"
     },
     "downloadCancelled": {
       "title": "下載已取消",


### PR DESCRIPTION
## Describe Your Changes

This PR addresses a few issues in the llama.cpp extension related to backend downloading, model loading, and generation management.
- Added abort request to streaming request. So it stops generating message immediately when user cancel the request without involving model unload.
- Ensure backend is ready before loading model #5780. We find that unblocking UI works better than asking users to wait and send message manually.
- Llama.cpp extension should not increase app start time, e.g. Backend download could block the GUI (since it waits for onLoad to be completed) which is not really good.

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR improves llama.cpp integration by adding an abort mechanism for streaming requests, ensuring backend readiness before model loading, and preventing backend download from blocking the UI.
> 
>   - **Behavior**:
>     - Adds abort mechanism to streaming requests in `AIEngine.ts` and `index.ts` to stop message generation immediately upon user cancellation.
>     - Ensures backend readiness before model loading in `index.ts` by implementing `ensureBackendReady()`.
>     - Prevents backend download from blocking UI in `index.ts` by configuring backends asynchronously.
>   - **UI/UX**:
>     - Removes `stopAllModels()` call from `ChatInput.tsx` to avoid unnecessary model unloading.
>     - Updates download completion toast message in multiple locale files to use `{{item}}` instead of `{{modelId}}`.
>   - **Misc**:
>     - Minor code style changes in `AIEngine.ts` (removal of semicolons).
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 4c482adca1665cd832760138d2d98c9fe52635b5. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->