### PR TITLE
fix: wrong desc setting cont_batching

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -153,7 +153,7 @@
   {
     "key": "cont_batching",
     "title": "Continuous Batching",
-    "description": "Enable continuous batching (a.k.a dynamic batching) for concurrent requests (default: enabled).",
+    "description": "Enable continuous batching (a.k.a dynamic batching) for concurrent requests.",
     "controllerType": "checkbox",
     "controllerProps": {
       "value": false

--- a/web-app/src/hooks/useModelProvider.ts
+++ b/web-app/src/hooks/useModelProvider.ts
@@ -210,6 +210,29 @@ export const useModelProvider = create<ModelProviderState>()(
     {
       name: localStorageKey.modelProvider,
       storage: createJSONStorage(() => localStorage),
+      migrate: (persistedState: unknown, version: number) => {
+        const state = persistedState as ModelProviderState
+        
+        // Migration for cont_batching description update (version 0 -> 1)
+        if (version === 0 && state?.providers) {
+          state.providers = state.providers.map((provider) => {
+            if (provider.provider === 'llamacpp' && provider.settings) {
+              provider.settings = provider.settings.map((setting) => {
+                if (setting.key === 'cont_batching') {
+                  return {
+                    ...setting,
+                    description: 'Enable continuous batching (a.k.a dynamic batching) for concurrent requests.'
+                  }
+                }
+                return setting
+              })
+            }
+            return provider
+          })
+        }
+        return state
+      },
+      version: 1,
     }
   )
 )


### PR DESCRIPTION
## Describe Your Changes

This pull request includes a minor update to the description of the `cont_batching` setting and introduces a migration to ensure the updated description is applied to persisted state in the application.

### Updates to `cont_batching` setting:

* [`extensions/llamacpp-extension/settings.json`](diffhunk://#diff-dec2baac8d2054cbcb62c370b95aa047b140b67ce78d43e895f6af8697f6906dL156-R156): Simplified the description of the `cont_batching` setting by removing the mention of the default state.

### State migration for updated description:

* [`web-app/src/hooks/useModelProvider.ts`](diffhunk://#diff-5772464d4bc561fb171cab27635acf929619b7a350e0518ecd7a216df993f73fR213-R235): Added a migration function to update the `cont_batching` description in persisted state for `llamacpp` providers. This ensures consistency across application versions.

## Fixes Issues

- Closes #6032 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
