### PR TITLE
ci: tolerate artifact upload

### DIFF
--- a/.github/workflows/autoqa-template.yml
+++ b/.github/workflows/autoqa-template.yml
@@ -146,6 +146,7 @@ jobs:
       - name: Upload screen recordings
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
@@ -292,6 +293,7 @@ jobs:
       - name: Upload screen recordings
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/
@@ -451,6 +453,7 @@ jobs:
       - name: Upload screen recordings
         if: always()
         uses: actions/upload-artifact@v4
+        continue-on-error: true
         with:
           name: ${{ inputs.is_nightly && 'jan-nightly' || 'jan' }}-recordings-${{ github.run_number }}-${{ runner.os }}
           path: autoqa/recordings/


### PR DESCRIPTION
This pull request updates the `.github/workflows/autoqa-template.yml` file to improve the resilience of the workflow by allowing the "Upload screen recordings" step to continue even if it encounters an error.

Key change:

* Added the `continue-on-error: true` property to the "Upload screen recordings" step in three different locations within the `jobs:` section of the workflow file. This ensures that the workflow proceeds even if the artifact upload fails. [[1]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R149) [[2]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R296) [[3]](diffhunk://#diff-29e12dbcc8c8fd432ba91ce126649ed4cb3da259dd06f194ab908af3aac0e732R456)