### PR TITLE
feat: allow see Apikey when server local status running

### DIFF
--- a/web-app/src/containers/ApiKeyInput.tsx
+++ b/web-app/src/containers/ApiKeyInput.tsx
@@ -3,15 +3,18 @@ import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { useState, useEffect, useCallback } from 'react'
 import { Eye, EyeOff } from 'lucide-react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+import { cn } from '@/lib/utils'
 
 interface ApiKeyInputProps {
   showError?: boolean
   onValidationChange?: (isValid: boolean) => void
+  isServerRunning?: boolean
 }
 
 export function ApiKeyInput({
   showError = false,
   onValidationChange,
+  isServerRunning,
 }: ApiKeyInputProps) {
   const { apiKey, setApiKey } = useLocalApiServer()
   const [inputValue, setInputValue] = useState(apiKey.toString())
@@ -19,16 +22,19 @@ export function ApiKeyInput({
   const [error, setError] = useState('')
   const { t } = useTranslation()
 
-  const validateApiKey = useCallback((value: string) => {
-    if (!value || value.trim().length === 0) {
-      setError(t('common:apiKeyRequired'))
-      onValidationChange?.(false)
-      return false
-    }
-    setError('')
-    onValidationChange?.(true)
-    return true
-  }, [onValidationChange, t])
+  const validateApiKey = useCallback(
+    (value: string) => {
+      if (!value || value.trim().length === 0) {
+        setError(t('common:apiKeyRequired'))
+        onValidationChange?.(false)
+        return false
+      }
+      setError('')
+      onValidationChange?.(true)
+      return true
+    },
+    [onValidationChange, t]
+  )
 
   useEffect(() => {
     if (showError) {
@@ -64,11 +70,12 @@ export function ApiKeyInput({
         value={inputValue}
         onChange={handleChange}
         onBlur={handleBlur}
-        className={`w-full text-sm pr-10 ${
-          hasError
-            ? 'border-1 border-destructive focus:border-destructive focus:ring-destructive'
-            : ''
-        }`}
+        className={cn(
+          'w-full text-sm pr-10',
+          hasError &&
+            'border-1 border-destructive focus:border-destructive focus:ring-destructive',
+          isServerRunning && 'opacity-50 pointer-events-none'
+        )}
         placeholder={t('common:enterApiKey')}
       />
       <div className="absolute right-2 top-1/2 transform -translate-y-1/2 flex items-center gap-1">

--- a/web-app/src/containers/ApiPrefixInput.tsx
+++ b/web-app/src/containers/ApiPrefixInput.tsx
@@ -1,8 +1,13 @@
 import { Input } from '@/components/ui/input'
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
+import { cn } from '@/lib/utils'
 import { useState } from 'react'
 
-export function ApiPrefixInput() {
+export function ApiPrefixInput({
+  isServerRunning,
+}: {
+  isServerRunning?: boolean
+}) {
   const { apiPrefix, setApiPrefix } = useLocalApiServer()
   const [inputValue, setInputValue] = useState(apiPrefix)
 
@@ -27,7 +32,10 @@ export function ApiPrefixInput() {
       value={inputValue}
       onChange={handleChange}
       onBlur={handleBlur}
-      className="w-24 h-8 text-sm"
+      className={cn(
+        'w-24 h-8 text-sm',
+        isServerRunning && 'opacity-50 pointer-events-none'
+      )}
       placeholder="/v1"
     />
   )

--- a/web-app/src/containers/PortInput.tsx
+++ b/web-app/src/containers/PortInput.tsx
@@ -1,8 +1,9 @@
 import { Input } from '@/components/ui/input'
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
+import { cn } from '@/lib/utils'
 import { useState } from 'react'
 
-export function PortInput() {
+export function PortInput({ isServerRunning }: { isServerRunning?: boolean }) {
   const { serverPort, setServerPort } = useLocalApiServer()
   const [inputValue, setInputValue] = useState(serverPort.toString())
 
@@ -29,7 +30,10 @@ export function PortInput() {
       value={inputValue}
       onChange={handleChange}
       onBlur={handleBlur}
-      className="w-24 h-8 text-sm"
+      className={cn(
+        'w-24 h-8 text-sm',
+        isServerRunning && 'opacity-50 pointer-events-none'
+      )}
     />
   )
 }

--- a/web-app/src/containers/ServerHostSwitcher.tsx
+++ b/web-app/src/containers/ServerHostSwitcher.tsx
@@ -4,6 +4,7 @@ import {
   DropdownMenuItem,
   DropdownMenuTrigger,
 } from '@/components/ui/dropdown-menu'
+
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { cn } from '@/lib/utils'
 
@@ -12,12 +13,19 @@ const hostOptions = [
   { value: '0.0.0.0', label: '0.0.0.0' },
 ]
 
-export function ServerHostSwitcher() {
+export function ServerHostSwitcher({
+  isServerRunning,
+}: {
+  isServerRunning?: boolean
+}) {
   const { serverHost, setServerHost } = useLocalApiServer()
 
   return (
     <DropdownMenu>
-      <DropdownMenuTrigger asChild>
+      <DropdownMenuTrigger
+        asChild
+        className={cn(isServerRunning && 'opacity-50 pointer-events-none')}
+      >
         <span
           title="Edit Server Host"
           className="flex cursor-pointer items-center gap-1 px-2 py-1 rounded-sm bg-main-view-fg/15 text-sm outline-none text-main-view-fg font-medium"

--- a/web-app/src/containers/TrustedHostsInput.tsx
+++ b/web-app/src/containers/TrustedHostsInput.tsx
@@ -2,8 +2,13 @@ import { Input } from '@/components/ui/input'
 import { useLocalApiServer } from '@/hooks/useLocalApiServer'
 import { useState, useEffect } from 'react'
 import { useTranslation } from '@/i18n/react-i18next-compat'
+import { cn } from '@/lib/utils'
 
-export function TrustedHostsInput() {
+export function TrustedHostsInput({
+  isServerRunning,
+}: {
+  isServerRunning?: boolean
+}) {
   const { trustedHosts, setTrustedHosts } = useLocalApiServer()
   const [inputValue, setInputValue] = useState(trustedHosts.join(', '))
   const { t } = useTranslation()
@@ -38,8 +43,11 @@ export function TrustedHostsInput() {
       value={inputValue}
       onChange={handleChange}
       onBlur={handleBlur}
-      className="w-full h-8 text-sm"
       placeholder={t('common:enterTrustedHosts')}
+      className={cn(
+        'w-24 h-8 text-sm',
+        isServerRunning && 'opacity-50 pointer-events-none'
+      )}
     />
   )
 }

--- a/web-app/src/routes/settings/local-api-server.tsx
+++ b/web-app/src/routes/settings/local-api-server.tsx
@@ -45,7 +45,8 @@ function LocalAPIServer() {
   } = useLocalApiServer()
 
   const { serverStatus, setServerStatus } = useAppState()
-  const { selectedModel, selectedProvider, getProviderByName } = useModelProvider()
+  const { selectedModel, selectedProvider, getProviderByName } =
+    useModelProvider()
   const [showApiKeyError, setShowApiKeyError] = useState(false)
   const [isApiKeyEmpty, setIsApiKeyEmpty] = useState(
     !apiKey || apiKey.toString().trim().length === 0
@@ -293,38 +294,31 @@ function LocalAPIServer() {
               <CardItem
                 title={t('settings:localApiServer.serverHost')}
                 description={t('settings:localApiServer.serverHostDesc')}
-                className={cn(
-                  isServerRunning && 'opacity-50 pointer-events-none'
-                )}
-                actions={<ServerHostSwitcher />}
+                actions={
+                  <ServerHostSwitcher isServerRunning={isServerRunning} />
+                }
               />
               <CardItem
                 title={t('settings:localApiServer.serverPort')}
                 description={t('settings:localApiServer.serverPortDesc')}
-                className={cn(
-                  isServerRunning && 'opacity-50 pointer-events-none'
-                )}
-                actions={<PortInput />}
+                actions={<PortInput isServerRunning={isServerRunning} />}
               />
               <CardItem
                 title={t('settings:localApiServer.apiPrefix')}
                 description={t('settings:localApiServer.apiPrefixDesc')}
-                className={cn(
-                  isServerRunning && 'opacity-50 pointer-events-none'
-                )}
-                actions={<ApiPrefixInput />}
+                actions={<ApiPrefixInput isServerRunning={isServerRunning} />}
               />
               <CardItem
                 title={t('settings:localApiServer.apiKey')}
                 description={t('settings:localApiServer.apiKeyDesc')}
                 className={cn(
                   'flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-y-2',
-                  isServerRunning && 'opacity-50 pointer-events-none',
                   isApiKeyEmpty && showApiKeyError && 'pb-6'
                 )}
                 classNameWrapperAction="w-full sm:w-auto"
                 actions={
                   <ApiKeyInput
+                    isServerRunning={isServerRunning}
                     showError={showApiKeyError}
                     onValidationChange={handleApiKeyValidation}
                   />
@@ -334,11 +328,12 @@ function LocalAPIServer() {
                 title={t('settings:localApiServer.trustedHosts')}
                 description={t('settings:localApiServer.trustedHostsDesc')}
                 className={cn(
-                  'flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-y-2',
-                  isServerRunning && 'opacity-50 pointer-events-none'
+                  'flex-col sm:flex-row items-start sm:items-center sm:justify-between gap-y-2'
                 )}
                 classNameWrapperAction="w-full sm:w-auto"
-                actions={<TrustedHostsInput />}
+                actions={
+                  <TrustedHostsInput isServerRunning={isServerRunning} />
+                }
               />
             </Card>
 


### PR DESCRIPTION
## Describe Your Changes

This pull request refactors several input components in the local API server settings to improve maintainability and user experience. The main change is to consistently disable editing of server configuration fields when the server is running, by passing an `isServerRunning` prop to each input component and using a shared utility (`cn`) to conditionally apply disabled styles. This ensures the UI state matches the server status and prevents accidental changes.

**Input component refactoring for server running state:**

* Updated `ApiKeyInput`, `ApiPrefixInput`, `PortInput`, `ServerHostSwitcher`, and `TrustedHostsInput` components to accept an `isServerRunning` prop, and conditionally apply disabled styles using the `cn` utility. This disables editing and visually indicates locked fields when the server is running. [[1]](diffhunk://#diff-ec47dd809b78cf8ec04e8ad344a1583e97a185f87c1e1cc000ab206a264cf2c6R6-R26) [[2]](diffhunk://#diff-7a8add6e1fb4798b1a809a2be1346dd6ef5ea8375155b04ad4aaaf7ec83cdbe2R3-R10) [[3]](diffhunk://#diff-665b6cc0e107c7e6e3e9c17209406dda2bd17b9d1c2687eb7bdd370c93e127bcR3-R6) [[4]](diffhunk://#diff-b666ba9bc9ec2408669d9cb27fef973a27e7269912c4383a93a8ed50aca66d74L15-R28) [[5]](diffhunk://#diff-d5072ad24108dc07b3a44c0e3b7f2891c851b572cbb2eb08fd18e3d6f8bd5f08R5-R11)
* Changed the parent settings page (`local-api-server.tsx`) to pass the `isServerRunning` prop to all relevant input components, removing redundant disabled logic from the parent and centralizing it in the child components. [[1]](diffhunk://#diff-eab866c9a4a23fc0856b47e90fca11f134be5f97d2b578427dfe72b69fdedf6cL296-R321) [[2]](diffhunk://#diff-eab866c9a4a23fc0856b47e90fca11f134be5f97d2b578427dfe72b69fdedf6cL337-R336)

**Consistent usage of the `cn` utility for conditional class names:**

* Replaced inline template string class names with the `cn` utility for all affected input and switcher components, improving readability and maintainability. [[1]](diffhunk://#diff-ec47dd809b78cf8ec04e8ad344a1583e97a185f87c1e1cc000ab206a264cf2c6L67-R78) [[2]](diffhunk://#diff-7a8add6e1fb4798b1a809a2be1346dd6ef5ea8375155b04ad4aaaf7ec83cdbe2L30-R38) [[3]](diffhunk://#diff-665b6cc0e107c7e6e3e9c17209406dda2bd17b9d1c2687eb7bdd370c93e127bcL32-R36) [[4]](diffhunk://#diff-b666ba9bc9ec2408669d9cb27fef973a27e7269912c4383a93a8ed50aca66d74R7) [[5]](diffhunk://#diff-d5072ad24108dc07b3a44c0e3b7f2891c851b572cbb2eb08fd18e3d6f8bd5f08L41-R50)

**Minor code style improvements:**

* Minor formatting and code style updates for better readability, such as improved callback formatting and import ordering. [[1]](diffhunk://#diff-ec47dd809b78cf8ec04e8ad344a1583e97a185f87c1e1cc000ab206a264cf2c6L31-R37) [[2]](diffhunk://#diff-eab866c9a4a23fc0856b47e90fca11f134be5f97d2b578427dfe72b69fdedf6cL48-R49)

## Fixes Issues


https://github.com/user-attachments/assets/2f1e2353-260d-4303-b23d-282d637ef197



- Closes #6310 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor input components to disable editing when the server is running, using `isServerRunning` prop and `cn` utility for consistent styling.
> 
>   - **Behavior**:
>     - Input components (`ApiKeyInput`, `ApiPrefixInput`, `PortInput`, `ServerHostSwitcher`, `TrustedHostsInput`) now accept `isServerRunning` prop to disable editing when the server is running.
>     - Parent component `local-api-server.tsx` passes `isServerRunning` to inputs, centralizing disabled logic.
>   - **Utilities**:
>     - Replaced inline class names with `cn` utility for conditional styling in input components.
>   - **Misc**:
>     - Minor code style improvements for readability in `local-api-server.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for cb4641e4adaa4694cbb0224927a84a6bad58441b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->