### PR TITLE
fix: update edge case experimental feature MCP

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -51,7 +51,7 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
   const { prompt, setPrompt } = usePrompt()
   const { currentThreadId } = useThreads()
   const { t } = useTranslation()
-  const { spellCheckChatInput } = useGeneralSetting()
+  const { spellCheckChatInput, experimentalFeatures } = useGeneralSetting()
 
   const maxRows = 10
 
@@ -459,7 +459,8 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
                   </TooltipProvider>
                 )}
 
-                {selectedModel?.capabilities?.includes('tools') &&
+                {experimentalFeatures &&
+                  selectedModel?.capabilities?.includes('tools') &&
                   hasActiveMCPServers && (
                     <TooltipProvider>
                       <Tooltip

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -123,6 +123,7 @@ describe('ChatInput', () => {
     vi.mocked(useGeneralSetting).mockReturnValue({
       spellCheckChatInput: true,
       allowSendWhenUnloaded: false,
+      experimentalFeatures: true,
     })
     
     vi.mocked(useModelProvider).mockReturnValue({

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -31,9 +31,11 @@ import { OUT_OF_CONTEXT_SIZE } from '@/utils/error'
 import { updateSettings } from '@/services/providers'
 import { useContextSizeApproval } from './useModelContextApproval'
 import { useModelLoad } from './useModelLoad'
+import { useGeneralSetting } from './useGeneralSetting'
 
 export const useChat = () => {
   const { prompt, setPrompt } = usePrompt()
+  const { experimentalFeatures } = useGeneralSetting()
   const {
     tools,
     updateTokenSpeed,
@@ -247,12 +249,13 @@ export const useChat = () => {
         let isCompleted = false
 
         // Filter tools based on model capabilities and available tools for this thread
-        let availableTools = selectedModel?.capabilities?.includes('tools')
-          ? tools.filter((tool) => {
-              const disabledTools = getDisabledToolsForThread(activeThread.id)
-              return !disabledTools.includes(tool.name)
-            })
-          : []
+        let availableTools =
+          experimentalFeatures && selectedModel?.capabilities?.includes('tools')
+            ? tools.filter((tool) => {
+                const disabledTools = getDisabledToolsForThread(activeThread.id)
+                return !disabledTools.includes(tool.name)
+              })
+            : []
 
         // TODO: Later replaced by Agent setup?
         const followUpWithToolUse = true

--- a/web-app/src/routes/settings/general.tsx
+++ b/web-app/src/routes/settings/general.tsx
@@ -45,6 +45,9 @@ import { emit } from '@tauri-apps/api/event'
 import { stopAllModels } from '@/services/models'
 import { SystemEvent } from '@/types/events'
 import { Input } from '@/components/ui/input'
+import { getConnectedServers } from '@/services/mcp'
+import { invoke } from '@tauri-apps/api/core'
+import { useMCPServers } from '@/hooks/useMCPServers'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.general as any)({
@@ -201,6 +204,38 @@ function General() {
       setIsCheckingUpdate(false)
     }
   }, [t, checkForUpdate])
+
+  const handleStopAllMCPServers = async () => {
+    try {
+      const connectedServers = await getConnectedServers()
+
+      // Stop each connected server
+      const stopPromises = connectedServers.map((serverName) =>
+        invoke('deactivate_mcp_server', { name: serverName }).catch((error) => {
+          console.error(`Error stopping MCP server ${serverName}:`, error)
+          return Promise.resolve() // Continue with other servers even if one fails
+        })
+      )
+
+      await Promise.all(stopPromises)
+
+      // Update server configs to set active: false for stopped servers
+      const { mcpServers, editServer } = useMCPServers.getState()
+      connectedServers.forEach((serverName) => {
+        const serverConfig = mcpServers[serverName]
+        if (serverConfig) {
+          editServer(serverName, { ...serverConfig, active: false })
+        }
+      })
+
+      if (connectedServers.length > 0) {
+        toast.success(`Stopped ${connectedServers.length} MCP server(s)`)
+      }
+    } catch (error) {
+      console.error('Error stopping MCP servers:', error)
+      toast.error('Failed to stop MCP servers')
+    }
+  }
 
   return (
     <div className="flex flex-col h-full">
@@ -395,7 +430,10 @@ function General() {
                 actions={
                   <Switch
                     checked={experimentalFeatures}
-                    onCheckedChange={(e) => setExperimentalFeatures(e)}
+                    onCheckedChange={async (e) => {
+                      await handleStopAllMCPServers()
+                      setExperimentalFeatures(e)
+                    }}
                   />
                 }
               />

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -114,8 +114,15 @@ function MCPServers() {
     setDeleteDialogOpen(true)
   }
 
-  const handleConfirmDelete = () => {
+  const handleConfirmDelete = async () => {
     if (serverToDelete) {
+      // Stop the server before deletion
+      try {
+        await invoke('deactivate_mcp_server', { name: serverToDelete })
+      } catch (error) {
+        console.error('Error stopping server before deletion:', error)
+      }
+
       deleteServer(serverToDelete)
       setServerToDelete(null)
       syncServersAndRestart()
@@ -225,6 +232,8 @@ function MCPServers() {
 
     return () => clearInterval(intervalId)
   }, [setConnectedServers])
+
+  console.log(mcpServers)
 
   return (
     <div className="flex flex-col h-full">

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -233,7 +233,6 @@ function MCPServers() {
     return () => clearInterval(intervalId)
   }, [setConnectedServers])
 
-  console.log(mcpServers)
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces support for experimental features in the chat application and includes updates to improve the management of MCP servers. Key changes involve conditional logic updates, test adjustments, and new server management functionality.

### Experimental Features Integration:
* Added `experimentalFeatures` to the `useGeneralSetting` hook and updated `ChatInput` to conditionally enable tools based on this setting. (`web-app/src/containers/ChatInput.tsx`: [[1]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L54-R54) [[2]](diffhunk://#diff-e6927577dd0c5d682ae3ac9367b9a6b7df9f76df4cf35c5a05779e539749f417L462-R463)
* Updated tests for `ChatInput` to mock the `experimentalFeatures` setting. (`web-app/src/containers/__tests__/ChatInput.test.tsx`: [web-app/src/containers/__tests__/ChatInput.test.tsxR126](diffhunk://#diff-2f4b73d2939af1b8f41eb86d7645956a0c820eff7abd683f7fb16a30e735a22bR126))
* Incorporated `experimentalFeatures` into the `useChat` hook to filter available tools based on this setting. (`web-app/src/hooks/useChat.ts`: [[1]](diffhunk://#diff-59eb5d98b18b4ca78a2f111ac815894aff65119eccedf03adf0ef24c74b987bdR34-R38) [[2]](diffhunk://#diff-59eb5d98b18b4ca78a2f111ac815894aff65119eccedf03adf0ef24c74b987bdL250-R253)

### MCP Server Management Enhancements:
* Added a function to stop all connected MCP servers, update their configurations, and display success or error messages. (`web-app/src/routes/settings/general.tsx`: [web-app/src/routes/settings/general.tsxR208-R239](diffhunk://#diff-740613346f469114d3fae10488e30bccb61aa6ba942e086610a625820c185340R208-R239))
* Integrated the server-stopping functionality into the toggle for enabling/disabling experimental features. (`web-app/src/routes/settings/general.tsx`: [web-app/src/routes/settings/general.tsxL398-R436](diffhunk://#diff-740613346f469114d3fae10488e30bccb61aa6ba942e086610a625820c185340L398-R436))
* Updated the MCP server deletion process to ensure servers are stopped before being deleted. (`web-app/src/routes/settings/mcp-servers.tsx`: [web-app/src/routes/settings/mcp-servers.tsxL117-R125](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78L117-R125))

### Miscellaneous:
* Added a debug log for MCP servers in the MCP Servers settings page. (`web-app/src/routes/settings/mcp-servers.tsx`: [web-app/src/routes/settings/mcp-servers.tsxR236-R237](diffhunk://#diff-72b10433b6e314de3a4fd888c009ee5d691aef5ba675a4630423a280d4382b78R236-R237))

## Fixes Issues

https://github.com/user-attachments/assets/bcc1ad0a-dee5-4eeb-b3c3-fa4b2ff56779
https://github.com/user-attachments/assets/585b01c2-d787-4f03-b2df-1aa93d11e7bd
https://github.com/user-attachments/assets/d0aeed83-b602-4b6f-9f07-7f9f8d8d5d71


- Closes #5946 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Integrate experimental features and enhance MCP server management in `ChatInput`, `useChat`, and settings routes.
> 
>   - **Experimental Features Integration**:
>     - Add `experimentalFeatures` to `useGeneralSetting` and update `ChatInput` to conditionally enable tools based on this setting.
>     - Update `ChatInput` tests to mock `experimentalFeatures`.
>     - Incorporate `experimentalFeatures` into `useChat` to filter tools.
>   - **MCP Server Management Enhancements**:
>     - Add function to stop all connected MCP servers and update configurations in `general.tsx`.
>     - Integrate server-stopping functionality into experimental features toggle in `general.tsx`.
>     - Update MCP server deletion to ensure servers are stopped before deletion in `mcp-servers.tsx`.
>   - **Miscellaneous**:
>     - Add debug log for MCP servers in `mcp-servers.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for bed4ac7e38a009a5ab0c9953ee834b0290814c19. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->