### PR TITLE
feat: Add support for custom environmental variables to llama.cpp

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -10,7 +10,18 @@
       "recommended": ""
     }
   },
-
+  {
+    "key": "llamacpp_env",
+    "title": "Environmental variables",
+    "description": "Environmental variables for llama.cpp(KEY=VALUE), separated by ';'",
+    "controllerType": "input",
+    "controllerProps": {
+      "value": "none",
+      "placeholder": "Eg, GGML_VK_VISIBLE_DEVICES='0,1'",
+      "type": "text",
+      "textAlign": "right"
+    }
+  },
   {
     "key": "auto_update_engine",
     "title": "Auto update engine",

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -39,6 +39,7 @@ type LlamacppConfig = {
   version_backend: string
   auto_update_engine: boolean
   auto_unload: boolean
+  llamacpp_env: string
   chat_template: string
   n_gpu_layers: number
   offload_mmproj: boolean
@@ -146,6 +147,7 @@ const logger = {
 export default class llamacpp_extension extends AIEngine {
   provider: string = 'llamacpp'
   autoUnload: boolean = true
+  llamacpp_env: string = ''
   readonly providerId: string = 'llamacpp'
 
   private config: LlamacppConfig
@@ -175,6 +177,7 @@ export default class llamacpp_extension extends AIEngine {
     this.config = loadedConfig as LlamacppConfig
 
     this.autoUnload = this.config.auto_unload
+    this.llamacpp_env = this.config.llamacpp_env
 
     // This sets the base directory where model files for this provider are stored.
     this.providerPath = await joinPath([
@@ -801,6 +804,8 @@ export default class llamacpp_extension extends AIEngine {
       closure()
     } else if (key === 'auto_unload') {
       this.autoUnload = value as boolean
+    } else if (key === 'llamacpp_env') {
+      this.llamacpp_env = value as string
     }
   }
 
@@ -1133,6 +1138,27 @@ export default class llamacpp_extension extends AIEngine {
     }
   }
 
+  private parseEnvFromString(
+    target: Record<string, string>,
+    envString: string
+  ): void {
+    envString
+      .split(';')
+      .filter((pair) => pair.trim())
+      .forEach((pair) => {
+        const [key, ...valueParts] = pair.split('=')
+        const cleanKey = key?.trim()
+
+        if (
+          cleanKey &&
+          valueParts.length > 0 &&
+          !cleanKey.startsWith('LLAMA')
+        ) {
+          target[cleanKey] = valueParts.join('=').trim()
+        }
+      })
+  }
+
   override async load(
     modelId: string,
     overrideSettings?: Partial<LlamacppConfig>,
@@ -1220,6 +1246,9 @@ export default class llamacpp_extension extends AIEngine {
     args.push('--no-webui')
     const api_key = await this.generateApiKey(modelId, String(port))
     envs['LLAMA_API_KEY'] = api_key
+
+    // set user envs
+    this.parseEnvFromString(envs, this.llamacpp_env)
 
     // model option is required
     // NOTE: model_path and mmproj_path can be either relative to Jan's data folder or absolute path
@@ -1596,6 +1625,9 @@ export default class llamacpp_extension extends AIEngine {
         `Invalid version/backend format: ${cfg.version_backend}. Expected format: <version>/<backend>`
       )
     }
+    // set envs
+    const envs: Record<string, string> = {}
+    this.parseEnvFromString(envs, this.llamacpp_env)
 
     // Ensure backend is downloaded and ready before proceeding
     await this.ensureBackendReady(backend, version)
@@ -1606,6 +1638,7 @@ export default class llamacpp_extension extends AIEngine {
       const dList = await invoke<DeviceList[]>('plugin:llamacpp|get_devices', {
         backendPath,
         libraryPath,
+        envs,
       })
       return dList
     } catch (error) {

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/commands.rs
@@ -265,8 +265,9 @@ pub async fn unload_llama_model<R: Runtime>(
 pub async fn get_devices(
     backend_path: &str,
     library_path: Option<&str>,
+    envs: HashMap<String, String>
 ) -> ServerResult<Vec<DeviceInfo>> {
-    get_devices_from_backend(backend_path, library_path).await
+    get_devices_from_backend(backend_path, library_path, envs).await
 }
 
 /// Generate API key using HMAC-SHA256

--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/device.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/device.rs
@@ -1,4 +1,5 @@
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 use std::process::Stdio;
 use std::time::Duration;
 use tokio::process::Command;
@@ -19,6 +20,7 @@ pub struct DeviceInfo {
 pub async fn get_devices_from_backend(
     backend_path: &str,
     library_path: Option<&str>,
+    envs: HashMap<String, String>,
 ) -> ServerResult<Vec<DeviceInfo>> {
     log::info!("Getting devices from server at path: {:?}", backend_path);
 
@@ -27,6 +29,7 @@ pub async fn get_devices_from_backend(
     // Configure the command to run the server with --list-devices
     let mut command = Command::new(backend_path);
     command.arg("--list-devices");
+    command.envs(envs);
 
     // Set up library path
     setup_library_path(library_path, &mut command);


### PR DESCRIPTION
## Describe Your Changes

This commit adds a new setting `llamacpp_env` to the llama.cpp extension, allowing users to specify custom environment variables. These variables are passed to the backend process when it starts.

A new function `parseEnvFromString` is introduced to handle the parsing of the semicolon-separated key-value pairs from the user input. The environment variables are then used in the `load` function and when listing available devices. This enables more flexible configuration of the llama.cpp backend, such as specifying visible GPUs for Vulkan.

This change also updates the Tauri command `get_devices` to accept environment variables, ensuring that device discovery respects the user's settings.

<img width="1094" height="870" alt="image" src="https://github.com/user-attachments/assets/6d4a2f5d-083f-4872-b8ab-b49a0cfb3f45" />


## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds support for custom environment variables in llama.cpp, enhancing backend configuration flexibility.
> 
>   - **Behavior**:
>     - Adds `llamacpp_env` setting in `settings.json` for custom environment variables, parsed by `parseEnvFromString()` in `index.ts`.
>     - Environment variables applied in `load()` and `getDevices()` in `index.ts` for backend configuration.
>   - **Commands**:
>     - Updates `get_devices` in `commands.rs` to accept and use environment variables.
>   - **Device Handling**:
>     - Modifies `get_devices_from_backend()` in `device.rs` to utilize environment variables for device discovery.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 046fe510a9450d3d46d0611392b75b4f04765338. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->