### PR TITLE
fix: show error toast message on download error

### DIFF
--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -161,8 +161,14 @@ export function DownloadManagement() {
       console.debug('onFileDownloadError', state)
       removeDownload(state.modelId)
       removeLocalDownloadingModel(state.modelId)
+      toast.error(t('common:toast.downloadFailed.title'), {
+        id: 'download-failed',
+        description: t('common:toast.downloadFailed.description', {
+          item: state.modelId,
+        }),
+      })
     },
-    [removeDownload, removeLocalDownloadingModel]
+    [removeDownload, removeLocalDownloadingModel, t]
   )
 
   const onFileDownloadStopped = useCallback(

--- a/web-app/src/locales/en/common.json
+++ b/web-app/src/locales/en/common.json
@@ -257,6 +257,10 @@
     "downloadCancelled": {
       "title": "Download Cancelled",
       "description": "The download process was cancelled"
+    },
+    "downloadFailed": {
+      "title": "Download Failed",
+      "description": "{{item}} download failed"
     }
   }
 }


### PR DESCRIPTION
## Describe Your Changes

- I noticed there was no toast error message to inform the user of a hub download failure, which negatively impacts user experience. So in this PR, I have added a toast error message to provide clear feedback when a download fails.


https://github.com/user-attachments/assets/24c9883f-3423-473d-b24c-36e118df50f8


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
