### PR TITLE
fix: handle modelId special char

### DIFF
--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -287,8 +287,8 @@ function Hub() {
 
       const handleDownload = () => {
         // Immediately set local downloading state
-        addLocalDownloadingModel(modelId)
-        pullModel(modelId, modelUrl)
+        addLocalDownloadingModel(modelId.replace(/[^a-zA-Z0-9/_\-.]/g, ''))
+        pullModel(modelId.replace(/[^a-zA-Z0-9/_\-.]/g, ''), modelUrl)
       }
 
       return (

--- a/web-app/src/services/models.ts
+++ b/web-app/src/services/models.ts
@@ -162,7 +162,9 @@ export const convertHfRepoToCatalogModel = (
     }
 
     // Generate model_id from filename (remove .gguf extension, case-insensitive)
-    const modelId = file.rfilename.replace(/\.gguf$/i, '')
+    const modelId = file.rfilename
+      .replace(/\.gguf$/i, '')
+      .replace(/[^a-zA-Z0-9/_\-.]/g, '')
 
     return {
       model_id: modelId,


### PR DESCRIPTION
## Describe Your Changes

This pull request improves the handling and sanitization of model identifiers throughout the codebase to ensure consistency and prevent issues caused by invalid characters. The changes focus on consistently cleaning up model IDs before using them in downloads and catalog entries.

**Model Identifier Sanitization:**

* Updated the `handleDownload` function in `web-app/src/routes/hub/index.tsx` to sanitize `modelId` by removing invalid characters before passing it to `addLocalDownloadingModel` and `pullModel`.
* Modified the `convertHfRepoToCatalogModel` function in `web-app/src/services/models.ts` to further sanitize the generated `modelId` by stripping out unwanted characters after removing the `.gguf` extension.

## Fixes Issues

- Closes #6167
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
