### PR TITLE
Fix: Llama.cpp server hangs on model load

### DIFF
--- a/src-tauri/src/core/utils/extensions/inference_llamacpp_extension/server.rs
+++ b/src-tauri/src/core/utils/extensions/inference_llamacpp_extension/server.rs
@@ -193,14 +193,30 @@ pub async fn load_llama_model(
 
     // Spawn task to capture stderr and monitor for errors
     let stderr_task = tokio::spawn(async move {
-        let mut reader = BufReader::new(stderr).lines();
+        let mut reader = BufReader::new(stderr);
+        let mut buf = Vec::new();
         let mut stderr_buffer = String::new();
-        while let Ok(Some(line)) = reader.next_line().await {
-            log::info!("[llamacpp] {}", line); // Using your log format
+
+        loop {
+            // Read up through the next newline (or whatever bytes are available)
+            let n = reader
+                .read_until(b'\n', &mut buf)
+                .await
+                .expect("Failed to read from stderr");
+
+            // EOF
+            if n == 0 {
+                break;
+            }
+
+            // Convert the chunk (partial or full line) into a string
+            let line = String::from_utf8_lossy(&buf);
+            log::info!("[llamacpp] {}", line.trim_end());
+
+            // Accumulate for later full-stderr reporting
             stderr_buffer.push_str(&line);
-            stderr_buffer.push('\n');
-            // Check for critical error indicators that should stop the process
-            // TODO: check for different errors
+
+            // Error conditions
             if line.to_lowercase().contains("error")
                 || line.to_lowercase().contains("failed")
                 || line.to_lowercase().contains("fatal")
@@ -208,17 +224,23 @@ pub async fn load_llama_model(
                 || line.contains("out of memory")
                 || line.contains("failed to load")
             {
-                let _ = error_tx.send(line.clone()).await;
+                let _ = error_tx.send(line.to_string()).await;
             }
-            // Check for readiness indicator - llama-server outputs this when ready
+            // Readiness conditions
             else if line.contains("server is listening on")
                 || line.contains("starting the main loop")
                 || line.contains("server listening on")
             {
-                log::info!("Server appears to be ready based on stdout: '{}'", line);
+                log::info!(
+                    "Server appears to be ready based on stderr: '{}'",
+                    line.trim_end()
+                );
                 let _ = ready_tx.send(true).await;
             }
+
+            buf.clear();
         }
+
         stderr_buffer
     });
 
@@ -331,7 +353,10 @@ pub async fn unload_llama_model(
         #[cfg(all(windows, target_arch = "x86_64"))]
         {
             if let Some(raw_pid) = child.id() {
-                log::warn!("gracefully killing is unsupported on Windows, force-killing PID {}", raw_pid);
+                log::warn!(
+                    "gracefully killing is unsupported on Windows, force-killing PID {}",
+                    raw_pid
+                );
 
                 // Since we know a graceful shutdown doesn't work and there are no child processes
                 // to worry about, we can use `child.kill()` directly. On Windows, this is


### PR DESCRIPTION
## Describe Your Changes

Resolves an issue where the llama.cpp server would hang indefinitely when loading certain models, as described in the attached ticket. The server's readiness message was not being correctly detected, causing the application to stall.

The previous implementation used a line-buffered reader (BufReader::lines()) to process the stderr stream. This method proved to be unreliable for the specific output of the llama.cpp server.

This commit refactors the stderr handling logic to use a more robust, chunk-based approach (read_until(b'\n', ...)). This ensures that the output is processed as it arrives, reliably capturing critical status messages and preventing the application from hanging during model initialization.

## Fixes Issues

- Closes #6021

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
