### PR TITLE
fix: should use custom fetch provided by app

### DIFF
--- a/web-app/package.json
+++ b/web-app/package.json
@@ -72,7 +72,7 @@
     "remark-math": "^6.0.0",
     "sonner": "^2.0.3",
     "tailwindcss": "^4.1.4",
-    "token.js": "npm:token.js-fork@0.7.22",
+    "token.js": "npm:token.js-fork@0.7.23",
     "tw-animate-css": "^1.2.7",
     "ulidx": "^2.4.1",
     "unified": "^11.0.5",


### PR DESCRIPTION
## Describe Your Changes

This PR bumps inference client version with the fix of using passed fetch option for inferencing so that custom providers will not have CORS issue.
 
<img width="2272" height="1824" alt="CleanShot 2025-08-19 at 13 44 19@2x" src="https://github.com/user-attachments/assets/55e02b42-d32c-4529-97a5-2c4292d23dca" />
<img width="2272" height="1824" alt="CleanShot 2025-08-19 at 13 45 13@2x" src="https://github.com/user-attachments/assets/52a8d9e5-1eea-4096-bdd7-cf832f60c27c" />


## Fixes Issues

- Closes #5474 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
