### PR TITLE
chore: revert app artifact name for macos linux and windows builds

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -164,14 +164,14 @@ jobs:
         if: inputs.public_provider != 'github'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.channel == 'stable' && 'jan' || format('jan-{0}', inputs.channel) }}-linux-amd64-${{ inputs.new_version }}.deb
+          name: jan-linux-amd64-${{ inputs.new_version }}-deb
           path: ./src-tauri/target/release/bundle/deb/*.deb
 
       - name: Upload Artifact
         if: inputs.public_provider != 'github'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.channel == 'stable' && 'jan' || format('jan-{0}', inputs.channel) }}-linux-amd64-${{ inputs.new_version }}.AppImage
+          name: jan-linux-amd64-${{ inputs.new_version }}-AppImage
           path: ./src-tauri/target/release/bundle/appimage/*.AppImage
 
       ## Set output filename for linux

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -189,7 +189,7 @@ jobs:
         if: inputs.public_provider != 'github'
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.channel == 'stable' && 'jan' || format('jan-{0}', inputs.channel) }}-mac-universal-${{ inputs.new_version }}.dmg
+          name: jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.dmg
           path: |
             ./src-tauri/target/universal-apple-darwin/release/bundle/dmg/*.dmg
 

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -198,7 +198,7 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ inputs.channel == 'stable' && 'jan' || format('jan-{0}', inputs.channel) }}-windows-${{ inputs.new_version }}.exe
+          name: jan-windows-${{ inputs.new_version }}
           path: |
             ./src-tauri/target/release/bundle/nsis/*.exe
 


### PR DESCRIPTION
This pull request simplifies the artifact naming conventions across GitHub Actions workflows for Tauri builds. The changes standardize the artifact names by removing conditional logic and ensuring consistency across platforms.

### Standardization of artifact naming:

* [`.github/workflows/template-tauri-build-linux-x64.yml`](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L167-R174): Updated artifact names to use a consistent format, removing conditional logic based on the `channel` input.
* [`.github/workflows/template-tauri-build-macos.yml`](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L192-R192): Modified the macOS artifact naming to include the `channel` explicitly in the name for clarity.
* [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L201-R201): Simplified the Windows artifact naming by removing conditional logic and ensuring a uniform format.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes artifact naming across Linux, macOS, and Windows builds by removing conditional logic and ensuring consistent naming conventions.
> 
>   - **Artifact Naming Standardization**:
>     - In `template-tauri-build-linux-x64.yml`, removed conditional logic for artifact names, using `jan-linux-amd64-${{ inputs.new_version }}-deb` and `jan-linux-amd64-${{ inputs.new_version }}-AppImage`.
>     - In `template-tauri-build-macos.yml`, included `channel` in artifact name as `jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.dmg`.
>     - In `template-tauri-build-windows-x64.yml`, simplified artifact naming to `jan-windows-${{ inputs.new_version }}`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 31b3ee6956a0a22199dade8d22f24409166d98b1. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->