### PR TITLE
Fix: Token Calculation for remote providers (#6289)

### DIFF
--- a/web-app/src/hooks/__tests__/token-speed-edge-cases.test.ts
+++ b/web-app/src/hooks/__tests__/token-speed-edge-cases.test.ts
@@ -1,0 +1,254 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useAppState } from '../useAppState'
+
+// Mock the useAssistant hook
+vi.mock('../useAssistant', () => ({
+  useAssistant: Object.assign(
+    vi.fn(() => ({
+      selectedAssistant: null,
+      updateAssistantTools: vi.fn()
+    })),
+    {
+      getState: vi.fn(() => ({
+        currentAssistant: { id: 'test-assistant', name: 'Test Assistant' },
+        assistants: [{ id: 'test-assistant', name: 'Test Assistant' }]
+      }))
+    }
+  )
+}))
+
+describe('Token Speed Edge Cases', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    
+    act(() => {
+      useAppState.setState({
+        streamingContent: undefined,
+        loadingModel: false,
+        tools: [],
+        serverStatus: 'stopped',
+        abortControllers: {},
+        tokenSpeed: undefined,
+        currentToolCall: undefined,
+        showOutOfContextDialog: false
+      })
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should handle negative increment gracefully', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, -1)
+    })
+
+    expect(result.current.tokenSpeed?.tokenCount).toBe(-1)
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(0)
+  })
+
+  it('should handle zero increment', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 0)
+    })
+
+    expect(result.current.tokenSpeed?.tokenCount).toBe(0)
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(0)
+  })
+
+  it('should handle very large increments', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 1000000)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+      result.current.updateTokenSpeed(message, 1000000)
+    })
+
+    expect(result.current.tokenSpeed?.tokenCount).toBe(2000000)
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(2000000) // 2M tokens in 1 second
+  })
+
+  it('should handle fractional increments', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 0.5)
+    })
+
+    act(() => {
+      vi.advanceTimersByTime(1000)
+      result.current.updateTokenSpeed(message, 0.5)
+    })
+
+    expect(result.current.tokenSpeed?.tokenCount).toBe(1)
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(1) // 1 token in 1 second
+  })
+
+  it('should handle very fast successive calls', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    // Multiple calls in rapid succession
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+      result.current.updateTokenSpeed(message, 1)
+      result.current.updateTokenSpeed(message, 1)
+      result.current.updateTokenSpeed(message, 1)
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Should accumulate all tokens and use fallback time calculation
+    expect(result.current.tokenSpeed?.tokenCount).toBe(5)
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(5) // 5 tokens / 1 second (fallback)
+  })
+
+  it('should handle empty message ID', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: '',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    expect(result.current.tokenSpeed?.message).toBe('')
+    expect(result.current.tokenSpeed?.tokenCount).toBe(1)
+  })
+
+  it('should handle very long message IDs', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const longId = 'a'.repeat(10000) // 10k character ID
+    const message = {
+      id: longId,
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    expect(result.current.tokenSpeed?.message).toBe(longId)
+  })
+
+  it('should handle multiple resets during streaming', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 5)
+    })
+
+    expect(result.current.tokenSpeed).toBeDefined()
+
+    act(() => {
+      result.current.resetTokenSpeed()
+    })
+
+    expect(result.current.tokenSpeed).toBeUndefined()
+
+    act(() => {
+      result.current.resetTokenSpeed() // Reset again when already undefined
+    })
+
+    expect(result.current.tokenSpeed).toBeUndefined()
+
+    // Should work after reset
+    act(() => {
+      result.current.updateTokenSpeed(message, 3)
+    })
+
+    expect(result.current.tokenSpeed?.tokenCount).toBe(3)
+  })
+
+  it('should maintain precision with small time differences', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Advance by just 1ms
+    act(() => {
+      vi.advanceTimersByTime(1)
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Should calculate: 2 tokens / 0.001 seconds = 2000 tokens/sec
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(2000)
+  })
+})

