### PR TITLE
feat: add tool call cancellation

### DIFF
--- a/src-tauri/src/core/state.rs
+++ b/src-tauri/src/core/state.rs
@@ -6,7 +6,7 @@ use rmcp::{
     service::RunningService,
     RoleClient, ServiceError,
 };
-use tokio::sync::Mutex;
+use tokio::sync::{Mutex, oneshot};
 use tokio::task::JoinHandle;
 
 /// Server handle type for managing the proxy server lifecycle
@@ -27,6 +27,7 @@ pub struct AppState {
     pub mcp_active_servers: Arc<Mutex<HashMap<String, serde_json::Value>>>,
     pub mcp_successfully_connected: Arc<Mutex<HashMap<String, bool>>>,
     pub server_handle: Arc<Mutex<Option<ServerHandle>>>,
+    pub tool_call_cancellations: Arc<Mutex<HashMap<String, oneshot::Sender<()>>>>,
 }
 
 impl RunningServiceEnum {

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -74,6 +74,7 @@ pub fn run() {
             // MCP commands
             core::mcp::commands::get_tools,
             core::mcp::commands::call_tool,
+            core::mcp::commands::cancel_tool_call,
             core::mcp::commands::restart_mcp_servers,
             core::mcp::commands::get_connected_servers,
             core::mcp::commands::save_mcp_configs,
@@ -105,6 +106,7 @@ pub fn run() {
             mcp_active_servers: Arc::new(Mutex::new(HashMap::new())),
             mcp_successfully_connected: Arc::new(Mutex::new(HashMap::new())),
             server_handle: Arc::new(Mutex::new(None)),
+            tool_call_cancellations: Arc::new(Mutex::new(HashMap::new())),
         })
         .setup(|app| {
             app.handle().plugin(

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -46,8 +46,13 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
   const textareaRef = useRef<HTMLTextAreaElement>(null)
   const [isFocused, setIsFocused] = useState(false)
   const [rows, setRows] = useState(1)
-  const { streamingContent, abortControllers, loadingModel, tools } =
-    useAppState()
+  const {
+    streamingContent,
+    abortControllers,
+    loadingModel,
+    tools,
+    cancelToolCall,
+  } = useAppState()
   const { prompt, setPrompt } = usePrompt()
   const { currentThreadId } = useThreads()
   const { t } = useTranslation()
@@ -161,8 +166,9 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
   const stopStreaming = useCallback(
     (threadId: string) => {
       abortControllers[threadId]?.abort()
+      cancelToolCall?.()
     },
-    [abortControllers]
+    [abortControllers, cancelToolCall]
   )
 
   const fileInputRef = useRef<HTMLInputElement>(null)

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -13,6 +13,7 @@ type AppState = {
   tokenSpeed?: TokenSpeed
   currentToolCall?: ChatCompletionMessageToolCall
   showOutOfContextDialog?: boolean
+  cancelToolCall?: () => void
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
   updateCurrentToolCall: (
@@ -24,6 +25,7 @@ type AppState = {
   updateTokenSpeed: (message: ThreadMessage, increment?: number) => void
   resetTokenSpeed: () => void
   setOutOfContextDialog: (show: boolean) => void
+  setCancelToolCall: (cancel: (() => void) | undefined) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -34,6 +36,7 @@ export const useAppState = create<AppState>()((set) => ({
   abortControllers: {},
   tokenSpeed: undefined,
   currentToolCall: undefined,
+  cancelToolCall: undefined,
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     const assistants = useAssistant.getState().assistants
     const currentAssistant = useAssistant.getState().currentAssistant
@@ -110,6 +113,11 @@ export const useAppState = create<AppState>()((set) => ({
   setOutOfContextDialog: (show) => {
     set(() => ({
       showOutOfContextDialog: show,
+    }))
+  },
+  setCancelToolCall: (cancel) => {
+    set(() => ({
+      cancelToolCall: cancel,
     }))
   },
 }))

--- a/web-app/src/lib/service.ts
+++ b/web-app/src/lib/service.ts
@@ -5,6 +5,7 @@ export const AppRoutes = [
   'installExtensions',
   'getTools',
   'callTool',
+  'cancelToolCall',
   'listThreads',
   'createThread',
   'modifyThread',

--- a/web-app/src/services/mcp.ts
+++ b/web-app/src/services/mcp.ts
@@ -56,3 +56,44 @@ export const callTool = (args: {
 }): Promise<{ error: string; content: { text: string }[] }> => {
   return window.core?.api?.callTool(args)
 }
+
+/**
+ * @description Enhanced function to invoke an MCP tool with cancellation support
+ * @param args - Tool call arguments
+ * @param cancellationToken - Optional cancellation token
+ * @returns Promise with tool result and cancellation function
+ */
+export const callToolWithCancellation = (args: {
+  toolName: string
+  arguments: object
+  cancellationToken?: string
+}): {
+  promise: Promise<{ error: string; content: { text: string }[] }>
+  cancel: () => Promise<void>
+  token: string
+} => {
+  // Generate a unique cancellation token if not provided
+  const token = args.cancellationToken ?? `tool_call_${Date.now()}_${Math.random().toString(36).substr(2, 9)}`
+  
+  // Create the tool call promise with cancellation token
+  const promise = window.core?.api?.callTool({
+    ...args,
+    cancellationToken: token
+  })
+  
+  // Create cancel function
+  const cancel = async () => {
+    await window.core?.api?.cancelToolCall({ cancellationToken: token })
+  }
+  
+  return { promise, cancel, token }
+}
+
+/**
+ * @description This function cancels a running tool call
+ * @param cancellationToken - The token identifying the tool call to cancel
+ * @returns
+ */
+export const cancelToolCall = (cancellationToken: string): Promise<void> => {
+  return window.core?.api?.cancelToolCall({ cancellationToken })
+}


### PR DESCRIPTION
## Describe Your Changes

This PR implements tool call cancellation functionality, allowing users to cancel running MCP tool calls mid-execution.

https://github.com/user-attachments/assets/37435bf1-122c-4087-a4bd-1ef616ab6874

### Backend (Rust/Tauri)
- Enhanced call_tool command with cancellation support via optional cancellation_token parameter
- New cancel_tool_call command to trigger cancellation of running tool calls
- Cancellation state management using HashMap<String, oneshot::Sender<()>> to track active tool calls
- Race condition handling using tokio::select! to manage timeout, tool execution, and cancellation signals

### Frontend (TypeScript/React)

 - Refactored callToolWithCancellation service to replace the original callTool, returning both promise and cancel function
 - Enhanced useAppState hook with cancelToolCall function and setCancelToolCall method for state management
 - Updated completion.ts to use the new cancellation-aware tool calling system
 - Integrated stop functionality in ChatInput component to cancel tool calls when user stops generation

## Fixes Issues

- Closes #5792

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
