### PR TITLE
ci: rename app github artifact on windows and linux build

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -164,14 +164,14 @@ jobs:
         if: inputs.public_provider != 'github'
         uses: actions/upload-artifact@v4
         with:
-          name: jan-linux-amd64-${{ inputs.new_version }}-deb
+          name: jan-${{ inputs.channel }}-linux-amd64-${{ inputs.new_version }}.deb
           path: ./src-tauri/target/release/bundle/deb/*.deb
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
         uses: actions/upload-artifact@v4
         with:
-          name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
+          name: jan-${{ inputs.channel }}-linux-amd64-${{ inputs.new_version }}.AppImage
           path: ./src-tauri/target/release/bundle/appimage/*.AppImage
 
       ## Set output filename for linux

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: jan-windows-${{ inputs.new_version }}
+          name: jan-${{ inputs.channel }}-windows-${{ inputs.new_version }}.exe
           path: |
             ./src-tauri/target/release/bundle/nsis/*.exe
 


### PR DESCRIPTION
This pull request updates the artifact naming conventions in the GitHub Actions workflows for Tauri builds. The changes ensure that the artifact names include the release channel (`inputs.channel`) for better clarity and organization.

## Previously

<img width="1871" height="899" alt="image" src="https://github.com/user-attachments/assets/b06f17b3-13ba-42d2-a9a0-30c467d9fe69" />

- On Linux:
  - jan-linux-amd64-0.6.5-872-deb
  - jan-linux-amd64-0.6.5-872-AppImage
- On Windows
  - jan-windows-0.6.5-872

Now we need to add input channel and extension for the filename, in case it's nightly build, it should be:
- On Linux:
  - jan-nightly-linux-amd64-0.6.5-872.deb
  - jan-nightly-linux-amd64-0.6.5-872.AppImage
- On Windows
  - jan-nightly-windows-0.6.5-872.exe

If input channel is stable version:
- On Linux:
  - jan-linux-amd64-0.6.5-872.deb
  - jan-linux-amd64-0.6.5-872.AppImage
- On Windows
  - jan-windows-0.6.5-872.exe

### Workflow updates for artifact naming:

* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L167-R174): Updated the artifact names for `.deb` and `.AppImage` files to include the release channel (`inputs.channel`).
* [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L201-R201): Updated the artifact name for `.exe` files to include the release channel (`inputs.channel`).