### PR TITLE
fix: charmap encoding

### DIFF
--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -82,13 +82,13 @@ jobs:
             # Find the exe file in the artifact
             $exeFile = Get-ChildItem -Path "${{ runner.temp }}/windows-artifact" -Recurse -Filter "*.exe" | Select-Object -First 1
             if ($exeFile) {
-              Write-Host "✅ Found local installer: $($exeFile.FullName)"
+              Write-Host "[SUCCESS] Found local installer: $($exeFile.FullName)"
               Copy-Item -Path $exeFile.FullName -Destination "$env:TEMP\jan-installer.exe" -Force
-              Write-Host "✅ Installer copied to: $env:TEMP\jan-installer.exe"
+              Write-Host "[SUCCESS] Installer copied to: $env:TEMP\jan-installer.exe"
               # Don't set JAN_APP_PATH here - let the install script set it to the correct installed app path
               echo "IS_NIGHTLY=${{ inputs.is_nightly }}" >> $env:GITHUB_ENV
             } else {
-              Write-Error "❌ No .exe file found in artifact"
+              Write-Error "[FAILED] No .exe file found in artifact"
               exit 1
             }
           } else {
@@ -196,9 +196,9 @@ jobs:
             # Find the deb file in the artifact
             DEB_FILE=$(find "${{ runner.temp }}/ubuntu-artifact" -name "*.deb" -type f | head -1)
             if [ -n "$DEB_FILE" ]; then
-              echo "✅ Found local installer: $DEB_FILE"
+              echo "[SUCCESS] Found local installer: $DEB_FILE"
               cp "$DEB_FILE" "/tmp/jan-installer.deb"
-              echo "✅ Installer copied to: /tmp/jan-installer.deb"
+              echo "[SUCCESS] Installer copied to: /tmp/jan-installer.deb"
               echo "JAN_APP_PATH=/tmp/jan-installer.deb" >> $GITHUB_ENV
               echo "IS_NIGHTLY=${{ inputs.is_nightly }}" >> $GITHUB_ENV
               if [ "${{ inputs.is_nightly }}" = "true" ]; then
@@ -207,7 +207,7 @@ jobs:
                 echo "JAN_PROCESS_NAME=Jan" >> $GITHUB_ENV
               fi
             else
-              echo "❌ No .deb file found in artifact"
+              echo "[FAILED] No .deb file found in artifact"
               exit 1
             fi
           else
@@ -296,9 +296,9 @@ jobs:
             # Find the dmg file in the artifact
             DMG_FILE=$(find "${{ runner.temp }}/macos-artifact" -name "*.dmg" -type f | head -1)
             if [ -n "$DMG_FILE" ]; then
-              echo "✅ Found local installer: $DMG_FILE"
+              echo "[SUCCESS] Found local installer: $DMG_FILE"
               cp "$DMG_FILE" "/tmp/jan-installer.dmg"
-              echo "✅ Installer copied to: /tmp/jan-installer.dmg"
+              echo "[SUCCESS] Installer copied to: /tmp/jan-installer.dmg"
               echo "JAN_APP_PATH=/tmp/jan-installer.dmg" >> $GITHUB_ENV
               echo "IS_NIGHTLY=${{ inputs.is_nightly }}" >> $GITHUB_ENV
               if [ "${{ inputs.is_nightly }}" = "true" ]; then
@@ -307,7 +307,7 @@ jobs:
                 echo "PROCESS_NAME=Jan" >> $GITHUB_ENV
               fi
             else
-              echo "❌ No .dmg file found in artifact"
+              echo "[FAILED] No .dmg file found in artifact"
               exit 1
             fi
           else
@@ -349,7 +349,7 @@ jobs:
           else
             echo "Homebrew not available, checking if tkinter works..."
             python3 -c "import tkinter" || {
-              echo "⚠️ tkinter not available and Homebrew not found"
+              echo "[WARNING] tkinter not available and Homebrew not found"
               echo "This may cause issues with mouse control"
             }
           fi
@@ -362,7 +362,7 @@ jobs:
           echo "Installing Python dependencies..."
           pip install --upgrade pip
           pip install -r requirements.txt
-          echo "✅ Python dependencies installed"
+          echo "[SUCCESS] Python dependencies installed"
 
       - name: Setup ReportPortal environment
         run: |

--- a/autoqa/main.py
+++ b/autoqa/main.py
@@ -449,17 +449,17 @@ async def main():
                 # Update counters and log result
                 if test_passed:
                     test_results["passed"] += 1
-                    logger.info(f"✅ Test {i} PASSED: {test_data['path']}")
+                    logger.info(f"[SUCCESS] Test {i} PASSED: {test_data['path']}")
                 else:
                     test_results["failed"] += 1
-                    logger.error(f"❌ Test {i} FAILED: {test_data['path']}")
+                    logger.error(f"[FAILED] Test {i} FAILED: {test_data['path']}")
                     
                 # Debug log for troubleshooting
-                logger.info(f"🔍 Debug - Test result: type={type(test_result)}, value={test_result}, success_field={test_result.get('success', 'N/A') if isinstance(test_result, dict) else 'N/A'}, final_passed={test_passed}")
+                logger.info(f"[INFO] Debug - Test result: type={type(test_result)}, value={test_result}, success_field={test_result.get('success', 'N/A') if isinstance(test_result, dict) else 'N/A'}, final_passed={test_passed}")
                     
             except Exception as e:
                 test_results["failed"] += 1
-                logger.error(f"❌ Test {i} FAILED with exception: {test_data['path']} - {e}")
+                logger.error(f"[FAILED] Test {i} FAILED with exception: {test_data['path']} - {e}")
             
             # Add delay between tests
             if i < len(test_files):
@@ -477,10 +477,10 @@ async def main():
         logger.info("=" * 50)
         
         if test_results["failed"] > 0:
-            logger.error(f"❌ Test execution completed with {test_results['failed']} failures!")
+            logger.error(f"[FAILED] Test execution completed with {test_results['failed']} failures!")
             final_exit_code = 1
         else:
-            logger.info("✅ All tests completed successfully!")
+            logger.info("[SUCCESS] All tests completed successfully!")
             final_exit_code = 0
         
     except KeyboardInterrupt:

--- a/autoqa/reportportal_handler.py
+++ b/autoqa/reportportal_handler.py
@@ -212,7 +212,7 @@ def upload_jan_logs(client, test_item_id, is_nightly=False, max_log_files=5):
         client.log(
             time=timestamp(),
             level="WARNING",
-            message=f"📝 No Jan {app_type} application logs found",
+            message=f"[INFO] No Jan {app_type} application logs found",
             item_id=test_item_id
         )
         return
@@ -236,7 +236,7 @@ def upload_jan_logs(client, test_item_id, is_nightly=False, max_log_files=5):
                     client.log(
                         time=timestamp(),
                         level="WARNING",
-                        message=f"📝 Log file {file_name} skipped (size: {file_size} bytes > 50MB limit)",
+                        message=f"[INFO] Log file {file_name} skipped (size: {file_size} bytes > 50MB limit)",
                         item_id=test_item_id
                     )
                     continue
@@ -251,7 +251,7 @@ def upload_jan_logs(client, test_item_id, is_nightly=False, max_log_files=5):
                 client.log(
                     time=timestamp(),
                     level="INFO",
-                    message=f"📝 Jan {app_type} application log: {file_name}",
+                    message=f"[INFO] Jan {app_type} application log: {file_name}",
                     item_id=test_item_id,
                     attachment={
                         "name": f"jan_{app_type}_log_{i}_{file_name}",
@@ -275,7 +275,7 @@ def upload_jan_logs(client, test_item_id, is_nightly=False, max_log_files=5):
         client.log(
             time=timestamp(),
             level="INFO",
-            message=f"📝 Uploaded {len(log_files_to_upload)} Jan {app_type} log files (total available: {len(all_log_files)})",
+            message=f"[INFO] Uploaded {len(log_files_to_upload)} Jan {app_type} log files (total available: {len(all_log_files)})",
             item_id=test_item_id
         )
         
@@ -305,7 +305,7 @@ def upload_test_results_to_rp(client, launch_id, test_path, trajectory_dir, forc
         client.log(
             time=timestamp(),
             level="ERROR",
-            message="❌ TEST FAILED ❌\nNo trajectory directory found",
+            message="[FAILED] TEST FAILED [FAILED]\nNo trajectory directory found",
             item_id=test_item_id
         )
         
@@ -364,7 +364,7 @@ def upload_test_results_to_rp(client, launch_id, test_path, trajectory_dir, forc
                        if os.path.isdir(os.path.join(trajectory_dir, f)) and f.startswith("turn_")]
         
         # Add clear status log
-        status_emoji = "✅" if final_status == "PASSED" else "❌"
+        status_emoji = "[SUCCESS]" if final_status == "PASSED" else "[FAILED]"
         client.log(
             time=timestamp(),
             level="INFO" if final_status == "PASSED" else "ERROR",
@@ -383,7 +383,7 @@ def upload_test_results_to_rp(client, launch_id, test_path, trajectory_dir, forc
                     client.log(
                         time=timestamp(),
                         level="INFO",
-                        message="🎥 Screen recording of test execution",
+                        message="[INFO] Screen recording of test execution",
                         item_id=test_item_id,
                         attachment={
                             "name": f"test_recording_{formatted_test_path}.mp4",

--- a/autoqa/scripts/macos_download.sh
+++ b/autoqa/scripts/macos_download.sh
@@ -41,9 +41,9 @@ echo "Downloading Jan app from: $JAN_APP_URL"
 curl -L -o "/tmp/jan-installer.dmg" "$JAN_APP_URL"
 
 if [ ! -f "/tmp/jan-installer.dmg" ]; then
-    echo "❌ Failed to download Jan app"
+    echo "[FAILED] Failed to download Jan app"
     exit 1
 fi
 
-echo "✅ Successfully downloaded Jan app"
+echo "[SUCCESS] Successfully downloaded Jan app"
 ls -la "/tmp/jan-installer.dmg"

--- a/autoqa/scripts/macos_install.sh
+++ b/autoqa/scripts/macos_install.sh
@@ -10,7 +10,7 @@ hdiutil attach "/tmp/jan-installer.dmg" -mountpoint "/tmp/jan-mount"
 APP_FILE=$(find "/tmp/jan-mount" -name "*.app" -type d | head -1)
 
 if [ -z "$APP_FILE" ]; then
-    echo "❌ No .app file found in DMG"
+    echo "[Failed] No .app file found in DMG"
     hdiutil detach "/tmp/jan-mount" || true
     exit 1
 fi
@@ -61,7 +61,7 @@ if [ -z "$APP_PATH" ]; then
 fi
 
 if [ -z "$APP_PATH" ]; then
-    echo "❌ No executable found in MacOS folder"
+    echo "[FAILED] No executable found in MacOS folder"
     ls -la "/Applications/$APP_NAME/Contents/MacOS/"
     exit 1
 fi
@@ -76,16 +76,16 @@ echo "Process name: $PROCESS_NAME"
 echo "JAN_APP_PATH=$APP_PATH" >> $GITHUB_ENV
 echo "PROCESS_NAME=$PROCESS_NAME" >> $GITHUB_ENV
 
-echo "⏳ Waiting for Jan app first initialization (120 seconds)..."
+echo "[INFO] Waiting for Jan app first initialization (120 seconds)..."
 echo "This allows Jan to complete its initial setup and configuration"
 sleep 120
-echo "✅ Initialization wait completed"
+echo "[SUCCESS] Initialization wait completed"
 
 # Verify installation
 if [ -f "$APP_PATH" ]; then
-    echo "✅ Jan app installed successfully"
+    echo "[SUCCESS] Jan app installed successfully"
     ls -la "/Applications/$APP_NAME"
 else
-    echo "❌ Jan app installation failed - executable not found"
+    echo "[FAILED] Jan app installation failed - executable not found"
     exit 1
 fi

--- a/autoqa/scripts/setup_permissions.sh
+++ b/autoqa/scripts/setup_permissions.sh
@@ -9,7 +9,7 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 # Make all shell scripts executable
 chmod +x "$SCRIPT_DIR"/*.sh
 
-echo "✅ All shell scripts are now executable:"
+echo "[SUCCESS] All shell scripts are now executable:"
 ls -la "$SCRIPT_DIR"/*.sh
 
-echo "✅ Permission setup completed"
+echo "[SUCCESS] Permission setup completed"

--- a/autoqa/scripts/ubuntu_install.sh
+++ b/autoqa/scripts/ubuntu_install.sh
@@ -15,10 +15,10 @@ sudo apt-get install -f -y
 # Wait for installation to complete
 sleep 10
 
-echo "⏳ Waiting for Jan app first initialization (120 seconds)..."
+echo "[INFO] Waiting for Jan app first initialization (120 seconds)..."
 echo "This allows Jan to complete its initial setup and configuration"
 sleep 120
-echo "✅ Initialization wait completed"
+echo "[SUCCESS] Initialization wait completed"
 
 # Verify installation based on nightly flag
 if [ "$IS_NIGHTLY" = "true" ]; then

--- a/autoqa/scripts/windows_install.ps1
+++ b/autoqa/scripts/windows_install.ps1
@@ -24,10 +24,10 @@ catch {
 # Wait a bit for installation to complete
 Start-Sleep -Seconds 10
 
-Write-Host "⏳ Waiting for Jan app first initialization (120 seconds)..."
+Write-Host "[INFO] Waiting for Jan app first initialization (120 seconds)..."
 Write-Host "This allows Jan to complete its initial setup and configuration"
 Start-Sleep -Seconds 120
-Write-Host "✅ Initialization wait completed"
+Write-Host "[SUCCESS] Initialization wait completed"
 
 # Verify installation based on nightly flag
 if ($isNightly) {

--- a/autoqa/test_runner.py
+++ b/autoqa/test_runner.py
@@ -238,7 +238,7 @@ async def run_single_test_with_timeout(computer, test_data, rp_client, launch_id
                                 rp_client.log(
                                     time=timestamp(),
                                     level="INFO",
-                                    message="🎥 Screen recording of failed test",
+                                    message="[INFO] Screen recording of failed test",
                                     item_id=test_item_id,
                                     attachment={
                                         "name": f"failed_test_recording_{formatted_test_path}.mp4",
@@ -298,9 +298,9 @@ async def run_single_test_with_timeout(computer, test_data, rp_client, launch_id
             
             if not enable_reportportal:
                 # Local development mode - log results
-                logger.info(f"🏠 LOCAL RESULT: {path} - {final_status} ({status_message})")
-                logger.info(f"📹 Video saved: {video_path}")
-                logger.info(f"📁 Trajectory: {trajectory_dir}")
+                logger.info(f"[INFO] LOCAL RESULT: {path} - {final_status} ({status_message})")
+                logger.info(f"[INFO] Video saved: {video_path}")
+                logger.info(f"[INFO] Trajectory: {trajectory_dir}")
         else:
             final_status = "FAILED"
             status_message = "no trajectory found"
@@ -312,7 +312,7 @@ async def run_single_test_with_timeout(computer, test_data, rp_client, launch_id
             })
             
             if not enable_reportportal:
-                logger.warning(f"🏠 LOCAL RESULT: {path} - {final_status} ({status_message})")
+                logger.warning(f"[INFO] LOCAL RESULT: {path} - {final_status} ({status_message})")
         
         # Step 9: Always force close Jan app after test completion
         logger.info(f"Cleaning up after test: {path}")


### PR DESCRIPTION
This pull request standardizes logging messages across the codebase by replacing emoji-based status indicators with bracketed text labels such as `[SUCCESS]`, `[FAILED]`, and `[INFO]`. This change improves log readability and consistency across different environments and platforms.

### Logging Standardization:

* [`.github/workflows/autoqa-template.yml`](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L85-R91): Replaced emojis in logging messages for various installer checks and setup steps with standardized text labels like `[SUCCESS]`, `[FAILED]`, and `[WARNING]`. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L85-R91) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L199-R201) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L210-R210) [[4]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L299-R301) [[5]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L310-R310) [[6]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L352-R352) [[7]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L365-R365)
* [`autoqa/main.py`](diffhunk://#diff-1f5446dd76db6e94b569f4c49b0ddff3eae88afe4396c9deec8614d3cb7660daL452-R462): Updated test result logging to use `[SUCCESS]` and `[FAILED]` labels instead of emojis, and standardized debug logs with `[INFO]`. [[1]](diffhunk://#diff-1f5446dd76db6e94b569f4c49b0ddff3eae88afe4396c9deec8614d3cb7660daL452-R462) [[2]](diffhunk://#diff-1f5446dd76db6e94b569f4c49b0ddff3eae88afe4396c9deec8614d3cb7660daL480-R483)
* [`autoqa/reportportal_handler.py`](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL215-R215): Unified log messages for application logs and test results with `[INFO]` and `[FAILED]` labels, replacing emojis. [[1]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL215-R215) [[2]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL239-R239) [[3]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL254-R254) [[4]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL278-R278) [[5]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL308-R308) [[6]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL367-R367) [[7]](diffhunk://#diff-472a54e587bb7b6cfc8a5f0db6c6de802bcdc95514239b595ecf7a958e54ffaeL386-R386)
* [`autoqa/test_runner.py`](diffhunk://#diff-9113134a2163fbc676836c1eadf10c7e43e672bd7d60f71479c7f0a87d9d80dcL241-R241): Adjusted local development and screen recording logs to use `[INFO]` labels for consistency. [[1]](diffhunk://#diff-9113134a2163fbc676836c1eadf10c7e43e672bd7d60f71479c7f0a87d9d80dcL241-R241) [[2]](diffhunk://#diff-9113134a2163fbc676836c1eadf10c7e43e672bd7d60f71479c7f0a87d9d80dcL301-R303) [[3]](diffhunk://#diff-9113134a2163fbc676836c1eadf10c7e43e672bd7d60f71479c7f0a87d9d80dcL315-R315)

### Script Updates:

* [`autoqa/scripts/macos_download.sh`](diffhunk://#diff-4ef4cd1798d00908e1383f4205208a5eaeb9e98a07a28e8212781806c34e9f03L44-R48): Replaced emojis with `[SUCCESS]` and `[FAILED]` in download status messages.
* [`autoqa/scripts/macos_install.sh`](diffhunk://#diff-46ef46a395c1d78da059b830f02777a28756885bb4eda95b8cbafb66d763c117L13-R13): Standardized installation and initialization logs with `[SUCCESS]`, `[FAILED]`, and `[INFO]` labels. [[1]](diffhunk://#diff-46ef46a395c1d78da059b830f02777a28756885bb4eda95b8cbafb66d763c117L13-R13) [[2]](diffhunk://#diff-46ef46a395c1d78da059b830f02777a28756885bb4eda95b8cbafb66d763c117L64-R64) [[3]](diffhunk://#diff-46ef46a395c1d78da059b830f02777a28756885bb4eda95b8cbafb66d763c117L79-R89)
* [`autoqa/scripts/ubuntu_install.sh`](diffhunk://#diff-c6532329d39a43721be24e9fbfedb02f21caa0f24932e652d5306f449b9c9a02L18-R21): Updated initialization wait messages to use `[SUCCESS]` and `[INFO]` labels.
* [`autoqa/scripts/windows_install.ps1`](diffhunk://#diff-40b6e8209addc43fdd06d94d98c1cfe121e6278bff951caf4ecfc2a24e0dfa53L27-R30): Changed initialization logs to use `[SUCCESS]` and `[INFO]` labels.
* [`autoqa/scripts/setup_permissions.sh`](diffhunk://#diff-9cf34e66d78180e33dd80814cda5f28f8409e49d5256e4f22e9b76dc08eff6cbL12-R15): Replaced emojis with `[SUCCESS]` in permission setup logs.