### PR TITLE
fix: visualize readme content for private repo with HF token

### DIFF
--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -156,13 +156,20 @@ function HubModelDetail() {
   useEffect(() => {
     if (modelData?.readme) {
       setIsLoadingReadme(true)
-      fetch(modelData.readme, {
-        headers: huggingfaceToken
-          ? {
-              Authorization: `Bearer ${huggingfaceToken}`,
-            }
-          : {},
-      })
+      // Try fetching without headers first
+      // There is a weird issue where this HF link will return error when access public repo with auth header
+      fetch(modelData.readme)
+        .then((response) => {
+          if (!response.ok && huggingfaceToken && modelData?.readme) {
+            // Retry with Authorization header if first fetch failed
+            return fetch(modelData.readme, {
+              headers: {
+                Authorization: `Bearer ${huggingfaceToken}`,
+              },
+            })
+          }
+          return response
+        })
         .then((response) => response.text())
         .then((content) => {
           setReadmeContent(content)

--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -27,6 +27,7 @@ import {
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
+import { useGeneralSetting } from '@/hooks/useGeneralSetting'
 
 type SearchParams = {
   repo: string
@@ -42,6 +43,7 @@ export const Route = createFileRoute('/hub/$modelId')({
 function HubModelDetail() {
   const { modelId } = useParams({ from: Route.id })
   const navigate = useNavigate()
+  const { huggingfaceToken } = useGeneralSetting()
   const { sources, fetchSources } = useModelSources()
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   const search = useSearch({ from: Route.id as any })
@@ -60,12 +62,15 @@ function HubModelDetail() {
   }, [fetchSources])
 
   const fetchRepo = useCallback(async () => {
-    const repoInfo = await fetchHuggingFaceRepo(search.repo || modelId)
+    const repoInfo = await fetchHuggingFaceRepo(
+      search.repo || modelId,
+      huggingfaceToken
+    )
     if (repoInfo) {
       const repoDetail = convertHfRepoToCatalogModel(repoInfo)
       setRepoData(repoDetail)
     }
-  }, [modelId, search])
+  }, [modelId, search, huggingfaceToken])
 
   useEffect(() => {
     fetchRepo()
@@ -151,7 +156,13 @@ function HubModelDetail() {
   useEffect(() => {
     if (modelData?.readme) {
       setIsLoadingReadme(true)
-      fetch(modelData.readme)
+      fetch(modelData.readme, {
+        headers: huggingfaceToken
+          ? {
+              Authorization: `Bearer ${huggingfaceToken}`,
+            }
+          : {},
+      })
         .then((response) => response.text())
         .then((content) => {
           setReadmeContent(content)
@@ -162,7 +173,7 @@ function HubModelDetail() {
           setIsLoadingReadme(false)
         })
     }
-  }, [modelData?.readme])
+  }, [modelData?.readme, huggingfaceToken])
 
   if (!modelData) {
     return (


### PR DESCRIPTION
## Describe Your Changes

This PR is to address the issue where model detail in hub does not render private repo README content.

Changes:
- HF token will be used for the README fetch as well.

Before
<img width="2152" height="1682" alt="CleanShot 2025-08-12 at 12 08 31@2x" src="https://github.com/user-attachments/assets/67cbc363-188a-43f0-8739-24f11bfde512" />

After
<img width="2274" height="1826" alt="CleanShot 2025-08-12 at 12 08 17@2x" src="https://github.com/user-attachments/assets/f6a2c699-687b-47cf-88fd-101a0ab4d53b" />


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Use HF token to fetch README content for private repos in `HubModelDetail`, ensuring proper rendering.
> 
>   - **Behavior**:
>     - Use HF token for fetching README content in private repos in `HubModelDetail`.
>     - Retry README fetch with Authorization header if initial fetch fails.
>   - **Functions**:
>     - Update `fetchRepo` in `HubModelDetail` to include `huggingfaceToken`.
>     - Modify README fetch logic in `HubModelDetail` to handle private repos.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 7b2d0432e6ec7cf4bd14aa1fb1fb326df874e357. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->