### PR TITLE
chore: update new domain for jan docs

### DIFF
--- a/.github/workflows/jan-astro-docs.yml
+++ b/.github/workflows/jan-astro-docs.yml
@@ -19,7 +19,7 @@ jobs:
   deploy:
     name: Deploy to CloudFlare Pages
     env:
-      CLOUDFLARE_PROJECT_NAME: astro-docs
+      CLOUDFLARE_PROJECT_NAME: astro-docs # docs.jan.ai
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This pull request makes a minor update to the deployment workflow configuration by adding a clarifying comment to the `CLOUDFLARE_PROJECT_NAME` environment variable in `.github/workflows/jan-astro-docs.yml`. No functional changes were made.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add comment to clarify `CLOUDFLARE_PROJECT_NAME` in `jan-astro-docs.yml`.
> 
>   - **Comment Update**:
>     - Adds a comment `# docs.jan.ai` to `CLOUDFLARE_PROJECT_NAME` in `.github/workflows/jan-astro-docs.yml` to clarify its purpose.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for df4491e568c330ed6e56f3af44034f7a476aca87. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->