### PR TITLE
chore: uninstall when upgrading windows installer

### DIFF
--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -286,6 +286,12 @@ Function PageReinstallUpdateSelection
   ${EndIf}
 FunctionEnd
 Function PageLeaveReinstall
+  ; In passive mode, always uninstall when upgrading
+  ${If} $PassiveMode = 1
+  ${AndIf} $R0 = 1  ; Upgrading
+    Goto reinst_uninstall
+  ${EndIf}
+
   ${NSD_GetState} $R2 $R1
 
   ; If migrating from Wix, always uninstall


### PR DESCRIPTION
This pull request introduces a small but important enhancement to the NSIS installer script to improve the behavior during upgrades in passive mode.

* [`src-tauri/tauri.bundle.windows.nsis.template`](diffhunk://#diff-ea45fdac6b0d37b85ce8b88b068c50ac6c44fd53cf2c3ce1d18691c5c73f3facR289-R294): Updated the `PageLeaveReinstall` function to ensure that in passive mode, the installer always uninstalls the previous version when upgrading.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Ensure previous version is uninstalled during upgrades in passive mode in NSIS installer script.
> 
>   - **Behavior**:
>     - In `PageLeaveReinstall` function, ensure previous version is uninstalled during upgrades in passive mode in `tauri.bundle.windows.nsis.template`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for cb524631b9930f4fbc5b248e7f3fa030de3f4145. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->