### PR TITLE
fix: Prevent accidental message submitting on ChatInput for IME users

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -371,7 +371,9 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
                 setRows(Math.min(newRows, maxRows))
               }}
               onKeyDown={(e) => {
-                if (e.key === 'Enter' && !e.shiftKey && prompt.trim()) {
+                // e.keyCode 229 is for IME input with Safari
+                const isComposing = e.nativeEvent.isComposing || e.keyCode === 229;
+                if (e.key === 'Enter' && !e.shiftKey && prompt.trim() && !isComposing) {
                   e.preventDefault()
                   // Submit the message when Enter is pressed without Shift
                   handleSendMesage(prompt)


### PR DESCRIPTION
Japanese or Chinese users use a IME (Input Method Editor) to type their language, where you typically use the enter key to select the characters you want. So when I went go to use Jan, as soon as I type in a single word it triggers the activation because the component is listening for "enter" key presses. 

The isComposing flag returns true if the user is using one of these input tools so as not to trigger accidental input, however Safari's implementation is not working correctly, so the keyCode method is also required. See the following webkit bug:

https://bugs.webkit.org/show_bug.cgi?id=165004

## Describe Your Changes

- Added an additional check to prevent chat submissions during IME input

## Self Checklist

- [ x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Prevent accidental message submission in `ChatInput` for IME users by checking `isComposing` and `keyCode` for Safari.
> 
>   - **Behavior**:
>     - Prevents message submission in `ChatInput` during IME composition by checking `isComposing` flag and `e.keyCode === 229` for Safari.
>   - **Misc**:
>     - Added comments in `ChatInput.tsx` to explain the IME handling logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9b8fb62790165786b15929019aa17a5063f68ec3. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->