### PR TITLE
fix: tool approval params scrollable

### DIFF
--- a/web-app/src/containers/dialogs/ToolApproval.tsx
+++ b/web-app/src/containers/dialogs/ToolApproval.tsx
@@ -59,12 +59,12 @@ export default function ToolApproval() {
         </DialogHeader>
 
         {toolParameters && Object.keys(toolParameters).length > 0 && (
-          <div className="bg-main-view-fg/4 p-2 border border-main-view-fg/5 rounded-lg">
+          <div className="bg-main-view-fg/4 p-2 border border-main-view-fg/5 rounded-lg overflow-x-scroll">
             <h4 className="text-sm font-medium text-main-view-fg mb-2">
               {t('tools:toolApproval.parameters')}
             </h4>
-            <div className="bg-main-view-fg/6 rounded-md p-2 text-sm font-mono border border-main-view-fg/5">
-              <pre className="text-main-view-fg/80 whitespace-pre-wrap break-words">
+            <div className="relative bg-main-view-fg/6 rounded-md p-2 text-sm font-mono border border-main-view-fg/5 overflow-x-auto">
+              <pre className="text-main-view-fg/80 whitespace-pre-wrap">
                 {JSON.stringify(toolParameters, null, 2)}
               </pre>
             </div>


### PR DESCRIPTION
## Describe Your Changes
Issue 
<img width="674" height="533" alt="41132" src="https://github.com/user-attachments/assets/5f99df21-215d-4d51-8fd6-cbf8386244cb" />

This pull request includes multiple changes across workflow files, Python scripts, and the `Makefile`. The changes primarily focus on improving logging consistency, enhancing artifact collection and upload in workflows, and refining build and cleanup processes. Below is a summary of the most important changes:

### Logging Improvements
* Updated log messages in `.github/workflows/autoqa-template.yml` and `autoqa/main.py` to use consistent tags like `[SUCCESS]`, `[FAILED]`, and `[INFO]` instead of emojis for better readability and standardization. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L85-R91) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732L199-R231) [[3]](diffhunk://#diff-1f5446dd76db6e94b569f4c49b0ddff3eae88afe4396c9deec8614d3cb7660daL452-R462)

### Workflow Enhancements
* Added steps to collect and upload Jan logs and screen recordings as artifacts in `.github/workflows/autoqa-template.yml` for all platforms (Windows, Ubuntu, macOS). This ensures better traceability and debugging capabilities. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R130-R159) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R285-R312) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R444-R464)
* Updated `runs-on` labels in `.github/workflows/jan-linter-and-test.yml` to use `macos-selfhosted-15-arm64` for consistency with other workflows.

### Build and Cleanup Refinements
* Replaced `yarn copy:lib` with `yarn download:lib` in the `Makefile` to streamline dependency management.
* Enhanced the `clean` target in the `Makefile` by adding verbose output (`-v`) to cleanup commands for better visibility into the cleanup process.

### Artifact Path Adjustments
* Adjusted artifact paths in `.github/workflows/jan-linter-and-test.yml` to point to `coverage/lcov.info` instead of `coverage/merged/lcov.info`, aligning with the updated directory structure.

### Dependency and Configuration Updates
* Modified the Linux Tauri build workflow (`template-tauri-build-linux-x64.yml`) to update the `tauri.linux.conf.json` configuration, ensuring Vulkan library paths are correctly set under `resources/lib`.

These changes collectively enhance the maintainability, readability, and functionality of the workflows and scripts.


## Fixes Issues

<img width="1063" height="845" alt="Screenshot 2025-07-28 at 08 44 05" src="https://github.com/user-attachments/assets/1b7bb122-ec86-46e8-bf0d-000d399e6c23" />


- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Make tool parameters horizontally scrollable in `ToolApproval.tsx` for better usability.
> 
>   - **UI Enhancement**:
>     - In `ToolApproval.tsx`, added `overflow-x-scroll` to the container div for tool parameters, making them horizontally scrollable.
>     - Added `overflow-x-auto` to the inner div containing the JSON string, ensuring it is also scrollable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 3cb1a18fdf66a99093a9c09a955207121c53ff0b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->