### PR TITLE
ci: update generate release note and jan docs release

### DIFF
--- a/.github/workflows/jan-docs.yml
+++ b/.github/workflows/jan-docs.yml
@@ -76,7 +76,7 @@ jobs:
               Preview URL: ${{ steps.deployCloudflarePages.outputs.url }}
 
       - name: Publish to Cloudflare Pages Production
-        if: (github.event_name == 'push' && github.ref == 'refs/heads/dev') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev')
+        if: (github.event_name == 'push' && github.ref == 'refs/heads/dev') || (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/dev') || (github.event_name == 'workflow_dispatch' && startsWith(github.ref, 'refs/heads/release/'))
         uses: cloudflare/pages-action@v1
         with:
           apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}

--- a/.github/workflows/jan-tauri-build.yaml
+++ b/.github/workflows/jan-tauri-build.yaml
@@ -32,6 +32,7 @@ jobs:
           name: "${{ env.VERSION }}"
           draft: true
           prerelease: false
+          generate_release_notes: true
 
   build-macos:
     uses: ./.github/workflows/template-tauri-build-macos.yml
@@ -119,27 +120,3 @@ jobs:
           asset_path: ./latest.json
           asset_name: latest.json
           asset_content_type: text/json
-
-  update_release_draft:
-    needs: [build-macos, build-windows-x64, build-linux-x64]
-    permissions:
-      # write permission is required to create a github release
-      contents: write
-      # write permission is required for autolabeler
-      # otherwise, read permission is required at least
-      pull-requests: write
-    runs-on: ubuntu-latest
-    steps:
-      # (Optional) GitHub Enterprise requires GHE_HOST variable set
-      #- name: Set GHE_HOST
-      #  run: |
-      #    echo "GHE_HOST=${GITHUB_SERVER_URL##https:\/\/}" >> $GITHUB_ENV
-
-      # Drafts your next Release notes as Pull Requests are merged into "master"
-      - uses: release-drafter/release-drafter@v5
-        # (Optional) specify config name to use, relative to .github/. Default: release-drafter.yml
-        # with:
-        #   config-name: my-config.yml
-        #   disable-autolabeler: true
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This pull request updates the deployment and release workflow configurations for documentation and Tauri builds. The main changes improve release note generation and expand production deployment triggers, while also removing redundant steps from the Tauri build workflow.

**Release workflow improvements:**

* Enabled automatic generation of release notes for Tauri releases by adding `generate_release_notes: true` to the release creation step in `.github/workflows/jan-tauri-build.yaml`.

**Deployment workflow enhancements:**

* Updated the Cloudflare Pages production deployment trigger in `.github/workflows/jan-docs.yml` to also allow deployments when a workflow is manually dispatched from any `release/*` branch, in addition to the existing conditions.

**Workflow simplification:**

* Removed the entire `update_release_draft` job from `.github/workflows/jan-tauri-build.yaml`, eliminating the use of the `release-drafter` action and associated permissions for drafting release notes.