### PR TITLE
feat: allow user to set max_attempt for MCP to avoid looping

### DIFF
--- a/web-app/src/containers/dialogs/AddEditAssistant.tsx
+++ b/web-app/src/containers/dialogs/AddEditAssistant.tsx
@@ -62,6 +62,7 @@ export default function AddEditAssistant({
   const [showEmojiPicker, setShowEmojiPicker] = useState(false)
   const emojiPickerRef = useRef<HTMLDivElement>(null)
   const [nameError, setNameError] = useState<string | null>(null)
+  const [toolSteps, setToolSteps] = useState(20)
 
   // Handle click outside emoji picker
   useEffect(() => {
@@ -90,6 +91,7 @@ export default function AddEditAssistant({
       setName(initialData.name)
       setDescription(initialData.description)
       setInstructions(initialData.instructions)
+      setToolSteps(initialData.tool_steps ?? 20)
       // Convert parameters object to arrays of keys and values
       const keys = Object.keys(initialData.parameters || {})
       const values = Object.values(initialData.parameters || {})
@@ -120,6 +122,7 @@ export default function AddEditAssistant({
     setParamsValues([''])
     setParamsTypes(['string'])
     setNameError(null)
+    setToolSteps(20)
   }
 
   const handleParameterChange = (
@@ -216,6 +219,7 @@ export default function AddEditAssistant({
       description,
       instructions,
       parameters: parameters || {},
+      tool_steps: toolSteps,
     }
     onSave(assistant)
     onOpenChange(false)
@@ -321,6 +325,30 @@ export default function AddEditAssistant({
               className="resize-none"
               rows={4}
             />
+          </div>
+
+          <div className="space-y-2 my-4">
+            <div className="flex items-center justify-between">
+              <label className="text-sm">{t('common:settings')}</label>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              <div className="flex items-center gap-4">
+                <div className="flex items-center flex-col sm:flex-row w-full gap-2">
+                  <span className="text-sm">{t('assistants:maxToolSteps')}</span>
+                  <Input
+                    value={toolSteps}
+                    type="number"
+                    onChange={(e) => {
+                      const newSteps = e.target.value
+                      const stepNumber = Number(newSteps)
+                      setToolSteps(isNaN(stepNumber) ? 20 : stepNumber)
+                    }}
+                    placeholder="20"
+                    className="w-full sm:w-24"
+                  />
+                </div>
+              </div>
+            </div>
           </div>
 
           <div className="space-y-2 my-4">

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -254,8 +254,8 @@ export const useChat = () => {
               })
             : []
 
-        // TODO: Later replaced by Agent setup?
-        const followUpWithToolUse = true
+        let assistantLoopSteps = 0
+
         while (
           !isCompleted &&
           !abortController.signal.aborted &&
@@ -264,6 +264,7 @@ export const useChat = () => {
           const modelConfig = activeProvider.models.find(
             (m) => m.id === selectedModel?.id
           )
+          assistantLoopSteps += 1
 
           const modelSettings = modelConfig?.settings
             ? Object.fromEntries(
@@ -508,7 +509,11 @@ export const useChat = () => {
 
           isCompleted = !toolCalls.length
           // Do not create agent loop if there is no need for it
-          if (!followUpWithToolUse) availableTools = []
+          // Check if assistant loop steps are within limits
+          if (assistantLoopSteps >= (currentAssistant?.tool_steps ?? 20)) {
+            // Stop the assistant tool call if it exceeds the maximum steps
+            availableTools = []
+          }
         }
       } catch (error) {
         if (!abortController.signal.aborted) {

--- a/web-app/src/locales/de-DE/assistants.json
+++ b/web-app/src/locales/de-DE/assistants.json
@@ -29,5 +29,6 @@
   "save": "Speichern",
   "createNew": "Neuen Assistenten anlegen",
   "personality": "Persönlichkeit",
-  "capabilities": "Fähigkeiten"
+  "capabilities": "Fähigkeiten",
+  "maxToolSteps": "Maximale Werkzeugschritte"
 }

--- a/web-app/src/locales/en/assistants.json
+++ b/web-app/src/locales/en/assistants.json
@@ -29,5 +29,6 @@
   "save": "Save",
   "createNew": "Create New Assistant",
   "personality": "Personality",
-  "capabilities": "Capabilities"
+  "capabilities": "Capabilities",
+  "maxToolSteps": "Max tool steps"
 }

--- a/web-app/src/locales/id/assistants.json
+++ b/web-app/src/locales/id/assistants.json
@@ -29,5 +29,6 @@
   "save": "Simpan",
   "createNew": "Buat Asisten Baru",
   "personality": "Kepribadian",
-  "capabilities": "Kemampuan"
+  "capabilities": "Kemampuan",
+  "maxToolSteps": "Langkah alat maksimum"
 }

--- a/web-app/src/locales/vn/assistants.json
+++ b/web-app/src/locales/vn/assistants.json
@@ -29,5 +29,6 @@
   "save": "Lưu",
   "createNew": "Tạo Trợ lý Mới",
   "personality": "Tính cách",
-  "capabilities": "Khả năng"
+  "capabilities": "Khả năng",
+  "maxToolSteps": "Bước tối đa của công cụ"
 }

--- a/web-app/src/locales/zh-CN/assistants.json
+++ b/web-app/src/locales/zh-CN/assistants.json
@@ -29,5 +29,6 @@
   "save": "保存",
   "createNew": "创建新助手",
   "personality": "个性",
-  "capabilities": "能力"
+  "capabilities": "能力",
+  "maxToolSteps": "最大工具步骤"
 }

--- a/web-app/src/locales/zh-TW/assistants.json
+++ b/web-app/src/locales/zh-TW/assistants.json
@@ -29,5 +29,6 @@
   "save": "儲存",
   "createNew": "建立新助理",
   "personality": "個性",
-  "capabilities": "能力"
+  "capabilities": "能力",
+  "maxToolSteps": "最大工具步驟"
 }

--- a/web-app/src/types/threads.d.ts
+++ b/web-app/src/types/threads.d.ts
@@ -54,6 +54,7 @@ type Assistant = {
   description?: string
   instructions: string
   parameters: Record<string, unknown>
+  tool_steps?: number
 }
 
 type TokenSpeed = {


### PR DESCRIPTION
## Describe Your Changes
Adds a configurable max tool steps setting for assistants to prevent infinite MCP tool call loops. Users can now set a maximum number of tool execution steps (default: 20) to control assistant behavior and avoid potential infinite loops.

## Fixes Issues

- Closes #5981

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
