### PR TITLE
fix: update ui info

### DIFF
--- a/web-app/src/components/ui/hover-card.tsx
+++ b/web-app/src/components/ui/hover-card.tsx
@@ -6,7 +6,14 @@ import { cn } from '@/lib/utils'
 function HoverCard({
   ...props
 }: React.ComponentProps<typeof HoverCardPrimitive.Root>) {
-  return <HoverCardPrimitive.Root data-slot="hover-card" {...props} />
+  return (
+    <HoverCardPrimitive.Root
+      openDelay={0}
+      closeDelay={0}
+      data-slot="hover-card"
+      {...props}
+    />
+  )
 }
 
 function HoverCardTrigger({

--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -562,7 +562,7 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
                         </div>
                       </TooltipTrigger>
                       <TooltipContent>
-                        <p>{t('visions')}</p>
+                        <p>{t('vision')}</p>
                       </TooltipContent>
                     </Tooltip>
                   </TooltipProvider>

--- a/web-app/src/containers/ModelInfoHoverCard.tsx
+++ b/web-app/src/containers/ModelInfoHoverCard.tsx
@@ -5,11 +5,11 @@ import {
 } from '@/components/ui/hover-card'
 import { IconInfoCircle } from '@tabler/icons-react'
 import { CatalogModel, ModelQuant } from '@/services/models'
-import { extractDescription } from '@/lib/models'
 
 interface ModelInfoHoverCardProps {
   model: CatalogModel
   variant?: ModelQuant
+  isDefaultVariant?: boolean
   defaultModelQuantizations: string[]
   modelSupportStatus: Record<string, string>
   onCheckModelSupport: (variant: ModelQuant) => void
@@ -19,12 +19,12 @@ interface ModelInfoHoverCardProps {
 export const ModelInfoHoverCard = ({
   model,
   variant,
+  isDefaultVariant,
   defaultModelQuantizations,
   modelSupportStatus,
   onCheckModelSupport,
   children,
 }: ModelInfoHoverCardProps) => {
-  const isVariantMode = !!variant
   const displayVariant =
     variant ||
     model.quants.find((m) =>
@@ -95,8 +95,8 @@ export const ModelInfoHoverCard = ({
         {children || (
           <div className="cursor-pointer">
             <IconInfoCircle
-              size={14}
-              className="mt-0.5 text-main-view-fg/50 hover:text-main-view-fg/80 transition-colors"
+              size={isDefaultVariant ? 20 : 14}
+              className="mt-0.5 text-main-view-fg/80 hover:text-main-view-fg/80 transition-colors"
             />
           </div>
         )}
@@ -106,10 +106,10 @@ export const ModelInfoHoverCard = ({
           {/* Header */}
           <div className="border-b border-main-view-fg/10 pb-3">
             <h4 className="text-sm font-semibold text-main-view-fg">
-              {isVariantMode ? variant.model_id : model.model_name}
+              {!isDefaultVariant ? variant?.model_id : model?.model_name}
             </h4>
             <p className="text-xs text-main-view-fg/60 mt-1">
-              {isVariantMode
+              {!isDefaultVariant
                 ? 'Model Variant Information'
                 : 'Model Information'}
             </p>
@@ -118,57 +118,21 @@ export const ModelInfoHoverCard = ({
           {/* Main Info Grid */}
           <div className="grid grid-cols-2 gap-3 text-xs">
             <div className="space-y-2">
-              {isVariantMode ? (
-                <>
-                  <div>
-                    <span className="text-main-view-fg/50 block">
-                      File Size
-                    </span>
-                    <span className="text-main-view-fg font-medium mt-1 inline-block">
-                      {variant.file_size}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-main-view-fg/50 block">
-                      Quantization
-                    </span>
-                    <span className="text-main-view-fg font-medium mt-1 inline-block">
-                      {variant.model_id.split('-').pop()?.toUpperCase() ||
-                        'N/A'}
-                    </span>
-                  </div>
-                </>
-              ) : (
-                <>
-                  <div>
-                    <span className="text-main-view-fg/50 block">
-                      Downloads
-                    </span>
-                    <span className="text-main-view-fg font-medium mt-1 inline-block">
-                      {model.downloads?.toLocaleString() || '0'}
-                    </span>
-                  </div>
-                  <div>
-                    <span className="text-main-view-fg/50 block">Variants</span>
-                    <span className="text-main-view-fg font-medium mt-1 inline-block">
-                      {model.quants?.length || 0}
-                    </span>
-                  </div>
-                </>
-              )}
+              <>
+                <div>
+                  <span className="text-main-view-fg/50 block">
+                    {isDefaultVariant
+                      ? 'Maybe Default Quantization'
+                      : 'Quantization'}
+                  </span>
+                  <span className="text-main-view-fg font-medium mt-1 inline-block">
+                    {variant?.model_id.split('-').pop()?.toUpperCase() || 'N/A'}
+                  </span>
+                </div>
+              </>
             </div>
 
             <div className="space-y-2">
-              {!isVariantMode && (
-                <div>
-                  <span className="text-main-view-fg/50 block">
-                    Default Size
-                  </span>
-                  <span className="text-main-view-fg font-medium mt-1 inline-block">
-                    {displayVariant?.file_size || 'N/A'}
-                  </span>
-                </div>
-              )}
               <div>
                 <span className="text-main-view-fg/50 block">
                   Compatibility
@@ -204,21 +168,6 @@ export const ModelInfoHoverCard = ({
               </div>
             </div>
           )}
-
-          {/* Content Section */}
-          <div className="border-t border-main-view-fg/10 pt-3">
-            <h5 className="text-xs font-medium text-main-view-fg/70 mb-1">
-              {isVariantMode ? 'Download URL' : 'Description'}
-            </h5>
-            <div className="text-xs text-main-view-fg/60 bg-main-view-fg/5 rounded p-2">
-              {isVariantMode ? (
-                <div className="font-mono break-all">{variant.path}</div>
-              ) : (
-                extractDescription(model?.description) ||
-                'No description available'
-              )}
-            </div>
-          </div>
         </div>
       </HoverCardContent>
     </HoverCard>

--- a/web-app/src/containers/dialogs/EditModel.tsx
+++ b/web-app/src/containers/dialogs/EditModel.tsx
@@ -7,11 +7,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Switch } from '@/components/ui/switch'
-import {
-  Tooltip,
-  TooltipContent,
-  TooltipTrigger,
-} from '@/components/ui/tooltip'
+
 import { useModelProvider } from '@/hooks/useModelProvider'
 import {
   IconPencil,
@@ -19,7 +15,7 @@ import {
   IconTool,
   // IconWorld,
   // IconAtom,
-  IconCodeCircle2,
+  // IconCodeCircle2,
 } from '@tabler/icons-react'
 import { useState, useEffect } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
@@ -186,7 +182,7 @@ export const DialogEditModel = ({
               />
             </div>
 
-            <div className="flex items-center justify-between">
+            {/* <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2">
                 <IconCodeCircle2 className="size-4 text-main-view-fg/70" />
                 <span className="text-sm">
@@ -208,7 +204,7 @@ export const DialogEditModel = ({
                   {t('providers:editModel.notAvailable')}
                 </TooltipContent>
               </Tooltip>
-            </div>
+            </div> */}
 
             {/* <div className="flex items-center justify-between">
               <div className="flex items-center space-x-2">

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -353,12 +353,7 @@ function Hub() {
         // Immediately set local downloading state
         addLocalDownloadingModel(modelId)
         const mmprojPath = model.mmproj_models?.[0]?.path
-        pullModelWithMetadata(
-          modelId, 
-          modelUrl,
-          mmprojPath,
-          huggingfaceToken
-        )
+        pullModelWithMetadata(modelId, modelUrl, mmprojPath, huggingfaceToken)
       }
 
       return (
@@ -661,6 +656,18 @@ function Hub() {
                                   defaultModelQuantizations={
                                     defaultModelQuantizations
                                   }
+                                  variant={
+                                    filteredModels[
+                                      virtualItem.index
+                                    ].quants.find((m) =>
+                                      defaultModelQuantizations.some((e) =>
+                                        m.model_id.toLowerCase().includes(e)
+                                      )
+                                    ) ??
+                                    filteredModels[virtualItem.index]
+                                      .quants?.[0]
+                                  }
+                                  isDefaultVariant={true}
                                   modelSupportStatus={modelSupportStatus}
                                   onCheckModelSupport={checkModelSupport}
                                 />

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -394,13 +394,13 @@ function Hub() {
       )
     }
   }, [
+    localDownloadingModels,
     downloadProcesses,
     llamaProvider?.models,
     isRecommendedModel,
-    downloadButtonRef,
-    localDownloadingModels,
-    addLocalDownloadingModel,
     t,
+    addLocalDownloadingModel,
+    huggingfaceToken,
     handleUseModel,
   ])
 
@@ -477,9 +477,9 @@ function Hub() {
   const isLastStep = currentStepIndex === steps.length - 1
 
   const renderFilter = () => {
-    if (searchValue.length === 0)
-      return (
-        <>
+    return (
+      <>
+        {searchValue.length === 0 && (
           <DropdownMenu>
             <DropdownMenuTrigger>
               <span className="flex cursor-pointer items-center gap-1 px-2 py-1 rounded-sm bg-main-view-fg/15 text-sm outline-none text-main-view-fg font-medium">
@@ -504,17 +504,18 @@ function Hub() {
               ))}
             </DropdownMenuContent>
           </DropdownMenu>
-          <div className="flex items-center gap-2">
-            <Switch
-              checked={showOnlyDownloaded}
-              onCheckedChange={setShowOnlyDownloaded}
-            />
-            <span className="text-xs text-main-view-fg/70 font-medium whitespace-nowrap">
-              {t('hub:downloaded')}
-            </span>
-          </div>
-        </>
-      )
+        )}
+        <div className="flex items-center gap-2">
+          <Switch
+            checked={showOnlyDownloaded}
+            onCheckedChange={setShowOnlyDownloaded}
+          />
+          <span className="text-xs text-main-view-fg/70 font-medium whitespace-nowrap">
+            {t('hub:downloaded')}
+          </span>
+        </div>
+      </>
+    )
   }
 
   return (

--- a/web-app/src/routes/settings/providers/$providerName.tsx
+++ b/web-app/src/routes/settings/providers/$providerName.tsx
@@ -584,10 +584,12 @@ function ProviderDetail() {
                           }
                           actions={
                             <div className="flex items-center gap-0.5">
-                              <DialogEditModel
-                                provider={provider}
-                                modelId={model.id}
-                              />
+                              {provider && provider.provider !== 'llamacpp' && (
+                                <DialogEditModel
+                                  provider={provider}
+                                  modelId={model.id}
+                                />
+                              )}
                               {model.settings && (
                                 <ModelSetting
                                   provider={provider}


### PR DESCRIPTION
## Describe Your Changes
This pull request introduces several improvements to the model information UI, refines tooltip and hover card behaviors, and cleans up unused code. The most significant changes are the refactoring of the `ModelInfoHoverCard` component to better distinguish between default and variant model views, and the addition of new props to support this. Other updates include tooltip text corrections, UI tweaks, and removal of unused imports and code blocks.

**Model Info UI Improvements:**
* Refactored `ModelInfoHoverCard` to use new `isDefaultVariant` and `variant` props, simplifying the logic for displaying model and variant information, and updating the info icon size and header/label texts accordingly. Removed the old `isVariantMode` logic and adjusted the info grid to more clearly show quantization and variant details. [[1]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1L8-R12) [[2]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1R22-L27) [[3]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1L98-R99) [[4]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1L109-R112) [[5]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1L121-L171) [[6]](diffhunk://#diff-9d2fa2225108d12e6a4b3124fdc64f93d5e7eb006e0e05f429290f34444d38e1L207-L221)
* Updated `Hub` route to pass the correct `variant` and `isDefaultVariant` props to `ModelInfoHoverCard`, ensuring the default quantization is shown for each model.

**UI and Tooltip Enhancements:**
* Set `openDelay` and `closeDelay` to 0 in `HoverCardPrimitive.Root` for instant hover card response.
* Corrected tooltip translation from `'visions'` to `'vision'` in `ChatInput`.

**Code Cleanup:**
* Removed unused imports and commented out unused UI sections in `EditModel` dialog. [[1]](diffhunk://#diff-85dd9bdabba639fff8aebd0fe639ec3cba59d2ca96dbb4f093e16f5af0869e6eL10-R18) [[2]](diffhunk://#diff-85dd9bdabba639fff8aebd0fe639ec3cba59d2ca96dbb4f093e16f5af0869e6eL189-R185) [[3]](diffhunk://#diff-85dd9bdabba639fff8aebd0fe639ec3cba59d2ca96dbb4f093e16f5af0869e6eL211-R207)
* Simplified argument formatting for `pullModelWithMetadata`.
* Restricted `DialogEditModel` rendering in provider settings to exclude the `'llamacpp'` provider.

## Fixes Issues

1. hide edit model capabilities for llamacpp provider
<img width="877" height="495" alt="Screenshot 2025-08-25 at 16 44 05" src="https://github.com/user-attachments/assets/d2808840-9495-40e6-9bd8-49fb15328f96" />

2. Increase size icon Info and update color more brigther, and remove several duplicate info such a file size, download number etc

<img width="1330" height="1130" alt="Screenshot 2025-08-25 at 16 41 57" src="https://github.com/user-attachments/assets/1a74e91b-995b-4e2f-b7da-dee4f5e76642" />

3. hide edit model capabilities embedings
<img width="2142" height="1678" alt="Screenshot 2025-08-25 at 16 44 46" src="https://github.com/user-attachments/assets/48d7b579-9ecb-44c8-ba42-fb926a1d54b9" />

4. enable back filter download when hub search value length > 0 
<img width="1110" height="185" alt="Screenshot 2025-08-25 at 16 50 34" src="https://github.com/user-attachments/assets/f7787425-91f0-4e56-8e22-ffabd8dc1e23" />

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
