### PR TITLE
ci: fix tauri build nightly for linux

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -106,7 +106,7 @@ jobs:
       new_version: ${{ needs.get-update-version.outputs.new_version }}
       channel: nightly
       cortex_api_port: '39261'
-      disable_updater: ${{ github.event.inputs.disable_updater }}
+      disable_updater: ${{ github.event.inputs.disable_updater == 'true' }}
 
   sync-temp-to-latest:
     needs:


### PR DESCRIPTION
This pull request makes a minor update to the GitHub Actions workflow configuration. The change ensures that the `disable_updater` input is explicitly compared to the string `'true'`, making the value passed to the job more predictable and robust.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Explicitly compare `disable_updater` input to `'true'` in `jan-tauri-build-nightly.yaml` for predictable handling.
> 
>   - **GitHub Actions Workflow**:
>     - In `.github/workflows/jan-tauri-build-nightly.yaml`, the `disable_updater` input is now explicitly compared to `'true'`.
>     - This change ensures predictable and robust value handling for the `disable_updater` input in the `build-linux-x64` job.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 156bf8230afd94109530250a2d28c0f1f8cc855a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->