### PR TITLE
fix: generate response button disappear on tool call

### DIFF
--- a/web-app/src/containers/dialogs/LoadModelErrorDialog.tsx
+++ b/web-app/src/containers/dialogs/LoadModelErrorDialog.tsx
@@ -52,7 +52,7 @@ export default function LoadModelErrorDialog() {
             <div>
               <DialogTitle>{t('common:error')}</DialogTitle>
               <DialogDescription className="mt-1 text-main-view-fg/70">
-                Failed to load model
+                Something went wrong
               </DialogDescription>
             </div>
           </div>

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -247,8 +247,7 @@ export const useChat = () => {
           messages,
           currentAssistant?.instructions
         )
-
-        builder.addUserMessage(message)
+        if (troubleshooting) builder.addUserMessage(message)
 
         let isCompleted = false
 

--- a/web-app/src/lib/messages.ts
+++ b/web-app/src/lib/messages.ts
@@ -26,7 +26,7 @@ export class CompletionMessagesBuilder {
               content:
                 msg.role === 'assistant'
                   ? this.normalizeContent(msg.content[0]?.text?.value || '.')
-                  : (msg.content[0]?.text?.value || '.'),
+                  : msg.content[0]?.text?.value || '.',
             }) as ChatCompletionMessageParam
         )
     )
@@ -37,6 +37,10 @@ export class CompletionMessagesBuilder {
    * @param content - The content of the user message.
    */
   addUserMessage(content: string) {
+    // Ensure no consecutive user messages
+    if (this.messages[this.messages.length - 1]?.role === 'user') {
+      this.messages.pop()
+    }
     this.messages.push({
       role: 'user',
       content: content,

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -39,7 +39,7 @@ function ThreadDetail() {
   const lastScrollTopRef = useRef(0)
   const { currentThreadId, setCurrentThreadId } = useThreads()
   const { setCurrentAssistant, assistants } = useAssistant()
-  const { setMessages } = useMessages()
+  const { setMessages, deleteMessage } = useMessages()
   const { streamingContent } = useAppState()
   const { appMainViewBgColor, chatWidth } = useAppearance()
   const { sendMessage } = useChat()
@@ -221,8 +221,23 @@ function ThreadDetail() {
   // used when there is a sent/added user message and no assistant message (error or manual deletion)
   const generateAIResponse = () => {
     const latestUserMessage = messages[messages.length - 1]
-    if (latestUserMessage?.content?.[0]?.text?.value) {
+    if (
+      latestUserMessage?.content?.[0]?.text?.value &&
+      latestUserMessage.role === 'user'
+    ) {
       sendMessage(latestUserMessage.content[0].text.value, false)
+    } else if (latestUserMessage?.metadata?.tool_calls) {
+      // Only regenerate assistant message is allowed
+      const threadMessages = [...messages]
+      let toSendMessage = threadMessages.pop()
+      while (toSendMessage && toSendMessage?.role !== 'user') {
+        deleteMessage(toSendMessage.thread_id, toSendMessage.id ?? '')
+        toSendMessage = threadMessages.pop()
+      }
+      if (toSendMessage) {
+        deleteMessage(toSendMessage.thread_id, toSendMessage.id ?? '')
+        sendMessage(toSendMessage.content?.[0]?.text?.value || '')
+      }
     }
   }
 
@@ -232,7 +247,10 @@ function ThreadDetail() {
 
   const showScrollToBottomBtn = !isAtBottom && hasScrollbar
   const showGenerateAIResponseBtn =
-    messages[messages.length - 1]?.role === 'user' && !streamingContent
+    (messages[messages.length - 1]?.role === 'user' ||
+      (messages[messages.length - 1]?.metadata &&
+        'tool_calls' in (messages[messages.length - 1].metadata ?? {}))) &&
+    !streamingContent
 
   return (
     <div className="flex flex-col h-full">


### PR DESCRIPTION
## Describe Your Changes

This PR fixes 2 issues: 
1. The generate button doesn't show as expected when there's an incomplete tool call message.
https://github.com/user-attachments/assets/c49973eb-2862-4833-82d1-8fc6baae727d

2. Gemma3 requires no consecutive user or assistant messages. This is to fix common cases such as regenerating and send a new message.
https://github.com/user-attachments/assets/3cbc869a-aab0-414e-ac48-5eed5c96cc6d

## Fixes Issues

- Closes #
- Closes #5909

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
