### PR TITLE
fix: llama.cpp backend shows blank list sometime

### DIFF
--- a/core/src/browser/extension.ts
+++ b/core/src/browser/extension.ts
@@ -128,6 +128,10 @@ export abstract class BaseExtension implements ExtensionType {
             setting.controllerProps.value = oldSettings.find(
               (e: any) => e.key === setting.key
             )?.controllerProps?.value
+          if ('options' in setting.controllerProps)
+            setting.controllerProps.options = setting.controllerProps.options?.length
+              ? setting.controllerProps.options
+              : oldSettings.find((e: any) => e.key === setting.key)?.controllerProps?.options
         })
       }
       localStorage.setItem(this.name, JSON.stringify(settings))

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -36,16 +36,20 @@ export const useModelProvider = create<ModelProviderState>()(
       },
       setProviders: (providers) =>
         set((state) => {
-          const existingProviders = state.providers.map((provider) => {
-            return {
-              ...provider,
-              models: provider.models.filter(
-                (e) =>
-                  ('id' in e || 'model' in e) &&
-                  typeof (e.id ?? e.model) === 'string'
-              ),
-            }
-          })
+          const existingProviders = state.providers
+            // Filter out legacy llama.cpp provider for migration
+            // Can remove after a couple of releases
+            .filter((e) => e.provider !== 'llama.cpp')
+            .map((provider) => {
+              return {
+                ...provider,
+                models: provider.models.filter(
+                  (e) =>
+                    ('id' in e || 'model' in e) &&
+                    typeof (e.id ?? e.model) === 'string'
+                ),
+              }
+            })
           // Ensure deletedModels is always an array
           const currentDeletedModels = Array.isArray(state.deletedModels)
             ? state.deletedModels


### PR DESCRIPTION
## Describe Your Changes

This PR is to address the issue where:
1. llama.cpp version list shows blank options
2. App shows legacy llama.cpp provider

#5444 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes blank options in llama.cpp version list and filters out legacy llama.cpp provider in `extension.ts` and `useModelProvider.ts`.
> 
>   - **Behavior**:
>     - Fixes blank options in llama.cpp version list by updating `registerSettings()` in `extension.ts` to populate options from old settings if missing.
>     - Filters out legacy llama.cpp provider in `setProviders()` in `useModelProvider.ts` to prevent it from appearing in the list.
>   - **Misc**:
>     - Adds comments in `useModelProvider.ts` to indicate the temporary nature of filtering out the legacy provider.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for fb6babb23695887af7f7e5e86113705eb00f3a74. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->