### PR TITLE
fix: factory reset fail with access denied error

### DIFF
--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -132,7 +132,8 @@ pub fn factory_reset(app_handle: tauri::AppHandle, state: State<'_, AppState>) {
         let _ = fs::create_dir_all(&data_folder).map_err(|e| e.to_string());
 
         // Reset the configuration
-        let default_config = AppConfiguration::default();
+        let mut default_config = AppConfiguration::default();
+        default_config.data_folder = default_data_folder_path(app_handle.clone());
         let _ = update_app_configuration(app_handle.clone(), default_config);
 
         app_handle.restart();

--- a/src-tauri/src/core/cmd.rs
+++ b/src-tauri/src/core/cmd.rs
@@ -2,6 +2,8 @@ use serde::{Deserialize, Serialize};
 use std::{fs, io, path::PathBuf};
 use tauri::{AppHandle, Manager, Runtime, State};
 
+use crate::core::utils::extensions::inference_llamacpp_extension::cleanup::cleanup_processes;
+
 use super::{server, setup, state::AppState};
 
 const CONFIGURATION_FILE_NAME: &str = "settings.json";
@@ -102,6 +104,39 @@ pub fn get_jan_data_folder_path<R: Runtime>(app_handle: tauri::AppHandle<R>) -> 
 #[tauri::command]
 pub fn get_jan_extensions_path(app_handle: tauri::AppHandle) -> PathBuf {
     get_jan_data_folder_path(app_handle).join("extensions")
+}
+
+#[tauri::command]
+pub fn factory_reset(app_handle: tauri::AppHandle, state: State<'_, AppState>) {
+    // close window
+    let windows = app_handle.webview_windows();
+    for (label, window) in windows.iter() {
+        window.close().unwrap_or_else(|_| {
+            log::warn!("Failed to close window: {:?}", label);
+        });
+    }
+    let data_folder = get_jan_data_folder_path(app_handle.clone());
+    log::info!("Factory reset, removing data folder: {:?}", data_folder);
+
+    tauri::async_runtime::block_on(async {
+        cleanup_processes(state).await;
+
+        if data_folder.exists() {
+            if let Err(e) = fs::remove_dir_all(&data_folder) {
+                log::error!("Failed to remove data folder: {}", e);
+                return;
+            }
+        }
+
+        // Recreate the data folder
+        let _ = fs::create_dir_all(&data_folder).map_err(|e| e.to_string());
+
+        // Reset the configuration
+        let default_config = AppConfiguration::default();
+        let _ = update_app_configuration(app_handle.clone(), default_config);
+
+        app_handle.restart();
+    });
 }
 
 #[tauri::command]

--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -199,7 +199,7 @@ pub fn setup_mcp(app: &App) {
     let state = app.state::<AppState>();
     let servers = state.mcp_servers.clone();
     let app_handle: tauri::AppHandle = app.handle().clone();
-    // Setup kill-mcp-servers event listener (similar to cortex kill-sidecar)
+    // Setup kill-mcp-servers event listener (similar to kill-sidecar)
     let app_handle_for_kill = app_handle.clone();
     app_handle.listen("kill-mcp-servers", move |_event| {
         let app_handle = app_handle_for_kill.clone();

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,4 +1,5 @@
 mod core;
+use core::utils::extensions::inference_llamacpp_extension::cleanup::cleanup_processes;
 use core::{
     cmd::get_jan_data_folder_path,
     setup::{self, setup_mcp},
@@ -8,7 +9,6 @@ use core::{
 use reqwest::Client;
 use std::{collections::HashMap, sync::Arc};
 use tauri::{Emitter, Manager};
-use core::utils::extensions::inference_llamacpp_extension::cleanup::cleanup_processes;
 
 use tokio::sync::Mutex;
 
@@ -58,6 +58,7 @@ pub fn run() {
             core::cmd::get_server_status,
             core::cmd::read_logs,
             core::cmd::change_app_data_folder,
+            core::cmd::factory_reset,
             // MCP commands
             core::mcp::get_tools,
             core::mcp::call_tool,

--- a/web-app/src/routes/settings/general.tsx
+++ b/web-app/src/routes/settings/general.tsx
@@ -45,6 +45,7 @@ import { emit } from '@tauri-apps/api/event'
 import { stopAllModels } from '@/services/models'
 import { SystemEvent } from '@/types/events'
 import { Input } from '@/components/ui/input'
+import { useHardware } from '@/hooks/useHardware'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.general as any)({
@@ -72,6 +73,7 @@ function General() {
     }
   }
   const { checkForUpdate } = useAppUpdater()
+  const { pausePolling } = useHardware()
   const [janDataFolder, setJanDataFolder] = useState<string | undefined>()
   const [isCopied, setIsCopied] = useState(false)
   const [selectedNewPath, setSelectedNewPath] = useState<string | null>(null)
@@ -88,6 +90,7 @@ function General() {
   }, [])
 
   const resetApp = async () => {
+    pausePolling()
     // TODO: Loading indicator
     await factoryReset()
   }

--- a/web-app/src/services/app.ts
+++ b/web-app/src/services/app.ts
@@ -1,8 +1,6 @@
 import { AppConfiguration, fs } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
-import { emit } from '@tauri-apps/api/event'
 import { stopAllModels } from './models'
-import { SystemEvent } from '@/types/events'
 
 /**
  * @description This function is used to reset the app to its factory settings.
@@ -12,14 +10,8 @@ import { SystemEvent } from '@/types/events'
 export const factoryReset = async () => {
   // Kill background processes and remove data folder
   await stopAllModels()
-  emit(SystemEvent.KILL_SIDECAR)
-  setTimeout(async () => {
-    const janDataFolderPath = await getJanDataFolder()
-    if (janDataFolderPath) await fs.rm(janDataFolderPath)
-    window.localStorage.clear()
-    await window.core?.api?.installExtensions()
-    await window.core?.api?.relaunch()
-  }, 1000)
+  window.localStorage.clear()
+  await invoke('factory_reset')
 }
 
 /**

--- a/web-app/src/services/app.ts
+++ b/web-app/src/services/app.ts
@@ -1,4 +1,4 @@
-import { AppConfiguration, fs } from '@janhq/core'
+import { AppConfiguration } from '@janhq/core'
 import { invoke } from '@tauri-apps/api/core'
 import { stopAllModels } from './models'
 


### PR DESCRIPTION
## Describe Your Changes

This is to stop all progresses running in the background before proceeding for a factory reset. Otherwise it may cause permission denied error on Windows.
This will also resolve the issue where the default data folder path is not reset.

## Fixes Issues

- Closes #5912
- Closes #5182

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `factory_reset` command to stop background processes before resetting to prevent Windows permission errors.
> 
>   - **Behavior**:
>     - Add `factory_reset` command in `cmd.rs` to stop background processes, close windows, and reset configurations.
>     - Update `general.tsx` to pause hardware polling during factory reset.
>   - **Tests**:
>     - Update `app.test.ts` to test `factoryReset` behavior with new command.
>   - **Misc**:
>     - Minor comment update in `setup.rs`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 94b1f7460908984bd04ba3c9ba0577da1a5b3709. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->