### PR TITLE
fix: factory reset process got blocked

### DIFF
--- a/src-tauri/src/core/mcp.rs
+++ b/src-tauri/src/core/mcp.rs
@@ -751,6 +751,26 @@ pub async fn reset_mcp_restart_count(state: State<'_, AppState>, server_name: St
     Ok(())
 }
 
+pub async fn clean_up_mcp_servers(
+    state: State<'_, AppState>,
+) {
+    log::info!("Cleaning up MCP servers");
+    
+    // Stop all running MCP servers
+    let _ = stop_mcp_servers(state.mcp_servers.clone()).await;
+    
+    // Clear active servers and restart counts
+    {
+        let mut active_servers = state.mcp_active_servers.lock().await;
+        active_servers.clear();
+    }
+    {
+        let mut restart_counts = state.mcp_restart_counts.lock().await;
+        restart_counts.clear();
+    }
+    log::info!("MCP servers cleaned up successfully");
+}
+
 pub async fn stop_mcp_servers(
     servers_state: Arc<Mutex<HashMap<String, RunningService<RoleClient, ()>>>>,
 ) -> Result<(), String> {


### PR DESCRIPTION
## Describe Your Changes

This PR resolves the issue preventing users from performing a factory reset while an MCP server is running. 

Changes:
1. Stop all MCP servers before performing factory reset
2.There should not be any asynchronous event emission for this type of process cleanup.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes factory reset blockage by stopping MCP servers before reset and removing async event emissions.
> 
>   - **Behavior**:
>     - `factory_reset` in `cmd.rs` now stops all MCP servers using `clean_up_mcp_servers` before proceeding.
>     - Removed asynchronous event emission for MCP server cleanup.
>   - **Functions**:
>     - Added `clean_up_mcp_servers` in `mcp.rs` to stop and clear MCP servers and restart counts.
>     - Removed `kill-mcp-servers` event listener in `setup.rs`.
>   - **Misc**:
>     - Updated `on_window_event` in `lib.rs` to use `clean_up_mcp_servers` directly for cleanup.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9ed98614fee32a7dd98635493b36305e3d49c101. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->