### PR TITLE
fix: rename thread dialog shows previous thread

### DIFF
--- a/web-app/src/containers/ThreadList.tsx
+++ b/web-app/src/containers/ThreadList.tsx
@@ -158,9 +158,10 @@ const SortableItem = memo(({ thread }: { thread: Thread }) => {
             )}
             <Dialog
               onOpenChange={(open) => {
-                if (!open) {
-                  setOpenDropdown(false)
+                if (open) {
                   setTitle(plainTitleForRename || t('common:newThread'))
+                } else {
+                  setOpenDropdown(false)
                 }
               }}
             >


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a small change to the `SortableItem` component in `ThreadList.tsx`. The logic for handling the `onOpenChange` event in the `Dialog` component was updated to ensure that the `setTitle` function is called when the dialog is opened, and `setOpenDropdown` is only set to `false` when the dialog is closed.

## Fixes Issues


https://github.com/user-attachments/assets/7e61b2fd-627c-4631-82fd-97173c30f495



- Closes #5961 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `Dialog` `onOpenChange` logic in `SortableItem` in `ThreadList.tsx` to correctly handle dialog title and dropdown state.
> 
>   - **Behavior**:
>     - Fixes `Dialog` `onOpenChange` logic in `SortableItem` in `ThreadList.tsx` to set `setTitle` when dialog opens and `setOpenDropdown(false)` when dialog closes.
>   - **Fixes**:
>     - Closes #5961, addressing issue with rename dialog showing previous thread title.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 7c4e13d3abcb48f98e699d2211b6c05005acd195. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->