### PR TITLE
ci: autoqa github artifact

### DIFF
--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -154,7 +154,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests
@@ -300,7 +300,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests
@@ -459,7 +459,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-logs-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests

--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -147,7 +147,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
@@ -293,7 +293,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
@@ -452,7 +452,7 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs

--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -145,14 +145,14 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screen-recordings-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jan-logs-${{ runner.os }}
           path: autoqa/jan-logs/
@@ -291,14 +291,14 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screen-recordings-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jan-logs-${{ runner.os }}
           path: autoqa/jan-logs/
@@ -450,14 +450,14 @@ jobs:
 
       - name: Upload screen recordings
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: screen-recordings-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           name: jan-logs-${{ runner.os }}
           path: autoqa/jan-logs/

--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -127,6 +127,36 @@ jobs:
         run: |
           .\scripts\run_tests.ps1 -JanAppPath "$env:JAN_APP_PATH" -ProcessName "$env:JAN_PROCESS_NAME" -RpToken "$env:RP_TOKEN"
 
+      - name: Collect Jan logs for artifact upload
+        if: always()
+        shell: powershell
+        run: |
+          $logDirs = @(
+            "$env:APPDATA\Jan-nightly\data\logs",
+            "$env:APPDATA\Jan\data\logs"
+          )
+          $dest = "autoqa\jan-logs"
+          mkdir $dest -Force | Out-Null
+          foreach ($dir in $logDirs) {
+            if (Test-Path $dir) {
+              Copy-Item "$dir\*.log" $dest -Force -ErrorAction SilentlyContinue
+            }
+          }
+
+      - name: Upload screen recordings
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: screen-recordings-${{ runner.os }}
+          path: autoqa/recordings/
+
+      - name: Upload Jan logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jan-logs-${{ runner.os }}
+          path: autoqa/jan-logs/
+
       - name: Cleanup after tests
         if: always()
         shell: powershell
@@ -251,6 +281,27 @@ jobs:
           LAUNCH_NAME: 'CI AutoQA Run Ubuntu - ${{ github.run_number }} - ${{ github.ref_name }}'
         run: |
           ./scripts/run_tests.sh "$JAN_APP_PATH" "$JAN_PROCESS_NAME" "$RP_TOKEN" "ubuntu"
+
+      - name: Collect Jan logs for artifact upload
+        if: always()
+        run: |
+          mkdir -p autoqa/jan-logs
+          cp ~/.local/share/Jan-nightly/data/logs/*.log autoqa/jan-logs/ 2>/dev/null || true
+          cp ~/.local/share/Jan/data/logs/*.log autoqa/jan-logs/ 2>/dev/null || true
+
+      - name: Upload screen recordings
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: screen-recordings-${{ runner.os }}
+          path: autoqa/recordings/
+
+      - name: Upload Jan logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jan-logs-${{ runner.os }}
+          path: autoqa/jan-logs/
 
       - name: Cleanup after tests
         if: always()
@@ -389,6 +440,27 @@ jobs:
           echo "IS_NIGHTLY: $IS_NIGHTLY"
 
           ./scripts/run_tests.sh "$JAN_APP_PATH" "$PROCESS_NAME" "$RP_TOKEN" "macos"
+
+      - name: Collect Jan logs for artifact upload
+        if: always()
+        run: |
+          mkdir -p autoqa/jan-logs
+          cp ~/Library/Application\ Support/Jan-nightly/data/logs/*.log autoqa/jan-logs/ 2>/dev/null || true
+          cp ~/Library/Application\ Support/Jan/data/logs/*.log autoqa/jan-logs/ 2>/dev/null || true
+
+      - name: Upload screen recordings
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: screen-recordings-${{ runner.os }}
+          path: autoqa/recordings/
+
+      - name: Upload Jan logs
+        if: always()
+        uses: actions/upload-artifact@v3
+        with:
+          name: jan-logs-${{ runner.os }}
+          path: autoqa/jan-logs/
 
       - name: Cleanup after tests
         if: always()

--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -147,14 +147,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ runner.os }}
+          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jan-logs-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests
@@ -293,14 +293,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ runner.os }}
+          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jan-logs-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests
@@ -452,14 +452,14 @@ jobs:
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: screen-recordings-${{ runner.os }}
+          name: screen-recordings-${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
 
       - name: Upload Jan logs
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: jan-logs-${{ runner.os }}
+          name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/jan-logs/
 
       - name: Cleanup after tests


### PR DESCRIPTION
This pull request enhances the `autoqa-template.yml` workflow by adding steps to collect and upload logs and screen recordings as artifacts for better debugging and traceability. These changes ensure that logs from different environments (Windows, Linux, macOS) are gathered and uploaded consistently.

### Improvements to artifact collection and upload:

* **Log collection for all environments**:
  - Added steps to collect Jan logs from environment-specific directories (Windows: `$env:APPDATA`, Linux: `~/.local/share`, macOS: `~/Library/Application Support`) and save them to a common directory for artifact upload. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R130-R159) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R285-R305) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R444-R464)

* **Artifact upload for screen recordings**:
  - Introduced a step to upload screen recordings as an artifact, with a naming convention that includes build type, run number, and OS. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R130-R159) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R285-R305) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R444-R464)

* **Artifact upload for logs**:
  - Added a step to upload collected Jan logs as an artifact, following the same naming convention as the screen recordings. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R130-R159) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R285-R305) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R444-R464)