### PR TITLE
fix: Add conditional Vulkan support check for better GPU compatibility

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -50,14 +50,18 @@ export async function listSupportedBackends(): Promise<
     if (features.avx2) supportedBackends.push('linux-avx2-x64')
     if (features.avx512) supportedBackends.push('linux-avx512-x64')
     if (features.cuda11) {
-      if (features.avx512) supportedBackends.push('linux-avx512-cuda-cu11.7-x64')
-      else if (features.avx2) supportedBackends.push('linux-avx2-cuda-cu11.7-x64')
+      if (features.avx512)
+        supportedBackends.push('linux-avx512-cuda-cu11.7-x64')
+      else if (features.avx2)
+        supportedBackends.push('linux-avx2-cuda-cu11.7-x64')
       else if (features.avx) supportedBackends.push('linux-avx-cuda-cu11.7-x64')
       else supportedBackends.push('linux-noavx-cuda-cu11.7-x64')
     }
     if (features.cuda12) {
-      if (features.avx512) supportedBackends.push('linux-avx512-cuda-cu12.0-x64')
-      else if (features.avx2) supportedBackends.push('linux-avx2-cuda-cu12.0-x64')
+      if (features.avx512)
+        supportedBackends.push('linux-avx512-cuda-cu12.0-x64')
+      else if (features.avx2)
+        supportedBackends.push('linux-avx2-cuda-cu12.0-x64')
       else if (features.avx) supportedBackends.push('linux-avx-cuda-cu12.0-x64')
       else supportedBackends.push('linux-noavx-cuda-cu12.0-x64')
     }
@@ -256,10 +260,16 @@ async function _getSupportedFeatures() {
       if (compareVersions(driverVersion, minCuda12DriverVersion) >= 0)
         features.cuda12 = true
     }
-
-    if (gpuInfo.vulkan_info?.api_version) features.vulkan = true
+    // Vulkan support check - only discrete GPUs with 6GB+ VRAM
+    if (
+      gpuInfo.vulkan_info?.api_version &&
+      gpuInfo.vulkan_info?.device_type === 'DISCRETE_GPU' &&
+      gpuInfo.total_memory >= 6 * 1024
+    ) {
+      // 6GB (total_memory is in MB)
+      features.vulkan = true
+    }
   }
-
   return features
 }
 


### PR DESCRIPTION
## Describe Your Changes
Introduce conditional Vulkan support check for discrete GPUs with 6GB+ VRAM to prevent issues like mentioned in the issue ticket

## Fixes Issues

- Closes #6009

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds conditional Vulkan support check for discrete GPUs with 6GB+ VRAM in `backend.ts`, addressing issue #6009.
> 
>   - **Behavior**:
>     - Adds conditional Vulkan support check in `_getSupportedFeatures()` in `backend.ts` for discrete GPUs with 6GB+ VRAM.
>     - Closes issue #6009 by preventing Vulkan support on incompatible GPUs.
>   - **Misc**:
>     - Minor formatting changes in `listSupportedBackends()` in `backend.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1acd162c78b9e60a378427e3220e99916e9beb41. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->