### PR TITLE
Chore cua mac runner

### DIFF
--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -309,7 +309,7 @@ jobs:
           ./autoqa/scripts/ubuntu_post_cleanup.sh "$IS_NIGHTLY"
 
   macos:
-    runs-on: macos-selfhosted-15-arm64
+    runs-on: macos-selfhosted-15-arm64-cua
     timeout-minutes: 60
 
     env:


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/autoqa-template.yml` file. The change updates the `runs-on` property for the `macos` job to use a more specific runner. 

* [`.github/workflows/autoqa-template.yml`](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L312-R312): Changed `runs-on` from `macos-selfhosted-15-arm64` to `macos-selfhosted-15-arm64-cua` for the `macos` job to specify a custom runner.