### PR TITLE
ci: add path for tauri nightly build

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -16,6 +16,23 @@ on:
     branches:
       - release/**
       - dev
+    paths:
+      - '.github/workflows/jan-tauri-build-nightly.yaml'
+      - '.github/workflows/template-get-update-version.yml'
+      - '.github/workflows/template-tauri-build-macos.yml'
+      - '.github/workflows/template-tauri-build-windows-x64.yml'
+      - '.github/workflows/template-tauri-build-linux-x64.yml'
+      - '.github/workflows/template-noti-discord-and-update-url-readme.yml'
+      - 'src-tauri/**'
+      - 'core/**'
+      - 'web-app/**'
+      - 'extensions/**'
+      - 'scripts/**'
+      - 'pre-install/**'
+      - 'Makefile'
+      - 'package.json'
+      - 'mise.toml'
+
 
 jobs:
   set-public-provider:


### PR DESCRIPTION
This pull request updates the workflow trigger conditions in `.github/workflows/jan-tauri-build-nightly.yaml` to make nightly builds run only when relevant files or directories are changed. This helps reduce unnecessary builds and ensures the workflow only runs for meaningful updates.

Workflow configuration improvements:

* Added a `paths` filter to the workflow trigger so the nightly build only runs when specific files or directories (such as workflow templates, source code directories, and build scripts) are modified. This includes files like `Makefile`, `package.json`, and directories such as `src-tauri`, `core`, `web-app`, `extensions`, `scripts`, and `pre-install`. (.github/workflows/jan-tauri-build-nightly.yaml)
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `paths` filter to `.github/workflows/jan-tauri-build-nightly.yaml` to trigger builds only on changes to specific files and directories.
> 
>   - **Workflow Configuration**:
>     - Adds `paths` filter to `.github/workflows/jan-tauri-build-nightly.yaml` to trigger builds only on changes to specific files and directories.
>     - Monitors changes in `Makefile`, `package.json`, `mise.toml`, and directories like `src-tauri`, `core`, `web-app`, `extensions`, `scripts`, and `pre-install`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d5ca195059f6905e7ad09d027a15d2b96cba1623. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->