### PR TITLE
enhancement: offload model when provider not active

### DIFF
--- a/web-app/src/routes/settings/providers/index.tsx
+++ b/web-app/src/routes/settings/providers/index.tsx
@@ -25,6 +25,7 @@ import { useCallback, useState } from 'react'
 import { openAIProviderSettings } from '@/consts/providers'
 import cloneDeep from 'lodash/cloneDeep'
 import { toast } from 'sonner'
+import { stopAllModels } from '@/services/models'
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 export const Route = createFileRoute(route.settings.model_providers as any)({
@@ -169,7 +170,10 @@ function ModelProviders() {
                       )}
                       <Switch
                         checked={provider.active}
-                        onCheckedChange={(e) => {
+                        onCheckedChange={async (e) => {
+                          if (!e && provider.provider.toLowerCase() === 'llamacpp') {
+                            await stopAllModels()
+                          }
                           updateProvider(provider.provider, {
                             ...provider,
                             active: e,


### PR DESCRIPTION
## Describe Your Changes

This pull request adds logic to stop all running models when the `llama.cpp` provider is deactivated from the model providers settings page. This ensures that no models continue running in the background when the provider is turned off.

Provider deactivation logic:

* [`web-app/src/routes/settings/providers/index.tsx`](diffhunk://#diff-0d0b0f92e85d8f8d663d7f1e4b6e3298596771f2d33cf123cf915c23867eeaf6L172-R176): Added a call to `stopAllModels()` when the `llama.cpp` provider is deactivated via the settings UI.
* [`web-app/src/routes/settings/providers/index.tsx`](diffhunk://#diff-0d0b0f92e85d8f8d663d7f1e4b6e3298596771f2d33cf123cf915c23867eeaf6R28): Imported the `stopAllModels` function from `@/services/models` to support this new behavior.

## Fixes Issues

https://github.com/user-attachments/assets/d8c9de4a-f19b-4de8-8368-63208fc7a468


- Closes #5664 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds logic to stop all models when `llama.cpp` provider is deactivated in `index.tsx`.
> 
>   - **Behavior**:
>     - Calls `stopAllModels()` in `index.tsx` when `llama.cpp` provider is deactivated.
>     - Ensures no models run when `llama.cpp` is turned off.
>   - **Imports**:
>     - Imports `stopAllModels` from `@/services/models` in `index.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 04f614cdaa5159cd9dd703f345eb3e71d251205d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->