### PR TITLE
ci: enable PR trigger for dev branch in tauri nightly workflow

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -15,6 +15,7 @@ on:
   pull_request:
     branches:
       - release/**
+      - dev
 
 jobs:
   set-public-provider:


### PR DESCRIPTION
This pull request makes a small change to the `.github/workflows/jan-tauri-build-nightly.yaml` file. It updates the workflow trigger to include the `dev` branch in addition to the existing `release/**` branches.