### PR TITLE
fix: local api server log (#6240)

### DIFF
--- a/web-app/src/routes/local-api-server/logs.tsx
+++ b/web-app/src/routes/local-api-server/logs.tsx
@@ -11,7 +11,7 @@ export const Route = createFileRoute(route.localApiServerlogs as any)({
   component: LogsViewer,
 })
 
-const SERVER_LOG_TARGET = 'app_lib::core::server'
+const SERVER_LOG_TARGET = 'app_lib::core::server::proxy'
 const LOG_EVENT_NAME = 'log://log'
 
 function LogsViewer() {


### PR DESCRIPTION
## Describe Your Changes

- Local API server log was not showing, now it should. Just a simple change on the filter on the frontend after the structure have changed on the backend side.

## Fixes Issues

- Closes #6240

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
