### PR TITLE
add disable auto updater input for nightly build

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -106,6 +106,7 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       channel: nightly
       cortex_api_port: '39261'
+      disable_updater: ${{ github.event.inputs.disable_updater }}
 
   sync-temp-to-latest:
     needs:


### PR DESCRIPTION
This pull request makes a small change to the nightly build workflow configuration. It adds support for passing a `disable_updater` input from the GitHub event to the job, allowing more control over the updater behavior during nightly builds.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `disable_updater` input to nightly build workflow for controlling updater behavior.
> 
>   - **Workflow Configuration**:
>     - Adds `disable_updater` input to `.github/workflows/jan-tauri-build-nightly.yaml` for controlling updater behavior in nightly builds.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for c708dce0339dfb742b9f6c1fd8d52fa7dc2b92ad. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->