### PR TITLE
fix: Remove sInfo from activeSessions before unloading

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1251,6 +1251,8 @@ export default class llamacpp_extension extends AIEngine {
     }
     const pid = sInfo.pid
     try {
+      this.activeSessions.delete(pid)
+
       // Pass the PID as the session_id
       const result = await invoke<UnloadResult>('unload_llama_model', {
         pid: pid,
@@ -1258,15 +1260,16 @@ export default class llamacpp_extension extends AIEngine {
 
       // If successful, remove from active sessions
       if (result.success) {
-        this.activeSessions.delete(pid)
         logger.info(`Successfully unloaded model with PID ${pid}`)
       } else {
         logger.warn(`Failed to unload model: ${result.error}`)
+        this.activeSessions.set(sInfo.pid, sInfo)
       }
 
       return result
     } catch (error) {
       logger.error('Error in unload command:', error)
+      this.activeSessions.set(sInfo.pid, sInfo)
       return {
         success: false,
         error: `Failed to unload model: ${error}`,


### PR DESCRIPTION
This change addresses a potential race condition that could lead to "connection errors" when unloading a llamacpp model.

The issue arose because the `activeSessions` map still has the session info of the model during unload. This could lead to "connection errors" when the backend is taking time to unload while there is an ongoing request to the model.

The fix involves:

1. **Deleting the `pid` from `activeSessions` before calling backend's unload:** This ensures that the model is cleared from the map before we start unloading.
2. **Failure handling**: If somehow the backend fails to unload, the session info for that model is added back to prevent any race conditions.

This change improves the robustness and reliability of the unloading process by preventing potential conflicts.
