### PR TITLE
fix: Frontend updates when llama.cpp backend auto-downloads

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -615,6 +615,17 @@ export default class llamacpp_extension extends AIEngine {
         `Successfully updated to backend: ${targetBackendString} (preserved backend type: ${currentBackend})`
       )
 
+      // Emit for updating fe
+      if (events && typeof events.emit === 'function') {
+        logger.info(
+          `Emitting settingsChanged event for version_backend with value: ${targetBackendString}`
+        )
+        events.emit('settingsChanged', {
+          key: 'version_backend',
+          value: targetBackendString,
+        })
+      }
+
       // Clean up old versions of the same backend type
       if (IS_WINDOWS) {
         await new Promise((resolve) => setTimeout(resolve, 500))

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -37,6 +37,7 @@ import { IconFolderPlus, IconLoader, IconRefresh } from '@tabler/icons-react'
 import { getProviders } from '@/services/providers'
 import { toast } from 'sonner'
 import { useEffect, useState } from 'react'
+import { events } from '@janhq/core'
 import { predefinedProviders } from '@/consts/providers'
 import { useModelLoad } from '@/hooks/useModelLoad'
 import { useLlamacppDevices } from '@/hooks/useLlamacppDevices'
@@ -129,6 +130,19 @@ function ProviderDetail() {
       return () => clearInterval(intervalId)
     }
   }, [provider, needsBackendConfig])
+
+  // Listen for settingsChanged event and refresh backend list if version_backend changes
+  useEffect(() => {
+    const handler = (event: { key: string; value: string }) => {
+      if (event.key === 'version_backend') {
+        refreshSettings()
+      }
+    }
+    events.on('settingsChanged', handler)
+    return () => {
+      events.off('settingsChanged', handler)
+    }
+  }, [provider])
 
   // Auto-refresh models for non-predefined providers
   useEffect(() => {


### PR DESCRIPTION
When the llama.cpp extension automatically downloads a new backend version, the frontend was not being notified, leading to it displaying outdated backend information.

This commit adds an `events.emit('settingsChanged')` call after a successful backend update. This event, with `key: 'version_backend'` and the `targetBackendString` as its `value`, will now inform the frontend of the change, ensuring that the displayed backend version correctly reflects the newly downloaded one.

Fixes: #5901

**Frontend**:
 - In `$providerName.tsx`, listens for `settingsChanged` event to refresh settings when `version_backend` changes.
 - Uses `useEffect` to handle event subscription and cleanup.

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds event emission in `llamacpp_extension` to notify frontend of backend updates, ensuring displayed version is current.
> 
>   - **Behavior**:
>     - Adds `events.emit('settingsChanged')` in `llamacpp_extension` class in `index.ts` after backend update to notify frontend.
>     - Emits event with `key: 'version_backend'` and `value: targetBackendString`.
>   - **Frontend**:
>     - In `$providerName.tsx`, listens for `settingsChanged` event to refresh settings when `version_backend` changes.
>     - Uses `useEffect` to handle event subscription and cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 37c4abd364ba58584cd29f51ba6546051c5e9d83. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->