### PR TITLE
chore: revert back to passive mode on windows installer

### DIFF
--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -454,7 +454,7 @@ Function .onInit
     StrCpy $PassiveMode 1
   ${EndIf}
   ; always run in passive mode
-  ; StrCpy $PassiveMode 1
+  StrCpy $PassiveMode 1
 
   ${GetOptions} $CMDLINE "/NS" $NoShortcutMode
   ${IfNot} ${Errors}


### PR DESCRIPTION
This pull request includes a minor change to the `src-tauri/tauri.bundle.windows.nsis.template` file. The change ensures that the `PassiveMode` variable is always set to `1` in the `.onInit` function.

There's no selection for path  or uninstall for now. We'll try to enhance it on upcoming releases

<img width="502" height="386" alt="image" src="https://github.com/user-attachments/assets/fd1c506b-1451-4c14-b8da-9d3d52838925" />


* [`src-tauri/tauri.bundle.windows.nsis.template`](diffhunk://#diff-ea45fdac6b0d37b85ce8b88b068c50ac6c44fd53cf2c3ce1d18691c5c73f3facL457-R457): Uncommented the line that sets `$PassiveMode` to `1`, ensuring it always runs in passive mode.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Uncommented line in `src-tauri/tauri.bundle.windows.nsis.template` to ensure Windows installer always runs in passive mode.
> 
>   - **Behavior**:
>     - In `src-tauri/tauri.bundle.windows.nsis.template`, uncommented `StrCpy $PassiveMode 1` in `.onInit` to ensure installer always runs in passive mode.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 2b91162a4e224c9f891ce7151ef2dedaaec8c30b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->