### PR TITLE
🐛fix: onboarding loop

### DIFF
--- a/web-app/src/constants/localStorage.ts
+++ b/web-app/src/constants/localStorage.ts
@@ -19,4 +19,5 @@ export const localStorageKey = {
   mcpGlobalPermissions: 'mcp-global-permissions',
   lastUsedModel: 'last-used-model',
   lastUsedAssistant: 'last-used-assistant',
+  setupCompleted: 'setup-completed',
 }

--- a/web-app/src/containers/SetupScreen.tsx
+++ b/web-app/src/containers/SetupScreen.tsx
@@ -5,12 +5,17 @@ import { route } from '@/constants/routes'
 import HeaderPage from './HeaderPage'
 import { isProd } from '@/lib/version'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+import { localStorageKey } from '@/constants/localStorage'
 
 function SetupScreen() {
   const { t } = useTranslation()
   const { providers } = useModelProvider()
   const firstItemRemoteProvider =
     providers.length > 0 ? providers[1].provider : 'openai'
+
+  // Check if setup tour has been completed
+  const isSetupCompleted =
+    localStorage.getItem(localStorageKey.setupCompleted) === 'true'
 
   return (
     <div className="flex h-full flex-col flex-justify-center">
@@ -50,7 +55,9 @@ function SetupScreen() {
                     providerName: firstItemRemoteProvider,
                   }}
                   search={{
-                    step: 'setup_remote_provider',
+                    ...(!isSetupCompleted
+                      ? { step: 'setup_remote_provider' }
+                      : {}),
                   }}
                 >
                   <h1 className="text-main-view-fg font-medium text-base">

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -15,7 +15,6 @@ import {
 import {
   createFileRoute,
   Link,
-  useNavigate,
   useParams,
   useSearch,
 } from '@tanstack/react-router'
@@ -32,6 +31,7 @@ import { CustomTooltipJoyRide } from '@/containers/CustomeTooltipJoyRide'
 import { route } from '@/constants/routes'
 import DeleteProvider from '@/containers/dialogs/DeleteProvider'
 import { updateSettings, fetchModelsFromProvider } from '@/services/providers'
+import { localStorageKey } from '@/constants/localStorage'
 import { Button } from '@/components/ui/button'
 import { IconFolderPlus, IconLoader, IconRefresh } from '@tabler/icons-react'
 import { getProviders } from '@/services/providers'
@@ -83,7 +83,6 @@ function ProviderDetail() {
   const { getProviderByName, setProviders, updateProvider } = useModelProvider()
   const provider = getProviderByName(providerName)
   const isSetup = step === 'setup_remote_provider'
-  const navigate = useNavigate()
 
   // Check if llamacpp provider needs backend configuration
   const needsBackendConfig =
@@ -137,9 +136,7 @@ function ProviderDetail() {
     const { status } = data
 
     if (status === STATUS.FINISHED) {
-      navigate({
-        to: route.home,
-      })
+      localStorage.setItem(localStorageKey.setupCompleted, 'true')
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a new persistent flag in `localStorage` to track whether the user has completed the setup tour, and updates the setup flow logic to use this flag. The most important changes are grouped below:

**Setup completion tracking:**

* Added a new `setupCompleted` key to the `localStorageKey` constants in `localStorage.ts` to persist the setup completion state.
* When the provider setup is finished in `ProviderDetail`, the `setupCompleted` flag is set to `'true'` in `localStorage`, replacing the previous navigation redirect.

**Conditional setup flow:**

* In `SetupScreen`, the code now checks the `setupCompleted` flag in `localStorage` to determine whether to show the setup step for remote providers, conditionally including the `step` parameter in the search object. [[1]](diffhunk://#diff-d892c5ebcde40fcdfb642657b6f87fb36bcd63218c78b644c842a781a9675892R8-R19) [[2]](diffhunk://#diff-d892c5ebcde40fcdfb642657b6f87fb36bcd63218c78b644c842a781a9675892L53-R60)

**Code cleanup:**

* Removed the unused `useNavigate` import and related navigation code from `ProviderDetail`, as navigation is no longer performed on setup completion. [[1]](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5L18) [[2]](diffhunk://#diff-bf67bc43ea4ed453c69e14c27bd2fe2006545cb6cedc1fbad166857e073303b5L86)
* Imported `localStorageKey` in `ProviderDetail` to access the new setup completion key.

## Fixes Issues

- Closes #5566 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
