### PR TITLE
refactor: standardize build process and remove build-tauri target

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -143,7 +143,7 @@ jobs:
           fi
       - name: Build app
         run: |
-          make build-tauri
+          make build
 
           APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
           yarn tauri signer sign \

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Build app
         run: |
           rustup target add x86_64-apple-darwin
-          make build-tauri
+          make build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_PATH: '.'

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -181,7 +181,7 @@ jobs:
           curl -L -o ./src-tauri/binaries/vcomp140.dll https://catalog.jan.ai/vcomp140.dll
           curl -L -o ./src-tauri/binaries/msvcp140_codecvt_ids.dll https://catalog.jan.ai/msvcp140_codecvt_ids.dll
           ls ./src-tauri/binaries
-          make build-tauri
+          make build
         env:
           AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -49,10 +49,6 @@ build-and-publish: install-and-build
 
 # Build
 build: install-and-build
-	yarn build
-
-# Deprecated soon
-build-tauri: install-and-build
 	yarn copy:lib
 	yarn build
 

--- a/mise.toml
+++ b/mise.toml
@@ -77,11 +77,6 @@ run = [
 [tasks.build]
 description = "Build complete application (matches Makefile)"
 depends = ["install-and-build"]
-run = "yarn build"
-
-[tasks.build-tauri]
-description = "Build Tauri application (DEPRECATED - matches Makefile)"
-depends = ["install-and-build"]
 run = [
   "yarn copy:lib",
   "yarn build"


### PR DESCRIPTION
This pull request simplifies the build process by consolidating the `build` and `build-tauri` targets into a single `build` target across multiple files. The changes remove the deprecated `build-tauri` target and update workflows and configurations to use the unified `build` target.

### Build process unification:

* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L146-R146): Replaced `make build-tauri` with `make build` in the Linux build workflow.
* [`.github/workflows/template-tauri-build-macos.yml`](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L171-R171): Replaced `make build-tauri` with `make build` in the macOS build workflow.
* [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L184-R184): Replaced `make build-tauri` with `make build` in the Windows build workflow.

### Code cleanup:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L52-L55): Removed the `build-tauri` target, consolidating its functionality under the `build` target.
* [`mise.toml`](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L80-L84): Removed the deprecated `build-tauri` task and updated the `build` task to include all necessary steps.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Consolidates build process by removing `build-tauri` target and updating workflows and configurations to use a unified `build` target.
> 
>   - **Build Process Unification**:
>     - Replaced `make build-tauri` with `make build` in `.github/workflows/template-tauri-build-linux-x64.yml`, `.github/workflows/template-tauri-build-macos.yml`, and `.github/workflows/template-tauri-build-windows-x64.yml`.
>   - **Code Cleanup**:
>     - Removed `build-tauri` target from `Makefile`, consolidating its functionality under `build`.
>     - Removed `build-tauri` task from `mise.toml` and updated `build` task to include all necessary steps.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 23ba0f311cefa0fea5291e06e2de4518fb0e85e4. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->