### PR TITLE
make validation message infinite

### DIFF
--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -178,7 +178,7 @@ export function DownloadManagement() {
         description: t('common:toast.modelValidationStarted.description', {
           modelId: event.modelId,
         }),
-        duration: 10000,
+        duration: Infinity,
       })
     },
     [t]
@@ -199,7 +199,7 @@ export function DownloadManagement() {
         description: t('common:toast.modelValidationFailed.description', {
           modelId: event.modelId,
         }),
-        duration: 30000, // Requires manual dismissal for security-critical message
+        duration: 30000,
       })
     },
     [removeDownload, removeLocalDownloadingModel, t]
@@ -244,9 +244,12 @@ export function DownloadManagement() {
       removeLocalDownloadingModel(state.modelId)
       toast.success(t('common:toast.downloadAndVerificationComplete.title'), {
         id: 'download-complete',
-        description: t('common:toast.downloadAndVerificationComplete.description', {
-          item: state.modelId,
-        }),
+        description: t(
+          'common:toast.downloadAndVerificationComplete.description',
+          {
+            item: state.modelId,
+          }
+        ),
       })
     },
     [removeDownload, removeLocalDownloadingModel, t]
@@ -260,7 +263,10 @@ export function DownloadManagement() {
     events.on(DownloadEvent.onFileDownloadStopped, onFileDownloadStopped)
     events.on(DownloadEvent.onModelValidationStarted, onModelValidationStarted)
     events.on(DownloadEvent.onModelValidationFailed, onModelValidationFailed)
-    events.on(DownloadEvent.onFileDownloadAndVerificationSuccess, onFileDownloadAndVerificationSuccess)
+    events.on(
+      DownloadEvent.onFileDownloadAndVerificationSuccess,
+      onFileDownloadAndVerificationSuccess
+    )
 
     // Register app update event listeners
     events.on(AppEvent.onAppUpdateDownloadUpdate, onAppUpdateDownloadUpdate)
@@ -278,7 +284,10 @@ export function DownloadManagement() {
         onModelValidationStarted
       )
       events.off(DownloadEvent.onModelValidationFailed, onModelValidationFailed)
-      events.off(DownloadEvent.onFileDownloadAndVerificationSuccess, onFileDownloadAndVerificationSuccess)
+      events.off(
+        DownloadEvent.onFileDownloadAndVerificationSuccess,
+        onFileDownloadAndVerificationSuccess
+      )
 
       // Unregister app update event listeners
       events.off(AppEvent.onAppUpdateDownloadUpdate, onAppUpdateDownloadUpdate)


### PR DESCRIPTION
## Describe Your Changes
Validation message infinite -> will be dismissed later on by newer message on the same model

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Set validation message duration to infinite in `DownloadManagement.tsx` to persist until a new message for the same model appears.
> 
>   - **Behavior**:
>     - Change `duration` of validation message to `Infinity` in `onModelValidationStarted` in `DownloadManagement.tsx`.
>     - Ensures message persists until a new message for the same model is shown.
>   - **Misc**:
>     - Minor formatting changes in `DownloadManagement.tsx` for better readability.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 2cbb66b39a3c53cf11698f982283cf67e1713892. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->