### PR TITLE
hotfix: regression issue with colon in model name

### DIFF
--- a/web-app/src/hooks/__tests__/useThreads.test.ts
+++ b/web-app/src/hooks/__tests__/useThreads.test.ts
@@ -88,7 +88,7 @@ describe('useThreads', () => {
     })
 
     expect(Object.keys(result.current.threads)).toHaveLength(2)
-    expect(result.current.threads['thread1'].model.id).toEqual('thread1:free')
+    expect(result.current.threads['thread1'].model.id).toEqual('thread1/free')
     expect(result.current.threads['thread1'].model.provider).toEqual('llamacpp')
     expect(result.current.threads['thread2'].model.id).toEqual('thread2/test')
     expect(result.current.threads['thread2'].model.provider).toEqual('llamacpp')

--- a/web-app/src/hooks/useThreads.ts
+++ b/web-app/src/hooks/useThreads.ts
@@ -44,9 +44,11 @@ export const useThreads = create<ThreadState>()((set, get) => ({
                   'llamacpp'
                 ),
                 // Cortex migration: take first two parts of the ID (the last is file name which is not needed)
-                id: !thread.model?.id.endsWith(':free')
-                  ? thread.model?.id.split(':').slice(0, 2).join(sep())
-                  : thread.model?.id,
+                id:
+                  thread.model.provider === 'llama.cpp' ||
+                  thread.model.provider === 'llamacpp'
+                    ? thread.model?.id.split(':').slice(0, 2).join(sep())
+                    : thread.model?.id,
               }
             : undefined,
         }


### PR DESCRIPTION
## Describe Your Changes

Fixed the model selection issue where it auto switch back to unselected value when there is a colon in model name

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes model selection issue by replacing colons with slashes in model IDs for 'llama.cpp' in `useThreads.ts`.
> 
>   - **Behavior**:
>     - Fixes issue with model selection reverting when model ID contains a colon in `useThreads.ts`.
>     - Updates model ID processing to replace colons with slashes for 'llama.cpp' and 'llamacpp' providers.
>   - **Tests**:
>     - Updates `useThreads.test.ts` to expect model IDs with slashes instead of colons for 'llama.cpp' models.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for f86a4f9c190529578e1b11f9728ac1856b05c37c. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->