### PR TITLE
fix: support missing llamacpp cuda backends

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -27,8 +27,18 @@ export async function listSupportedBackends(): Promise<
     if (features.avx) supportedBackends.push('win-avx-x64')
     if (features.avx2) supportedBackends.push('win-avx2-x64')
     if (features.avx512) supportedBackends.push('win-avx512-x64')
-    if (features.cuda11) supportedBackends.push('win-avx2-cuda-cu11.7-x64')
-    if (features.cuda12) supportedBackends.push('win-avx2-cuda-cu12.0-x64')
+    if (features.cuda11) {
+      if (features.avx512) supportedBackends.push('win-avx512-cuda-cu11.7-x64')
+      else if (features.avx2) supportedBackends.push('win-avx2-cuda-cu11.7-x64')
+      else if (features.avx) supportedBackends.push('win-avx-cuda-cu11.7-x64')
+      else supportedBackends.push('win-noavx-cuda-cu11.7-x64')
+    }
+    if (features.cuda12) {
+      if (features.avx512) supportedBackends.push('win-avx512-cuda-cu12.0-x64')
+      else if (features.avx2) supportedBackends.push('win-avx2-cuda-cu12.0-x64')
+      else if (features.avx) supportedBackends.push('win-avx-cuda-cu12.0-x64')
+      else supportedBackends.push('win-noavx-cuda-cu12.0-x64')
+    }
     if (features.vulkan) supportedBackends.push('win-vulkan-x64')
   }
   // not available yet, placeholder for future
@@ -39,8 +49,18 @@ export async function listSupportedBackends(): Promise<
     if (features.avx) supportedBackends.push('linux-avx-x64')
     if (features.avx2) supportedBackends.push('linux-avx2-x64')
     if (features.avx512) supportedBackends.push('linux-avx512-x64')
-    if (features.cuda11) supportedBackends.push('linux-avx2-cuda-cu11.7-x64')
-    if (features.cuda12) supportedBackends.push('linux-avx2-cuda-cu12.0-x64')
+    if (features.cuda11) {
+      if (features.avx512) supportedBackends.push('linux-avx512-cuda-cu11.7-x64')
+      else if (features.avx2) supportedBackends.push('linux-avx2-cuda-cu11.7-x64')
+      else if (features.avx) supportedBackends.push('linux-avx-cuda-cu11.7-x64')
+      else supportedBackends.push('linux-noavx-cuda-cu11.7-x64')
+    }
+    if (features.cuda12) {
+      if (features.avx512) supportedBackends.push('linux-avx512-cuda-cu12.0-x64')
+      else if (features.avx2) supportedBackends.push('linux-avx2-cuda-cu12.0-x64')
+      else if (features.avx) supportedBackends.push('linux-avx-cuda-cu12.0-x64')
+      else supportedBackends.push('linux-noavx-cuda-cu12.0-x64')
+    }
     if (features.vulkan) supportedBackends.push('linux-vulkan-x64')
   }
   // not available yet, placeholder for future

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
     "test:coverage": "vitest run --coverage",
     "test:prepare": "yarn build:icon && yarn copy:assets:tauri && yarn build --no-bundle ",
     "dev:web": "yarn workspace @janhq/web-app dev",
-    "dev:tauri": "yarn build:icon && yarn copy:assets:tauri && tauri dev",
+    "dev:tauri": "yarn build:icon && yarn copy:assets:tauri && cross-env IS_CLEAN=true tauri dev",
     "copy:assets:tauri": "cpx \"pre-install/*.tgz\" \"src-tauri/resources/pre-install/\"",
     "download:lib": "node ./scripts/download-lib.mjs",
     "download:bin": "node ./scripts/download-bin.mjs",

--- a/src-tauri/src/core/setup.rs
+++ b/src-tauri/src/core/setup.rs
@@ -43,8 +43,8 @@ pub fn install_extensions(app: tauri::AppHandle, force: bool) -> Result<(), Stri
 
     let mut clean_up = force;
 
-    // Check CLEAN environment variable to optionally skip extension install
-    if std::env::var("CLEAN").is_ok() {
+    // Check IS_CLEAN environment variable to optionally skip extension install
+    if std::env::var("IS_CLEAN").is_ok() {
         clean_up = true;
     }
     log::info!(

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -6,7 +6,7 @@
   "build": {
     "frontendDist": "../web-app/dist",
     "devUrl": "http://localhost:1420",
-    "beforeDevCommand": "cross-env IS_TAURI=true CLEAN=true yarn dev:web",
+    "beforeDevCommand": "cross-env IS_TAURI=true yarn dev:web",
     "beforeBuildCommand": "cross-env IS_TAURI=true yarn build:web"
   },
   "app": {


### PR DESCRIPTION
## Describe Your Changes

This PR addresses issue #6043 by ensuring both non-AVX and AVX backends are shown for CUDA support. This allows users to get the correct default backend for their hardware. Currently, CPUs without AVX2 support will not function with the CUDA backend.

A minor devex improvement added where run app in dev mode should reinstall extensions.

<img width="1026" height="832" alt="image" src="https://github.com/user-attachments/assets/c9dd0b6c-bd87-4aeb-ab02-507db1acc122" />


## Fixes Issues

- Closes #6043 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Enhances CUDA backend support for non-AVX2 CPUs and improves development experience by reinstalling extensions in dev mode.
> 
>   - **Behavior**:
>     - Updates `listSupportedBackends` in `backend.ts` to include non-AVX and AVX backends for CUDA, ensuring compatibility with CPUs lacking AVX2 support.
>     - Modifies `configureBackends` in `index.ts` to handle backend selection and update UI settings accordingly.
>   - **Testing**:
>     - Adds test cases in `backend.test.ts` to verify CUDA backend selection based on CPU features for Windows and Linux.
>   - **Dev Experience**:
>     - Updates `dev:tauri` script in `package.json` to reinstall extensions in development mode.
>   - **Misc**:
>     - Changes `CLEAN` to `IS_CLEAN` in `setup.rs` and `tauri.conf.json` for environment variable consistency.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 4a4bc35ccef346c0924ea2ee53eee2259d30ebf7. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->