### PR TITLE
fix: correctly apply `auto_unload` setting from config

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -779,6 +779,8 @@ export default class llamacpp_extension extends AIEngine {
         await this.ensureBackendReady(backend, version)
       }
       closure()
+    } else if (key === 'auto_unload') {
+        this.autoUnload = value as boolean
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes
Previously, the `autoUnload` flag was not being updated when set via config, causing models to be auto-unloaded regardless of the intended behavior. This patch ensures the setting is respected at runtime.

Thanks @louis-menlo for the help!