### PR TITLE
fix: handle paste image on linux

### DIFF
--- a/web-app/src/containers/ChatInput.tsx
+++ b/web-app/src/containers/ChatInput.tsx
@@ -381,13 +381,53 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
     }
 
     const clipboardItems = e.clipboardData?.items
+    let hasProcessedImage = false
 
-    // Linux fallback: Use modern Clipboard API if clipboardData.items is unavailable
-    if (
-      !clipboardItems &&
-      navigator.clipboard &&
-      'read' in navigator.clipboard
-    ) {
+    // Try clipboardData.items first (traditional method)
+    if (clipboardItems && clipboardItems.length > 0) {
+      const imageItems = Array.from(clipboardItems).filter((item) =>
+        item.type.startsWith('image/')
+      )
+
+      if (imageItems.length > 0) {
+        e.preventDefault()
+
+        const files: File[] = []
+        let processedCount = 0
+
+        imageItems.forEach((item) => {
+          const file = item.getAsFile()
+          if (file) {
+            files.push(file)
+          }
+          processedCount++
+
+          // When all items are processed, handle the valid files
+          if (processedCount === imageItems.length) {
+            if (files.length > 0) {
+              const syntheticEvent = {
+                target: {
+                  files: files,
+                },
+              } as unknown as React.ChangeEvent<HTMLInputElement>
+
+              handleFileChange(syntheticEvent)
+              hasProcessedImage = true
+            }
+          }
+        })
+        
+        // If we found image items but couldn't get files, fall through to modern API
+        if (processedCount === imageItems.length && !hasProcessedImage) {
+          // Continue to modern clipboard API fallback below
+        } else {
+          return // Successfully processed with traditional method
+        }
+      }
+    }
+
+    // Modern Clipboard API fallback (for Linux, images copied from web, etc.)
+    if (navigator.clipboard && 'read' in navigator.clipboard) {
       e.preventDefault()
 
       try {
@@ -402,10 +442,11 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
           for (const type of imageTypes) {
             try {
               const blob = await item.getType(type)
-              // Convert blob to File
+              // Convert blob to File with better naming
+              const extension = type.split('/')[1] || 'png'
               const file = new File(
                 [blob],
-                `pasted-image.${type.split('/')[1]}`,
+                `pasted-image-${Date.now()}.${extension}`,
                 { type }
               )
               files.push(file)
@@ -423,47 +464,16 @@ const ChatInput = ({ model, className, initialMessage }: ChatInputProps) => {
           } as unknown as React.ChangeEvent<HTMLInputElement>
 
           handleFileChange(syntheticEvent)
+          return
         }
-        return
       } catch (error) {
-        console.error('Error reading clipboard contents:', error)
-        return
+        console.error('Clipboard API access failed:', error)
       }
     }
 
-    // Original logic for browsers with working clipboardData.items
-    if (!clipboardItems) {
-      return
-    }
-
-    const imageItems = Array.from(clipboardItems).filter((item) =>
-      item.type.startsWith('image/')
-    )
-
-    if (imageItems.length > 0) {
-      e.preventDefault()
-
-      const files: File[] = []
-      let processedCount = 0
-
-      imageItems.forEach((item) => {
-        const file = item.getAsFile()
-        if (file) {
-          files.push(file)
-        }
-        processedCount++
-
-        // When all items are processed, handle the valid files
-        if (processedCount === imageItems.length && files.length > 0) {
-          const syntheticEvent = {
-            target: {
-              files: files,
-            },
-          } as unknown as React.ChangeEvent<HTMLInputElement>
-
-          handleFileChange(syntheticEvent)
-        }
-      })
+    // If we reach here, no image was found or processed
+    if (!hasProcessedImage) {
+      console.log('No image data found in clipboard or clipboard access failed')
     }
   }
 


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the paste handling logic in the `ChatInput` component to improve compatibility with Linux systems and browsers that do not support the legacy `clipboardData.items` API. The main change is the addition of a fallback that uses the modern Clipboard API to read pasted images when the legacy API is unavailable.

**Paste handling improvements:**

* Added a fallback to use the modern Clipboard API (`navigator.clipboard.read`) when `clipboardData.items` is unavailable, improving image paste support on Linux and newer browsers.
* Ensured pasted images are converted to `File` objects and handled consistently by synthesizing a change event for the existing file handling logic.
* Added error handling for clipboard read operations to prevent crashes and log issues for debugging.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves image paste handling in `ChatInput.tsx` for Linux and newer browsers by using modern Clipboard API as a fallback and adding error handling.
> 
>   - **Behavior**:
>     - Updates `handlePaste` in `ChatInput.tsx` to use modern Clipboard API (`navigator.clipboard.read`) as a fallback when `clipboardData.items` is unavailable.
>     - Ensures pasted images are converted to `File` objects and processed by synthesizing a change event.
>     - Adds error handling for clipboard read operations to prevent crashes and log issues.
>   - **Compatibility**:
>     - Improves image paste support on Linux and newer browsers.
>     - Handles cases where traditional clipboard methods are unsupported.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for b93f77a9f54b4365d8710a4c35a199f9c8a8265a. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->