--- a/web-app/src/hooks/__tests__/token-speed-validation.test.ts
+++ b/web-app/src/hooks/__tests__/token-speed-validation.test.ts
@@ -1,0 +1,220 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest'
+import { act, renderHook } from '@testing-library/react'
+import { useAppState } from '../useAppState'
+
+// Mock the useAssistant hook
+vi.mock('../useAssistant', () => ({
+  useAssistant: Object.assign(
+    vi.fn(() => ({
+      selectedAssistant: null,
+      updateAssistantTools: vi.fn()
+    })),
+    {
+      getState: vi.fn(() => ({
+        currentAssistant: { id: 'test-assistant', name: 'Test Assistant' },
+        assistants: [{ id: 'test-assistant', name: 'Test Assistant' }]
+      }))
+    }
+  )
+}))
+
+describe('Token Speed Calculation Validation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    vi.useFakeTimers()
+    
+    // Reset Zustand store
+    act(() => {
+      useAppState.setState({
+        streamingContent: undefined,
+        loadingModel: false,
+        tools: [],
+        serverStatus: 'stopped',
+        abortControllers: {},
+        tokenSpeed: undefined,
+        currentToolCall: undefined,
+        showOutOfContextDialog: false
+      })
+    })
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('should initialize token speed correctly on first call', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    expect(result.current.tokenSpeed).toEqual({
+      lastTimestamp: expect.any(Number),
+      tokenSpeed: 0,
+      tokenCount: 1,
+      message: 'msg-1'
+    })
+  })
+
+  it('should calculate token speed correctly for subsequent calls', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    // First call
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Advance time by 1 second
+    act(() => {
+      vi.advanceTimersByTime(1000)
+    })
+
+    // Second call - should calculate tokens/second
+    act(() => {
+      result.current.updateTokenSpeed(message, 2)
+    })
+
+    // Should have total 3 tokens over 1 second = 3 tokens/sec
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(3)
+    expect(result.current.tokenSpeed?.tokenCount).toBe(3)
+  })
+
+  it('should handle same message ID consistently', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const messageId = 'consistent-msg-id'
+    const message1 = {
+      id: messageId,
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+    
+    const message2 = {
+      id: messageId,
+      content: 'Hello world',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    // First call
+    act(() => {
+      result.current.updateTokenSpeed(message1, 1)
+    })
+
+    // Advance time
+    act(() => {
+      vi.advanceTimersByTime(500)
+    })
+
+    // Second call with same message ID
+    act(() => {
+      result.current.updateTokenSpeed(message2, 1)
+    })
+
+    // Should accumulate tokens and continue calculation
+    expect(result.current.tokenSpeed?.tokenCount).toBe(2)
+    expect(result.current.tokenSpeed?.message).toBe(messageId)
+  })
+
+  it('should handle zero time difference correctly', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    // First call
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Second call immediately (0ms time difference)
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Should use fallback of 1 second to avoid division by zero
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(2) // 2 tokens / 1 second
+  })
+
+  it('should calculate correct average speed over multiple updates', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    // First call (t=0, count=1)
+    act(() => {
+      result.current.updateTokenSpeed(message, 1)
+    })
+
+    // Second call (t=1s, count=3 total)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+      result.current.updateTokenSpeed(message, 2)
+    })
+
+    // Third call (t=2s, count=5 total)
+    act(() => {
+      vi.advanceTimersByTime(1000)
+      result.current.updateTokenSpeed(message, 2)
+    })
+
+    // Average: 5 tokens / 2 seconds = 2.5 tokens/sec
+    expect(result.current.tokenSpeed?.tokenSpeed).toBe(2.5)
+    expect(result.current.tokenSpeed?.tokenCount).toBe(5)
+  })
+
+  it('should reset token speed correctly', () => {
+    const { result } = renderHook(() => useAppState())
+    
+    const message = {
+      id: 'msg-1',
+      content: 'Hello',
+      role: 'assistant' as const,
+      created_at: Date.now(),
+      thread_id: 'thread-123'
+    }
+
+    act(() => {
+      result.current.updateTokenSpeed(message, 5)
+    })
+
+    expect(result.current.tokenSpeed).toBeDefined()
+
+    act(() => {
+      result.current.resetTokenSpeed()
+    })
+
+    expect(result.current.tokenSpeed).toBeUndefined()
+  })
+})

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { ulid } from 'ulidx'
 import { usePrompt } from './usePrompt'
 import { useModelProvider } from './useModelProvider'
 import { useThreads } from './useThreads'
@@ -296,6 +297,7 @@ export const useChat = () => {
           let accumulatedText = ''
           const currentCall: ChatCompletionMessageToolCall | null = null
           const toolCalls: ChatCompletionMessageToolCall[] = []
+          const streamingMessageId = ulid() // Generate a single ID for this streaming session
           try {
             if (isCompletionResponse(completion)) {
               const message = completion.choices[0]?.message
@@ -344,7 +346,8 @@ export const useChat = () => {
                         ...e,
                         state: 'pending',
                       })),
-                    }
+                    },
+                    streamingMessageId
                   )
                   updateStreamingContent(currentContent)
                   if (pendingDeltaCount > 0) {
@@ -373,7 +376,8 @@ export const useChat = () => {
                       ...e,
                       state: 'pending',
                     })),
