### PR TITLE
fix: Allow N-GPU Layers (NGL) to be set to 0 in llama.cpp

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1182,7 +1182,7 @@ export default class llamacpp_extension extends AIEngine {
 
     // Add remaining options from the interface
     if (cfg.chat_template) args.push('--chat-template', cfg.chat_template)
-    args.push('-ngl', String(cfg.n_gpu_layers > 0 ? cfg.n_gpu_layers : 100))
+    args.push('-ngl', String(cfg.n_gpu_layers >= 0 ? cfg.n_gpu_layers : 100))
     if (cfg.threads > 0) args.push('--threads', String(cfg.threads))
     if (cfg.threads_batch > 0)
       args.push('--threads-batch', String(cfg.threads_batch))

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1182,7 +1182,9 @@ export default class llamacpp_extension extends AIEngine {
 
     // Add remaining options from the interface
     if (cfg.chat_template) args.push('--chat-template', cfg.chat_template)
-    args.push('-ngl', String(cfg.n_gpu_layers >= 0 ? cfg.n_gpu_layers : 100))
+    const gpu_layers =
+      parseInt(String(cfg.n_gpu_layers)) >= 0 ? cfg.n_gpu_layers : 100
+    args.push('-ngl', String(gpu_layers))
     if (cfg.threads > 0) args.push('--threads', String(cfg.threads))
     if (cfg.threads_batch > 0)
       args.push('--threads-batch', String(cfg.threads_batch))


### PR DESCRIPTION
The `n_gpu_layers` (NGL) setting in the llama.cpp extension was incorrectly preventing users from disabling GPU layers by automatically defaulting to 100 when set to 0.

This was caused by a condition that only pushed `cfg.n_gpu_layers` if it was greater than 0 (`cfg.n_gpu_layers > 0`).

This commit updates the condition to `cfg.n_gpu_layers >= 0`, allowing 0 to be a valid and accepted value for NGL. This ensures that users can effectively disable GPU offloading when desired.

## Fixes Issues

- Closes #5899

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes issue in `index.ts` allowing `n_gpu_layers` to be set to 0, enabling GPU layer disabling.
> 
>   - **Behavior**:
>     - Fixes issue in `index.ts` where setting `n_gpu_layers` to 0 defaulted to 100, preventing GPU layer disabling.
>     - Updates condition to `cfg.n_gpu_layers >= 0` to allow 0 as a valid value.
>   - **Fixes**:
>     - Closes issue #5899.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 23e2a32682eec78d69c3d60127da7038001d025a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->