### PR TITLE
fix: update default GPU toggle, and simplify state

### DIFF
--- a/web-app/src/routes/settings/hardware.tsx
+++ b/web-app/src/routes/settings/hardware.tsx
@@ -45,7 +45,6 @@ function Hardware() {
     devices: llamacppDevices,
     loading: llamacppDevicesLoading,
     error: llamacppDevicesError,
-    activatedDevices,
     toggleDevice,
     fetchDevices,
   } = IS_MACOS
@@ -53,7 +52,6 @@ function Hardware() {
         devices: [],
         loading: false,
         error: null,
-        activatedDevices: new Set(),
         toggleDevice: () => {},
         fetchDevices: () => {},
       }
@@ -87,43 +85,7 @@ function Hardware() {
     })
   }, [setHardwareData, updateSystemUsage])
 
-  const { getProviderByName } = useModelProvider()
 
-  // Initialize llamacpp device activations from provider settings
-  useEffect(() => {
-    if (llamacppDevices.length > 0 && activatedDevices.size === 0) {
-      const llamacppProvider = getProviderByName('llamacpp')
-      const currentDeviceSetting = llamacppProvider?.settings.find(
-        (s) => s.key === 'device'
-      )?.controller_props.value as string
-
-      if (currentDeviceSetting) {
-        const deviceIds = currentDeviceSetting
-          .split(',')
-          .map((device) => device.trim())
-          .filter((device) => device.length > 0)
-
-        // Find matching devices by ID
-        const matchingDeviceIds = deviceIds.filter((deviceId) =>
-          llamacppDevices.some((device) => device.id === deviceId)
-        )
-
-        if (matchingDeviceIds.length > 0) {
-          console.log(
-            `Initializing llamacpp device activations from device setting: "${currentDeviceSetting}"`
-          )
-          // Update the activatedDevices in the hook
-          const { setActivatedDevices } = useLlamacppDevices.getState()
-          setActivatedDevices(matchingDeviceIds)
-        }
-      }
-    }
-  }, [
-    llamacppDevices.length,
-    activatedDevices.size,
-    getProviderByName,
-    llamacppDevices,
-  ])
 
   useEffect(() => {
     if (pollingPaused) return
@@ -361,7 +323,7 @@ function Hardware() {
                             </span>
                           </div> */}
                               <Switch
-                                checked={activatedDevices.has(device.id)}
+                                checked={device.activated}
                                 onCheckedChange={() => {
                                   toggleDevice(device.id)
                                   stopAllModels()

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -367,9 +367,10 @@ function ProviderDetail() {
 
                                   // Reset llamacpp device activations when backend version changes
                                   if (providerName === 'llamacpp') {
-                                    const { setActivatedDevices } =
+                                    // Refresh devices to update activation status from provider settings
+                                    const { fetchDevices } =
                                       useLlamacppDevices.getState()
-                                    setActivatedDevices([])
+                                    fetchDevices()
                                   }
                                 }
 

--- a/web-app/src/routes/system-monitor.tsx
+++ b/web-app/src/routes/system-monitor.tsx
@@ -9,7 +9,6 @@ import { IconDeviceDesktopAnalytics } from '@tabler/icons-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { toNumber } from '@/utils/number'
 import { useLlamacppDevices } from '@/hooks/useLlamacppDevices'
-import { useModelProvider } from '@/hooks/useModelProvider'
 import { getSystemUsage } from '@/services/hardware'
 
 export const Route = createFileRoute(route.systemMonitor as any)({
@@ -22,11 +21,8 @@ function SystemMonitor() {
 
   const {
     devices: llamacppDevices,
-    activatedDevices,
     fetchDevices,
-    setActivatedDevices,
   } = useLlamacppDevices()
-  const { getProviderByName } = useModelProvider()
 
   const [isInitialized, setIsInitialized] = useState(false)
 
@@ -57,41 +53,6 @@ function SystemMonitor() {
     }
   }, [hardwareData.gpus.length, isInitialized])
 
-  // Initialize llamacpp device activations from provider settings
-  useEffect(() => {
-    if (llamacppDevices.length > 0 && activatedDevices.size === 0) {
-      const llamacppProvider = getProviderByName('llamacpp')
-      const currentDeviceSetting = llamacppProvider?.settings.find(
-        (s) => s.key === 'device'
-      )?.controller_props.value as string
-
-      if (currentDeviceSetting) {
-        const deviceIds = currentDeviceSetting
-          .split(',')
-          .map((device) => device.trim())
-          .filter((device) => device.length > 0)
-
-        // Find matching devices by ID
-        const matchingDeviceIds = deviceIds.filter((deviceId) =>
-          llamacppDevices.some((device) => device.id === deviceId)
-        )
-
-        if (matchingDeviceIds.length > 0) {
-          console.log(
-            `Initializing llamacpp device activations from device setting: "${currentDeviceSetting}"`
-          )
-          // Update the activatedDevices in the hook
-          setActivatedDevices(matchingDeviceIds)
-        }
-      }
-    }
-  }, [
-    llamacppDevices.length,
-    activatedDevices.size,
-    getProviderByName,
-    llamacppDevices,
-    setActivatedDevices,
-  ])
 
   // Calculate RAM usage percentage
   const ramUsagePercentage =
@@ -209,12 +170,12 @@ function SystemMonitor() {
                       </span>
                       <span
                         className={`text-sm px-2 py-1 rounded-md ${
-                          activatedDevices.has(device.id)
+                          device.activated
                             ? 'bg-green-500/20 text-green-600 dark:text-green-400'
                             : 'hidden'
                         }`}
                       >
-                        {activatedDevices.has(device.id)
+                        {device.activated
                           ? t('system-monitor:active')
                           : 'Inactive'}
                       </span>

--- a/web-app/src/services/hardware.ts
+++ b/web-app/src/services/hardware.ts
@@ -7,6 +7,7 @@ export interface DeviceList {
   name: string
   mem: number
   free: number
+  activated: boolean
 }
 
 /**
@@ -31,12 +32,14 @@ export const getSystemUsage = async () => {
  */
 export const getLlamacppDevices = async (): Promise<DeviceList[]> => {
   const extensionManager = window.core.extensionManager
-  const llamacppExtension = extensionManager.getByName('@janhq/llamacpp-extension')
-  
+  const llamacppExtension = extensionManager.getByName(
+    '@janhq/llamacpp-extension'
+  )
+
   if (!llamacppExtension) {
     throw new Error('llamacpp extension not found')
   }
-  
+
   return llamacppExtension.getDevices()
 }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request refactors the `useLlamacppDevices` hook to simplify device activation management by incorporating the activation status directly into the `devices` array. It removes the separate `activatedDevices` state and updates related components and tests accordingly.

### Refactor of device activation management:

* [`web-app/src/hooks/useLlamacppDevices.ts`](diffhunk://#diff-c4b597a63b921ff5e312407fd6bcffca9f52ab270cdfe067b12d31eb59d0c50fL7-R48): Removed the `activatedDevices` state and added an `activated` property to each device in the `devices` array. Updated the `fetchDevices` and `toggleDevice` methods to handle activation status directly within the `devices` array. [[1]](diffhunk://#diff-c4b597a63b921ff5e312407fd6bcffca9f52ab270cdfe067b12d31eb59d0c50fL7-R48) [[2]](diffhunk://#diff-c4b597a63b921ff5e312407fd6bcffca9f52ab270cdfe067b12d31eb59d0c50fL44-R88) [[3]](diffhunk://#diff-c4b597a63b921ff5e312407fd6bcffca9f52ab270cdfe067b12d31eb59d0c50fL81-L83)

* [`web-app/src/services/hardware.ts`](diffhunk://#diff-2bc62b260eee5a2fafbd7c17eebed7ef6a1f7d7b5e1295bf3fe615cbd1f9c9fbR10): Updated the `DeviceList` interface to include an `activated` property and ensured that devices fetched from the llamacpp extension include their activation status. [[1]](diffhunk://#diff-2bc62b260eee5a2fafbd7c17eebed7ef6a1f7d7b5e1295bf3fe615cbd1f9c9fbR10) [[2]](diffhunk://#diff-2bc62b260eee5a2fafbd7c17eebed7ef6a1f7d7b5e1295bf3fe615cbd1f9c9fbL34-R37)

### Updates to tests:

* [`web-app/src/hooks/__tests__/useLlamacppDevices.test.ts`](diffhunk://#diff-f32e58eb552723e32c48706f8700ca82004fd5383d8e38022e519ec9e9df0cecL34-R40): Updated tests to reflect the new activation status handling. Removed references to `activatedDevices` and validated the `activated` property within the `devices` array. [[1]](diffhunk://#diff-f32e58eb552723e32c48706f8700ca82004fd5383d8e38022e519ec9e9df0cecL34-R40) [[2]](diffhunk://#diff-f32e58eb552723e32c48706f8700ca82004fd5383d8e38022e519ec9e9df0cecL56-R58) [[3]](diffhunk://#diff-f32e58eb552723e32c48706f8700ca82004fd5383d8e38022e519ec9e9df0cecL92-L131)

### Component updates:

* [`web-app/src/routes/settings/hardware.tsx`](diffhunk://#diff-d4f11f86491a0e923189aaa8facc6feff349ded1b6d5e72e81e7b17c21e8eebbL48-L56): Removed logic for initializing `activatedDevices` and updated UI bindings to use the `activated` property of devices. [[1]](diffhunk://#diff-d4f11f86491a0e923189aaa8facc6feff349ded1b6d5e72e81e7b17c21e8eebbL48-L56) [[2]](diffhunk://#diff-d4f11f86491a0e923189aaa8facc6feff349ded1b6d5e72e81e7b17c21e8eebbL90-L126) [[3]](diffhunk://#diff-d4f11f86491a0e923189aaa8facc6feff349ded1b6d5e72e81e7b17c21e8eebbL364-R326)

* [`web-app/src/routes/system-monitor.tsx`](diffhunk://#diff-bd816fbf26f1b5eda3ac410934b8ecf23505d4ed201cb7965338399dc3e6df7dL12): Simplified the component by removing initialization logic for `activatedDevices` and updated UI elements to reflect the new `activated` property. [[1]](diffhunk://#diff-bd816fbf26f1b5eda3ac410934b8ecf23505d4ed201cb7965338399dc3e6df7dL12) [[2]](diffhunk://#diff-bd816fbf26f1b5eda3ac410934b8ecf23505d4ed201cb7965338399dc3e6df7dL25-L29) [[3]](diffhunk://#diff-bd816fbf26f1b5eda3ac410934b8ecf23505d4ed201cb7965338399dc3e6df7dL60-L94) [[4]](diffhunk://#diff-bd816fbf26f1b5eda3ac410934b8ecf23505d4ed201cb7965338399dc3e6df7dL212-R178)

### Other updates:

* [`web-app/src/routes/settings/providers/$providerName.tsx`](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5L370-R373): Adjusted llamacpp device activation reset logic to use the updated `fetchDevices` method instead of `setActivatedDevices`.

## Fixes Issues

- Closes #5898 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor `useLlamacppDevices` to manage device activation within `devices` array, updating components and tests accordingly.
> 
>   - **Behavior**:
>     - Refactor `useLlamacppDevices` in `useLlamacppDevices.ts` to include `activated` status in `devices` array, removing `activatedDevices` state.
>     - Update `fetchDevices` and `toggleDevice` to manage activation within `devices`.
>     - Modify `DeviceList` in `hardware.ts` to include `activated` property.
>   - **Tests**:
>     - Update `useLlamacppDevices.test.ts` to validate `activated` property in `devices` and remove `activatedDevices` references.
>   - **Components**:
>     - Update `hardware.tsx` and `system-monitor.tsx` to use `activated` property for UI logic.
>     - Adjust llamacpp device activation reset logic in `$providerName.tsx` to use `fetchDevices`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ed8442e10180b496d53e94bebf63ff566ba1bd80. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->