### PR TITLE
fix: set autoUnload in onLoad()

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -170,6 +170,8 @@ export default class llamacpp_extension extends AIEngine {
     }
     this.config = loadedConfig as LlamacppConfig
 
+    this.autoUnload = this.config.auto_unload
+
     // This sets the base directory where model files for this provider are stored.
     this.providerPath = await joinPath([
       await getJanDataFolderPath(),


### PR DESCRIPTION
## Describe Your Changes

The variable was not initialised resulted in always setting true when starting.

This change fixes it.

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Initialize `autoUnload` in `onLoad()` to use configuration value in `index.ts`.
> 
>   - **Behavior**:
>     - Initialize `autoUnload` in `onLoad()` in `index.ts` to use `this.config.auto_unload` instead of defaulting to `true`.
>   - **Misc**:
>     - Fixes issue where `autoUnload` was always set to `true` on start.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b24301277f9c2acf9669683e2299b086bddd3512. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->