### PR TITLE
feat: download llamacpp backend fail back to cdn

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -77,7 +77,7 @@ export async function listSupportedBackends(): Promise<
     supportedBackends.push('macos-arm64')
   }
 
-  const { releases } = await _fetchReleasesWithFallback('menloresearch', 'llama.cpp')
+  const { releases } = await _fetchGithubReleases('menloresearch', 'llama.cpp')
   releases.sort((a, b) => b.tag_name.localeCompare(a.tag_name))
   releases.splice(10) // keep only the latest 10 releases
 
@@ -153,7 +153,7 @@ export async function downloadBackend(
   const backendDir = await getBackendDir(backend, version)
   const libDir = await joinPath([llamacppPath, 'lib'])
 
-  const downloadManager = (window as any).core.extensionManager.getByName(
+  const downloadManager = window.core.extensionManager.getByName(
     '@janhq/download-extension'
   )
 
@@ -292,7 +292,7 @@ async function _getSupportedFeatures() {
  * Fetch releases with GitHub-first strategy and fallback to CDN on any error.
  * CDN endpoint is expected to mirror GitHub releases JSON shape.
  */
-async function _fetchReleasesWithFallback(
+async function _fetchGithubReleases(
   owner: string,
   repo: string
 ): Promise<{ releases: any[]; source: 'github' | 'cdn' }> {


### PR DESCRIPTION
This pull request adds a fallback mechanism to the backend download process in `llamacpp-extension`. Now, if downloading from GitHub fails (due to rate limits or outages), the system will automatically retry using a CDN mirror. Additionally, the release fetching logic has been updated to prefer GitHub but gracefully fall back to the CDN if needed. This improves reliability for users in restrictive or unreliable network environments.

**Backend download improvements:**

* Added a `source` parameter to `downloadBackend` and updated download URLs to support both GitHub and CDN sources, allowing downloads to switch between sources as needed. [[1]](diffhunk://#diff-431c7321394a30147c4f045cf97d797d9be04f4ffe3e9266d02b36c9df0624aeL148-R156) [[2]](diffhunk://#diff-431c7321394a30147c4f045cf97d797d9be04f4ffe3e9266d02b36c9df0624aeR165-R173) [[3]](diffhunk://#diff-431c7321394a30147c4f045cf97d797d9be04f4ffe3e9266d02b36c9df0624aeL175-R194)
* Implemented automatic fallback: if a GitHub download fails, the system retries the download from the CDN, improving robustness.
* Updated logging to indicate which source is being used for downloads, aiding in debugging and transparency.

**Release fetching enhancements:**

* Replaced the old `_fetchGithubReleases` with `_fetchReleasesWithFallback`, which first tries GitHub and falls back to the CDN for release metadata, ensuring the latest releases are always accessible. [[1]](diffhunk://#diff-431c7321394a30147c4f045cf97d797d9be04f4ffe3e9266d02b36c9df0624aeL80-R80) [[2]](diffhunk://#diff-431c7321394a30147c4f045cf97d797d9be04f4ffe3e9266d02b36c9df0624aeL273-R316)

## Related issue
- https://github.com/menloresearch/jan/issues/6334
- https://github.com/menloresearch/jan/issues/6342
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds fallback to CDN for backend downloads in `llamacpp-extension` if GitHub fails, enhancing reliability.
> 
>   - **Backend download improvements**:
>     - Added `source` parameter to `downloadBackend` in `backend.ts` to support GitHub and CDN sources.
>     - Implemented automatic fallback to CDN if GitHub download fails.
>     - Updated logging to indicate download source.
>   - **Release fetching enhancements**:
>     - Replaced `_fetchGithubReleases` with `_fetchReleasesWithFallback` in `backend.ts` to try GitHub first, then CDN.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 651f907d883f9cb138e25621de0dfbdcc8d37b87. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->