### PR TITLE
fix: system monitor window permission

### DIFF
--- a/src-tauri/capabilities/system-monitor-window.json
+++ b/src-tauri/capabilities/system-monitor-window.json
@@ -9,6 +9,11 @@
     "core:window:allow-set-theme",
     "log:default",
     "core:webview:allow-create-webview-window",
-    "core:window:allow-set-focus"
+    "core:window:allow-set-focus",
+    "hardware:allow-get-system-info",
+    "hardware:allow-get-system-usage",
+    "llamacpp:allow-get-devices",
+    "llamacpp:allow-read-gguf-metadata",
+    "deep-link:allow-get-current"
   ]
 }


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the system monitor window capabilities to support additional hardware and application features. The main changes involve expanding the permissions to allow access to system information, usage statistics, device metadata, and deep linking functionality.

**New hardware and application capabilities:**

* Added `hardware:allow-get-system-info` and `hardware:allow-get-system-usage` to enable retrieving system information and usage statistics.
* Added `llamacpp:allow-get-devices` and `llamacpp:allow-read-gguf-metadata` to allow querying device information and reading model metadata for LlamaCpp integration.
* Added `deep-link:allow-get-current` to support deep linking features in the system monitor window.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add new permissions to `system-monitor-window.json` for system info, device metadata, and deep linking.
> 
>   - **Permissions**:
>     - Added `hardware:allow-get-system-info` and `hardware:allow-get-system-usage` to `system-monitor-window.json` for system info and usage stats.
>     - Added `llamacpp:allow-get-devices` and `llamacpp:allow-read-gguf-metadata` for device info and model metadata access.
>     - Added `deep-link:allow-get-current` to support deep linking in the system monitor window.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 4137821e535998985b762eb1c1ff7944685654ec. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->