### PR TITLE
fix: prevent terminal window from opening on model load on WindowsOS

### DIFF
--- a/src-tauri/src/core/utils/extensions/inference_llamacpp_extension/server.rs
+++ b/src-tauri/src/core/utils/extensions/inference_llamacpp_extension/server.rs
@@ -144,8 +144,9 @@ pub async fn load_llama_model(
     #[cfg(all(windows, target_arch = "x86_64"))]
     {
         use std::os::windows::process::CommandExt;
+        const CREATE_NO_WINDOW: u32 = 0x0800_0000;
         const CREATE_NEW_PROCESS_GROUP: u32 = 0x0000_0200;
-        command.creation_flags(CREATE_NEW_PROCESS_GROUP);
+        command.creation_flags(CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP);
     }
 
     // Spawn the child process


### PR DESCRIPTION
On Windows, spawning the llamacpp server was causing an unwanted terminal window to appear. This is now fixed by combining `CREATE_NO_WINDOW` with `CREATE_NEW_PROCESS_GROUP` using `.creation_flags(...)`, ensuring that the process runs in the background without a console window.

This change only applies to Windows builds.