### PR TITLE
fix: Use 80% total memory for compatibility check

### DIFF
--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1954,22 +1954,26 @@ export default class llamacpp_extension extends AIEngine {
       logger.info(
         `isModelSupported: Total memory requirement: ${totalRequired} for ${path}`
       )
-      let availableMemBytes: number
+      let totalMemBytes: number
       const devices = await this.getDevices()
       if (devices.length > 0) {
-        // Sum free memory across all GPUs
-        availableMemBytes = devices
-          .map((d) => d.free * 1024 * 1024)
+        // Sum total memory across all GPUs
+        totalMemBytes = devices
+          .map((d) => d.mem * 1024 * 1024)
           .reduce((a, b) => a + b, 0)
       } else {
         // CPU fallback
         const sys = await getSystemUsage()
-        availableMemBytes = (sys.total_memory - sys.used_memory) * 1024 * 1024
+        totalMemBytes = sys.total_memory * 1024 * 1024
       }
-      // check model size wrt system memory
-      if (modelSize > availableMemBytes) {
+
+      // Use 80% of total memory as the usable limit
+      const usableMemBytes = totalMemBytes * 0.8
+
+      // check model size wrt 80% of system memory
+      if (modelSize > usableMemBytes) {
         return 'RED'
-      } else if (modelSize + kvCacheSize > availableMemBytes) {
+      } else if (modelSize + kvCacheSize > usableMemBytes) {
         return 'YELLOW'
       } else {
         return 'GREEN'


### PR DESCRIPTION
## Describe Your Changes
Changed the memory calculation to use 80% of total system memory instead of currently available memory. This provides:

- Consistent results: Model support status remains the same regardless of current memory usage
- Safe memory allocation: 80% threshold leaves adequate headroom for the OS and other processes
- Predictable behavior: Users get reliable information about hardware compatibility

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
