### PR TITLE
chore: skip nightly build workflow for external contributor

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -20,6 +20,7 @@ on:
 jobs:
   set-public-provider:
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       public_provider: ${{ steps.set-public-provider.outputs.public_provider }}
       ref: ${{ steps.set-public-provider.outputs.ref }}
@@ -47,11 +48,13 @@ jobs:
           fi
   # Job create Update app version based on latest release tag with build number and save to output
   get-update-version:
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     uses: ./.github/workflows/template-get-update-version.yml
 
   build-macos:
     uses: ./.github/workflows/template-tauri-build-macos.yml
     needs: [get-update-version, set-public-provider]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     secrets: inherit
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
@@ -64,6 +67,7 @@ jobs:
     uses: ./.github/workflows/template-tauri-build-windows-x64.yml
     secrets: inherit
     needs: [get-update-version, set-public-provider]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
@@ -74,6 +78,7 @@ jobs:
     uses: ./.github/workflows/template-tauri-build-linux-x64.yml
     secrets: inherit
     needs: [get-update-version, set-public-provider]
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
@@ -91,6 +96,7 @@ jobs:
         build-macos,
       ]
     runs-on: ubuntu-latest
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - name: Getting the repo
         uses: actions/checkout@v3
@@ -236,7 +242,7 @@ jobs:
         set-public-provider,
         sync-temp-to-latest,
       ]
-    if: needs.set-public-provider.outputs.public_provider == 'aws-s3'
+    if: needs.set-public-provider.outputs.public_provider == 'aws-s3' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/autoqa-template.yml
     with:
       jan_app_windows_source: 'https://delta.jan.ai/nightly/Jan-nightly_${{ needs.get-update-version.outputs.new_version }}_x64-setup.exe'
@@ -257,7 +263,7 @@ jobs:
         get-update-version,
         set-public-provider,
       ]
-    if: needs.set-public-provider.outputs.public_provider == 'none'
+    if: needs.set-public-provider.outputs.public_provider == 'none' && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
     uses: ./.github/workflows/autoqa-template.yml
     with:
       jan_app_windows_source: '' # Not needed for artifacts


### PR DESCRIPTION
This pull request updates the `.github/workflows/jan-tauri-build-nightly.yaml` workflow to ensure that jobs only run for pull requests originating from the same repository, improving security and preventing unintended builds from forks. The main change is the addition of conditional `if` statements to several jobs.

Conditional execution for jobs (Security & Workflow Control):

* Added `if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository` to the following jobs to restrict execution to PRs from the same repository: `set-public-provider`, `get-update-version`, `build-macos`, `build-windows-x64`, `build-linux-x64`, and the job that checks out the repo. [[1]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R23) [[2]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R51-R57) [[3]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R70) [[4]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R81) [[5]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382R99)

* Updated `autoqa-template.yml` jobs to include the same conditional check, ensuring they only run for PRs from the same repo, both when the public provider is `aws-s3` and when it is `none`. [[1]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L239-R245) [[2]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L260-R266)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conditional checks to `.github/workflows/jan-tauri-build-nightly.yaml` to restrict job execution to PRs from the same repository for security.
> 
>   - **Security & Workflow Control**:
>     - Added conditional `if` statements to jobs in `.github/workflows/jan-tauri-build-nightly.yaml` to restrict execution to PRs from the same repository.
>     - Affected jobs: `set-public-provider`, `get-update-version`, `build-macos`, `build-windows-x64`, `build-linux-x64`, and `sync-temp-to-latest`.
>     - Updated `autoqa-template.yml` jobs to include the same conditional check for both `aws-s3` and `none` public providers.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e3331dd508d25a98d218fdd07e9f97569b6ddc84. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->