### PR TITLE
fix: downloaded model should from variant level instead of the model level

### DIFF
--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -146,13 +146,14 @@ function Hub() {
     }
     // Apply downloaded filter
     if (showOnlyDownloaded) {
-      filtered = filtered?.filter((model) =>
-        model.quants.some((variant) =>
+      filtered = filtered?.map((model) => ({
+        ...model,
+        quants: model.quants.filter((variant) =>
           llamaProvider?.models.some(
             (m: { id: string }) => m.id === variant.model_id
           )
         )
-      )
+      })).filter((model) => model.quants.length > 0)
     }
     // Add HuggingFace repo at the beginning if available
     if (huggingFaceRepo) {


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the logic for filtering downloaded models in the `Hub` component to ensure that only models with at least one downloaded variant are shown, and that their `quants` arrays only include downloaded variants.

Filtering improvements:

* The downloaded filter now maps over each model, keeping only the `quants` variants that are downloaded, and then filters out models that have no downloaded variants left in their `quants` array. (`web-app/src/routes/hub/index.tsx`, [web-app/src/routes/hub/index.tsxL149-R156](diffhunk://#diff-084290500086972e3af4737cfcaa017817be4696b71fe295e0afb29400715c9fL149-R156))

## Fixes Issues

<img width="818" height="686" alt="86792" src="https://github.com/user-attachments/assets/58990a5f-1f0a-4336-a74d-412e50da59fc" />


- Closes #5962 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
