### PR TITLE
fix: app should not show manually deleted models

### DIFF
--- a/autoqa/tests/new-user/1-user-start-chatting.txt
+++ b/autoqa/tests/new-user/1-user-start-chatting.txt
@@ -4,8 +4,8 @@ You are going to test the Jan application by downloading and chatting with a mod
 Step-by-step instructions:
 1. Given the Jan application is already opened.
 2. In the **bottom-left corner**, click the **Hub** menu item.
-3. Scroll through the model list or use the search bar to find **bitcpm4**.
-4. Click **Use** on the bitcpm4 model.
+3. Scroll through the model list or use the search bar to find **qwen3-0.6B**.
+4. Click **Use** on the qwen3-0.6B model.
 5. Wait for the model to finish downloading and become ready.
 6. Once redirected to the chat screen, type any message into the input box (e.g. `Hello World`).
 7. Press **Enter** to send the message.

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -72,7 +72,7 @@ export const useModelProvider = create<ModelProviderState>()(
             ]
             return {
               ...provider,
-              models: mergedModels,
+              models: provider.persist ? provider?.models : mergedModels,
               settings: provider.settings.map((setting) => {
                 const existingSetting = provider.persist
                   ? undefined

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -39,7 +39,7 @@ type ModelProps = {
 type SearchParams = {
   repo: string
 }
-const defaultModelQuantizations = ['iq4_xs.gguf', 'q4_k_m.gguf']
+const defaultModelQuantizations = ['iq4_xs', 'q4_k_m']
 
 export const Route = createFileRoute(route.hub.index as any)({
   component: Hub,

--- a/web-app/src/services/providers.ts
+++ b/web-app/src/services/providers.ts
@@ -21,6 +21,7 @@ export const getProviders = async (): Promise<ModelProvider[]> => {
       if (Array.isArray(builtInModels))
         models = builtInModels.map((model) => {
           const modelManifest = models.find((e) => e.id === model)
+          // TODO: Check chat_template for tool call support
           const capabilities = [
             ModelCapabilities.COMPLETION,
             (


### PR DESCRIPTION
## Summary

This PR fixes the issue where the app continued to show models that were manually deleted from the filesystem. Previously, the app used a cached models list, which became stale when users removed model files directly. Additionally, this PR enhances the model hub to show proper recommended models for download.

## Changes

### 🔧 Model List Refresh
- **Before**: App used cached models list that didn't reflect filesystem changes
- **After**: App now calls `llama.cpp list()` function to get current model state
- Models that are manually deleted are now immediately removed from the UI

### 🚀 Model Hub Enhancement
- Enhanced model hub to display proper recommended models for download
- Improved model discovery and recommendation logic

### Testing
- [x] Verified models list updates after manual deletion
- [x] Confirmed model hub shows appropriate recommendations
- [x] Tested model loading with refreshed list
