### PR TITLE
fix: remove auto refresh model custom provider

### DIFF
--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -133,22 +133,6 @@ function ProviderDetail() {
   // Note: settingsChanged event is now handled globally in GlobalEventHandler
   // This ensures all screens receive the event intermediately
 
-  // Auto-refresh models for non-predefined providers
-  useEffect(() => {
-    if (
-      provider &&
-      provider.provider !== 'llamacpp' &&
-      !predefinedProviders.some((p) => p.provider === provider.provider) &&
-      provider.base_url
-    ) {
-      // Auto-refresh models every 10 seconds for remote providers
-      const intervalId = setInterval(() => {
-        handleRefreshModels()
-      }, 10000)
-      return () => clearInterval(intervalId)
-    }
-  }, [provider])
-
   const handleJoyrideCallback = (data: CallBackProps) => {
     const { status } = data
 


### PR DESCRIPTION
## Describe Your Changes

This pull request removes the auto-refresh functionality for models of non-predefined providers in the `ProviderDetail` component. The change simplifies the code by delegating the responsibility for handling settings changes to a global event handler.

### Key change:
- **Code simplification in `ProviderDetail` component:**
  * Removed the `useEffect` hook that automatically refreshed models every 10 seconds for non-predefined providers. This functionality is now managed globally via the `GlobalEventHandler`, ensuring consistent handling of settings changes across all screens. (`[web-app/src/routes/settings/providers/$providerName.tsxL136-L151](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5L136-L151)`)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
