### PR TITLE
fix: add gitkeep to prevent failing local builds

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,7 +39,8 @@ docs/yarn.lock
 electron/.version.bak
 src-tauri/binaries/engines/cortex.llamacpp
 src-tauri/resources/themes
-src-tauri/resources/lib
+src-tauri/resources/lib/*
+!src-tauri/resources/lib/.gitkeep
 src-tauri/Cargo.lock
 src-tauri/icons
 !src-tauri/icons/icon.png


### PR DESCRIPTION
## Describe Your Changes

This PR simply adds an empty .gitkeep file to `src-tauri/resources/lib/`. For a newly cloned repository, this directory doesn't exist, and the build (`make build` / `mise build`) will fail at packaging step. This is preferred over js script editing as it doesn't introduce any breaking changes.

## Fixes Issues

N/A

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features) - no need to change
- [x] Created issues for follow-up changes or refactoring needed - #5830 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `.gitkeep` to `src-tauri/resources/lib/` to prevent build failures for new clones.
> 
>   - **Build Fix**:
>     - Adds `.gitkeep` to `src-tauri/resources/lib/` to ensure directory exists for build process.
>     - Prevents build failure during packaging step for new clones.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3251763b427eaceff85c01ffab8bfd5e9c421136. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->