### PR TITLE
chore: replace md5 with sha256 for CUDA

### DIFF
--- a/flatpak/ai.jan.Jan.yml
+++ b/flatpak/ai.jan.Jan.yml
@@ -92,7 +92,7 @@ modules:
           - x86_64
         url: https://developer.download.nvidia.com/compute/cuda/12.8.0/local_installers/cuda_12.8.0_570.86.10_linux.run
         dest-filename: cuda_toolkit.run
-        md5: c71027cf1a4ce84f80b9cbf81116e767
+        sha256: 610867dcd6d94c4e36c4924f1d01b9db28ec08164e8af6c764f21b84200695f8
 
   - name: binary
     buildsystem: simple


### PR DESCRIPTION
This pull request makes a minor update to the `flatpak/ai.jan.Jan.yml` file, specifically changing the hash used to verify the CUDA toolkit installer from MD5 to the more secure SHA-256 algorithm. This improves the security and integrity of the installer verification process.

- Security improvement:
  * Updated the hash verification for the CUDA toolkit installer from `md5` to `sha256` in `flatpak/ai.jan.Jan.yml`.