### PR TITLE
fix: check for env value before setting

### DIFF
--- a/extensions/llamacpp-extension/settings.json
+++ b/extensions/llamacpp-extension/settings.json
@@ -16,7 +16,7 @@
     "description": "Environmental variables for llama.cpp(KEY=VALUE), separated by ';'",
     "controllerType": "input",
     "controllerProps": {
-      "value": "none",
+      "value": "",
       "placeholder": "Eg. GGML_VK_VISIBLE_DEVICES=0,1",
       "type": "text",
       "textAlign": "right"

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1082,9 +1082,9 @@ export default class llamacpp_extension extends AIEngine {
 
         // If we reach here, download completed successfully (including validation)
         // The downloadFiles function only returns successfully if all files downloaded AND validated
-        events.emit(DownloadEvent.onFileDownloadAndVerificationSuccess, { 
-          modelId, 
-          downloadType: 'Model' 
+        events.emit(DownloadEvent.onFileDownloadAndVerificationSuccess, {
+          modelId,
+          downloadType: 'Model',
         })
       } catch (error) {
         logger.error('Error downloading model:', modelId, opts, error)
@@ -1092,7 +1092,8 @@ export default class llamacpp_extension extends AIEngine {
           error instanceof Error ? error.message : String(error)
 
         // Check if this is a cancellation
-        const isCancellationError = errorMessage.includes('Download cancelled') ||
+        const isCancellationError =
+          errorMessage.includes('Download cancelled') ||
           errorMessage.includes('Validation cancelled') ||
           errorMessage.includes('Hash computation cancelled') ||
           errorMessage.includes('cancelled') ||
@@ -1372,7 +1373,7 @@ export default class llamacpp_extension extends AIEngine {
     envs['LLAMA_API_KEY'] = api_key
 
     // set user envs
-    this.parseEnvFromString(envs, this.llamacpp_env)
+    if (this.llamacpp_env) this.parseEnvFromString(envs, this.llamacpp_env)
 
     // model option is required
     // NOTE: model_path and mmproj_path can be either relative to Jan's data folder or absolute path
@@ -1751,7 +1752,7 @@ export default class llamacpp_extension extends AIEngine {
     }
     // set envs
     const envs: Record<string, string> = {}
-    this.parseEnvFromString(envs, this.llamacpp_env)
+    if (this.llamacpp_env) this.parseEnvFromString(envs, this.llamacpp_env)
 
     // Ensure backend is downloaded and ready before proceeding
     await this.ensureBackendReady(backend, version)
@@ -1767,7 +1768,7 @@ export default class llamacpp_extension extends AIEngine {
       return dList
     } catch (error) {
       logger.error('Failed to query devices:\n', error)
-      throw new Error("Failed to load llamacpp backend")
+      throw new Error('Failed to load llamacpp backend')
     }
   }
 
@@ -1876,7 +1877,7 @@ export default class llamacpp_extension extends AIEngine {
       logger.info(
         `Using explicit key_length: ${keyLen}, value_length: ${valLen}`
       )
-      headDim = (keyLen + valLen)
+      headDim = keyLen + valLen
     } else {
       // Fall back to embedding_length estimation
       const embeddingLen = Number(meta[`${arch}.embedding_length`])


### PR DESCRIPTION
## Describe Your Changes
The variable `llamacpp_env` wasn't checked for validity before setting causing some errors in extension.
This changes adds a condition to only extract when `llamacpp_env` is set.

Also adds formatting fixes.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add condition to check if `llamacpp_env` is set before parsing, and fix formatting in `index.ts`.
> 
>   - **Behavior**:
>     - Add condition to check if `llamacpp_env` is set before calling `parseEnvFromString` in `index.ts`.
>   - **Formatting**:
>     - Fix formatting issues in `index.ts` around `events.emit` and `isCancellationError`.
>   - **Settings**:
>     - Change default `value` of `llamacpp_env` to an empty string in `settings.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 774d733504813dbda5e9b38feb417cae646f4c51. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->