-                  }
+                  },
+                  streamingMessageId
                 )
                 updateStreamingContent(currentContent)
                 if (pendingDeltaCount > 0) {

--- a/web-app/src/lib/__tests__/completion-streaming.test.ts
+++ b/web-app/src/lib/__tests__/completion-streaming.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from 'vitest'
+import { newAssistantThreadContent } from '../completion'
+
+describe('Streaming Message ID Consistency', () => {
+  it('should generate unique IDs when no messageId is provided', () => {
+    const content1 = newAssistantThreadContent('thread-1', 'Hello')
+    const content2 = newAssistantThreadContent('thread-1', 'World')
+    
+    expect(content1.id).toBeTruthy()
+    expect(content2.id).toBeTruthy()
+    expect(content1.id).not.toBe(content2.id)
+  })
+
+  it('should use provided messageId when specified', () => {
+    const customId = 'custom-message-id'
+    const content1 = newAssistantThreadContent('thread-1', 'Hello', {}, customId)
+    const content2 = newAssistantThreadContent('thread-1', 'Hello world', {}, customId)
+    
+    expect(content1.id).toBe(customId)
+    expect(content2.id).toBe(customId)
+  })
+
+  it('should maintain message properties correctly with custom ID', () => {
+    const customId = 'streaming-message-123'
+    const threadId = 'thread-456'
+    const content = 'Streaming content'
+    const metadata = { tool_calls: [] }
+    
+    const message = newAssistantThreadContent(threadId, content, metadata, customId)
+    
+    expect(message).toMatchObject({
+      id: customId,
+      thread_id: threadId,
+      content: [
+        {
+          type: 'text',
+          text: {
+            value: content,
+            annotations: []
+          }
+        }
+      ],
+      metadata,
+      role: 'assistant',
+      type: 'text',
+      object: 'thread.message',
+      status: 'ready',
+      created_at: 0,
+      completed_at: 0
+    })
+  })
+
+  it('should work with empty metadata when custom ID is provided', () => {
+    const customId = 'test-id'
+    const message = newAssistantThreadContent('thread-1', 'Test', undefined, customId)
+    
+    expect(message.id).toBe(customId)
+    expect(message.metadata).toEqual({})
+  })
+
+  it('should simulate streaming scenario with consistent ID', () => {
+    const streamingId = 'streaming-session-id'
+    const threadId = 'thread-123'
+    
+    // Simulate multiple streaming updates with same ID
+    const updates = [
+      newAssistantThreadContent(threadId, 'Hello', {}, streamingId),
+      newAssistantThreadContent(threadId, 'Hello world', { tool_calls: [] }, streamingId),
+      newAssistantThreadContent(threadId, 'Hello world!', { tool_calls: [], final: true }, streamingId)
+    ]
+    
+    // All should have the same ID
+    updates.forEach(update => {
+      expect(update.id).toBe(streamingId)
+      expect(update.thread_id).toBe(threadId)
+    })
+    
+    // Content should be different
+    expect(updates[0].content[0].text.value).toBe('Hello')
+    expect(updates[1].content[0].text.value).toBe('Hello world')
+    expect(updates[2].content[0].text.value).toBe('Hello world!')
+  })
+})

--- a/web-app/src/lib/completion.ts
+++ b/web-app/src/lib/completion.ts
@@ -109,7 +109,8 @@ export const newUserThreadContent = (
 export const newAssistantThreadContent = (
   threadId: string,
   content: string,
-  metadata: Record<string, unknown> = {}
+  metadata: Record<string, unknown> = {},
+  messageId?: string
 ): ThreadMessage => ({
   type: 'text',
   role: ChatCompletionRole.Assistant,
@@ -122,7 +123,7 @@ export const newAssistantThreadContent = (
       },
     },
   ],
-  id: ulid(),
+  id: messageId || ulid(),
   object: 'thread.message',
   thread_id: threadId,
   status: MessageStatus.Ready,


### PR DESCRIPTION
## Describe Your Changes

# Issue at hand

Token speed indicator was showing low/wrong token/s for remote providers due to each streaming chunk creating a new message ID, preventing proper token accumulation.


## What was done

- Modified newAssistantThreadContent() to accept optional messageId parameter
- Generate single streaming message ID per session in useChat.ts
- Pass consistent ID to all streaming updates to enable proper token tracking


## Fixes Issues

- Closes #6289

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
