### PR TITLE
chore: sync make build with dev

### DIFF
--- a/.github/workflows/jan-linter-and-test.yml
+++ b/.github/workflows/jan-linter-and-test.yml
@@ -71,7 +71,7 @@ jobs:
           path: coverage/lcov.info
 
   test-on-macos:
-    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'macos-latest' || 'macos-selfhosted-12-arm64' }}
+    runs-on: ${{ (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository) && 'macos-latest' || 'macos-selfhosted-15-arm64' }}
     if: github.event_name == 'pull_request' || github.event_name == 'push' || github.event_name == 'workflow_dispatch'
     steps:
       - name: Getting the repo

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -141,7 +141,7 @@ jobs:
           fi
       - name: Build app
         run: |
-          make build-tauri
+          make build
 
           APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
           yarn tauri signer sign \

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -168,7 +168,7 @@ jobs:
       - name: Build app
         run: |
           rustup target add x86_64-apple-darwin
-          make build-tauri
+          make build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           APP_PATH: '.'

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -178,7 +178,7 @@ jobs:
       - name: Build app
         shell: bash
         run: |
-          make build-tauri
+          make build
         env:
           AZURE_KEY_VAULT_URI: ${{ secrets.AZURE_KEY_VAULT_URI }}
           AZURE_CLIENT_ID: ${{ secrets.AZURE_CLIENT_ID }}

--- a/Makefile
+++ b/Makefile
@@ -56,11 +56,6 @@ build: install-and-build
 	yarn download:lib
 	yarn build
 
-# Deprecated soon
-build-tauri: install-and-build
-	yarn download:lib
-	yarn build
-
 clean:
 ifeq ($(OS),Windows_NT)
 	-powershell -Command "Get-ChildItem -Path . -Include node_modules, .next, dist, build, out, .turbo, .yarn -Recurse -Directory | Remove-Item -Recurse -Force"

--- a/mise.toml
+++ b/mise.toml
@@ -73,12 +73,8 @@ run = [
 [tasks.build]
 description = "Build complete application (matches Makefile)"
 depends = ["install-and-build"]
-run = "yarn build"
-
-[tasks.build-tauri]
-description = "Build Tauri application (DEPRECATED - matches Makefile)"
-depends = ["install-and-build"]
 run = [
+  "yarn copy:lib",
   "yarn build"
 ]
 


### PR DESCRIPTION
This pull request simplifies the build process by consolidating the Tauri-specific build command into a single general build command. The changes primarily focus on removing the deprecated `build-tauri` target and ensuring consistency across workflows and configuration files.

### Build process simplification:

* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L144-R144): Replaced the `make build-tauri` command with `make build` to use the general build target.
* [`.github/workflows/template-tauri-build-macos.yml`](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L171-R171): Updated the build command from `make build-tauri` to `make build` for consistency.
* [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L181-R181): Changed the build command from `make build-tauri` to `make build` in the Windows workflow.

### Removal of deprecated build target:

* [`Makefile`](diffhunk://#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L59-L63): Removed the `build-tauri` target, as it was marked for deprecation, and retained `install-and-build` as the primary build process.
* [`mise.toml`](diffhunk://#diff-3c9056799ce8e353b18de841a8b9c8492d46cb096e063c86fb0ce54cfcd117c2L76-R77): Removed the `build-tauri` task and updated the `build` task to include `yarn copy:lib` alongside `yarn build`.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Simplified build process by consolidating Tauri-specific build command into a general `make build` command and removing deprecated `build-tauri` target.
> 
>   - **Build Process Simplification**:
>     - Replaced `make build-tauri` with `make build` in `.github/workflows/template-tauri-build-linux-x64.yml`, `.github/workflows/template-tauri-build-macos.yml`, and `.github/workflows/template-tauri-build-windows-x64.yml`.
>   - **Removal of Deprecated Build Target**:
>     - Removed `build-tauri` target from `Makefile`.
>     - Updated `build` task in `mise.toml` to include `yarn copy:lib` and `yarn build`.
>   - **Miscellaneous**:
>     - Updated `test-on-macos` runner in `.github/workflows/jan-linter-and-test.yml` to `macos-selfhosted-15-arm64`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 4c2be85da17a30dd530579339f5dbaf12527313b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->