### PR TITLE
fix: mise build failing

### DIFF
--- a/mise.toml
+++ b/mise.toml
@@ -80,9 +80,22 @@ run = [
 # BUILD TASKS
 # ============================================================================
 
+[tasks.install-rust-targets]
+description = "Install required Rust targets for MacOS universal builds"
+run = '''
+#!/usr/bin/env bash
+# Check if we're on macOS
+if [[ "$OSTYPE" == "darwin"* ]]; then
+  echo "Detected macOS, installing universal build targets..."
+  rustup target add x86_64-apple-darwin
+  rustup target add aarch64-apple-darwin
+  echo "Rust targets installed successfully!"
+fi
+'''
+
 [tasks.build]
 description = "Build complete application (matches Makefile)"
-depends = ["install-and-build"]
+depends = ["install-rust-targets", "install-and-build"]
 run = [
   "yarn download:bin",
   "yarn build"

--- a/mise.toml
+++ b/mise.toml
@@ -84,7 +84,7 @@ run = [
 description = "Build complete application (matches Makefile)"
 depends = ["install-and-build"]
 run = [
-  "yarn copy:lib",
+  "yarn download:bin",
   "yarn build"
 ]
 

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -136,6 +136,11 @@ async function main() {
           console.log("Error Found:", err);
         }
       })
+      copyFile(path.join(binDir, 'bun'), path.join(binDir, 'bun-universal-apple-darwin'), (err) => {
+          if (err) {
+            console.log("Error Found:", err);
+          }
+        })
     } else if (platform === 'linux') {
       copyFile(path.join(binDir, 'bun'), path.join(binDir, 'bun-x86_64-unknown-linux-gnu'), (err) => {
         if (err) {
@@ -187,6 +192,11 @@ async function main() {
         }
       })
       copyFile(path.join(binDir, 'uv'), path.join(binDir, 'uv-aarch64-apple-darwin'), (err) => {
+        if (err) {
+          console.log("Error Found:", err);
+        }
+      })
+      copyFile(path.join(binDir, 'uv'), path.join(binDir, 'uv-universal-apple-darwin'), (err) => {
         if (err) {
           console.log("Error Found:", err);
         }


### PR DESCRIPTION
## Describe Your Changes
Creating a production build using `mise build` is failing on Mac. The yarn build is failing because of missing downloads.
-

## Fixes Issues

- Closes:
`mise build` fails with the following errors:

1. Usage Error: Couldn't find a script named "copy:lib".
2. Error failed to bundle project: Failed to copy external binaries: resource path `resources/bin/bun-universal-apple-darwin` doesn't exist: resource path `resources/bin/bun-universal-apple-darwin` doesn't exist.
3. Error failed to bundle project: Failed to copy external binaries: resource path `resources/bin/bun-universal-apple-darwin` doesn't exist: resource path `resources/bin/bun-universal-apple-darwin` doesn't exist.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes `mise build` failure on Mac by updating build script and adding Mac-specific binary operations in `download-bin.mjs`.
> 
>   - **Behavior**:
>     - Fixes `mise build` failure on Mac by replacing `yarn copy:lib` with `yarn download:bin` in `mise.toml`.
>     - Adds file copy operations for `bun-universal-apple-darwin` and `uv-universal-apple-darwin` in `download-bin.mjs` for Mac compatibility.
>   - **Scripts**:
>     - Updates `download-bin.mjs` to include copying of `bun` and `uv` binaries for Mac platforms, ensuring the existence of `bun-universal-apple-darwin` and `uv-universal-apple-darwin`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d9e61998356f9eeca77f3cf17e3164f044199172. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->