### PR TITLE
ci: enable nightly build for external contributor

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly.yaml
+++ b/.github/workflows/jan-tauri-build-nightly.yaml
@@ -41,7 +41,6 @@ on:
 jobs:
   set-public-provider:
     runs-on: ubuntu-latest
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     outputs:
       public_provider: ${{ steps.set-public-provider.outputs.public_provider }}
       ref: ${{ steps.set-public-provider.outputs.ref }}
@@ -59,6 +58,9 @@ jobs:
             elif [ "${{ github.event_name }}" == "push" ]; then
               echo "::set-output name=public_provider::aws-s3"
               echo "::set-output name=ref::${{ github.ref }}"
+            elif [ "${{ github.event_name }}" == "pull_request" ]; then
+              echo "::set-output name=public_provider::none"
+              echo "::set-output name=ref::${{ github.ref }}"
             elif [ "${{ github.event_name }}" == "pull_request_review" ]; then
               echo "::set-output name=public_provider::none"
               echo "::set-output name=ref::${{ github.ref }}"
@@ -75,7 +77,6 @@ jobs:
   build-macos:
     uses: ./.github/workflows/template-tauri-build-macos.yml
     needs: [get-update-version, set-public-provider]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     secrets: inherit
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
@@ -88,7 +89,6 @@ jobs:
     uses: ./.github/workflows/template-tauri-build-windows-x64.yml
     secrets: inherit
     needs: [get-update-version, set-public-provider]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}
@@ -99,7 +99,6 @@ jobs:
     uses: ./.github/workflows/template-tauri-build-linux-x64.yml
     secrets: inherit
     needs: [get-update-version, set-public-provider]
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
     with:
       ref: ${{ needs.set-public-provider.outputs.ref }}
       public_provider: ${{ needs.set-public-provider.outputs.public_provider }}

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -144,24 +144,38 @@ jobs:
             .github/scripts/rename-workspace.sh ./package.json ${{ inputs.channel }}
             cat ./package.json
           fi
-      - name: Build app
+      - name: Build app (internal)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           make build
-
-          APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
-          yarn tauri signer sign \
-          --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
-          --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
-          "$APP_IMAGE"
 
         env:
           RELEASE_CHANNEL: '${{ inputs.channel }}'
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           POSTHOG_KEY: ${{ secrets.POSTHOG_KEY }}
           POSTHOG_HOST: ${{ secrets.POSTHOG_HOST }}
+          AUTO_UPDATER_DISABLED: ${{ inputs.disable_updater && 'true' || 'false' }}
+
+      - name: Build app (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          make build
+
+        env:
+          RELEASE_CHANNEL: '${{ inputs.channel }}'
+          AUTO_UPDATER_DISABLED: ${{ inputs.disable_updater && 'true' || 'false' }}
+
+      - name: Sign AppImage
+        if: (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
+        run: |
+          APP_IMAGE=./src-tauri/target/release/bundle/appimage/$(ls ./src-tauri/target/release/bundle/appimage/ | grep AppImage | head -1)
+          yarn tauri signer sign \
+          --private-key "$TAURI_SIGNING_PRIVATE_KEY" \
+          --password "$TAURI_SIGNING_PRIVATE_KEY_PASSWORD" \
+          "$APP_IMAGE"
+        env:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
-          AUTO_UPDATER_DISABLED: ${{ inputs.disable_updater && 'true' || 'false' }}
       # Publish app
 
       ## Artifacts, for dev and test
@@ -188,13 +202,29 @@ jobs:
           if [ "${{ inputs.channel }}" != "stable" ]; then
             DEB_FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb
             APPIMAGE_FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage
-            DEB_SIG=$(cat deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig)
-            APPIMAGE_SIG=$(cat appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig)
+            if [ -f "deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig" ]; then
+              DEB_SIG=$(cat deb/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.deb.sig)
+            else
+              DEB_SIG=""
+            fi
+            if [ -f "appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig" ]; then
+              APPIMAGE_SIG=$(cat appimage/Jan-${{ inputs.channel }}_${{ inputs.new_version }}_amd64.AppImage.sig)
+            else
+              APPIMAGE_SIG=""
+            fi
           else
             DEB_FILE_NAME=Jan_${{ inputs.new_version }}_amd64.deb
             APPIMAGE_FILE_NAME=Jan_${{ inputs.new_version }}_amd64.AppImage
-            DEB_SIG=$(cat deb/Jan_${{ inputs.new_version }}_amd64.deb.sig)
-            APPIMAGE_SIG=$(cat appimage/Jan_${{ inputs.new_version }}_amd64.AppImage.sig)
+            if [ -f "deb/Jan_${{ inputs.new_version }}_amd64.deb.sig" ]; then
+              DEB_SIG=$(cat deb/Jan_${{ inputs.new_version }}_amd64.deb.sig)
+            else
+              DEB_SIG=""
+            fi
+            if [ -f "appimage/Jan_${{ inputs.new_version }}_amd64.AppImage.sig" ]; then
+              APPIMAGE_SIG=$(cat appimage/Jan_${{ inputs.new_version }}_amd64.AppImage.sig)
+            else
+              APPIMAGE_SIG=""
+            fi
           fi
 
           echo "DEB_SIG=$DEB_SIG" >> $GITHUB_OUTPUT
@@ -204,7 +234,7 @@ jobs:
 
       ## Upload to s3 for nightly and beta
       - name: upload to aws s3 if public provider is aws
-        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        if: (inputs.public_provider == 'aws-s3' || inputs.channel == 'beta') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           cd ./src-tauri/target/release/bundle
 

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -154,18 +154,21 @@ jobs:
             cat ./package.json
           fi
       - name: Get key for notarize
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: base64 -d <<< "$NOTARIZE_P8_BASE64" > /tmp/notary-key.p8
         shell: bash
         env:
           NOTARIZE_P8_BASE64: ${{ secrets.NOTARIZE_P8_BASE64 }}
 
       - uses: apple-actions/import-codesign-certs@v2
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         continue-on-error: true
         with:
           p12-file-base64: ${{ secrets.CODE_SIGN_P12_BASE64 }}
           p12-password: ${{ secrets.CODE_SIGN_P12_PASSWORD }}
 
-      - name: Build app
+      - name: Build app (internal)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         run: |
           rustup target add x86_64-apple-darwin
           make build
@@ -181,6 +184,14 @@ jobs:
           APPLE_API_KEY_PATH: /tmp/notary-key.p8
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
+
+      - name: Build app (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        run: |
+          rustup target add x86_64-apple-darwin
+          make build
+        env:
+          APP_PATH: '.'
 
       # Publish app
 
@@ -201,12 +212,20 @@ jobs:
             zip -r jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip Jan-${{ inputs.channel }}.app
             FILE_NAME=jan-${{ inputs.channel }}-mac-universal-${{ inputs.new_version }}.zip
             DMG_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_universal.dmg
-            MAC_UNIVERSAL_SIG=$(cat Jan-${{ inputs.channel }}.app.tar.gz.sig)
+            if [ -f "Jan-${{ inputs.channel }}.app.tar.gz.sig" ]; then
+              MAC_UNIVERSAL_SIG=$(cat Jan-${{ inputs.channel }}.app.tar.gz.sig)
+            else
+              MAC_UNIVERSAL_SIG=""
+            fi
             TAR_NAME=Jan-${{ inputs.channel }}.app.tar.gz
           else
             zip -r jan-mac-universal-${{ inputs.new_version }}.zip Jan.app
             FILE_NAME=jan-mac-universal-${{ inputs.new_version }}.zip
-            MAC_UNIVERSAL_SIG=$(cat Jan.app.tar.gz.sig)
+            if [ -f "Jan.app.tar.gz.sig" ]; then
+              MAC_UNIVERSAL_SIG=$(cat Jan.app.tar.gz.sig)
+            else
+              MAC_UNIVERSAL_SIG=""
+            fi
             DMG_NAME=Jan_${{ inputs.new_version }}_universal.dmg
             TAR_NAME=Jan.app.tar.gz
           fi
@@ -219,7 +238,7 @@ jobs:
 
       ## Upload to s3 for nightly and beta
       - name: upload to aws s3 if public provider is aws
-        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        if: (inputs.public_provider == 'aws-s3' || inputs.channel == 'beta') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           cd ./src-tauri/target/universal-apple-darwin/release/bundle
 

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -175,7 +175,8 @@ jobs:
         run: |
           dotnet tool install --global --version 6.0.0 AzureSignTool
 
-      - name: Build app
+      - name: Build app (internal, with signing)
+        if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository
         shell: bash
         run: |
           make build
@@ -195,6 +196,12 @@ jobs:
           TAURI_SIGNING_PRIVATE_KEY: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY }}
           TAURI_SIGNING_PRIVATE_KEY_PASSWORD: ${{ secrets.TAURI_SIGNING_PRIVATE_KEY_PASSWORD }}
 
+      - name: Build app (fork PR)
+        if: github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository
+        shell: bash
+        run: |
+          make build
+
       - name: Upload Artifact
         uses: actions/upload-artifact@v4
         with:
@@ -209,10 +216,18 @@ jobs:
           cd ./src-tauri/target/release/bundle/nsis
           if [ "${{ inputs.channel }}" != "stable" ]; then
             FILE_NAME=Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe
-            WIN_SIG=$(cat Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe.sig)
+            if [ -f "Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe.sig" ]; then
+              WIN_SIG=$(cat Jan-${{ inputs.channel }}_${{ inputs.new_version }}_x64-setup.exe.sig)
+            else
+              WIN_SIG=""
+            fi
           else
             FILE_NAME=Jan_${{ inputs.new_version }}_x64-setup.exe
-            WIN_SIG=$(cat Jan_${{ inputs.new_version }}_x64-setup.exe.sig)
+            if [ -f "Jan_${{ inputs.new_version }}_x64-setup.exe.sig" ]; then
+              WIN_SIG=$(cat Jan_${{ inputs.new_version }}_x64-setup.exe.sig)
+            else
+              WIN_SIG=""
+            fi
           fi
 
           echo "::set-output name=WIN_SIG::$WIN_SIG"
@@ -222,7 +237,7 @@ jobs:
       ## Upload to s3 for nightly and beta
       - name: upload to aws s3 if public provider is aws
         shell: bash
-        if: inputs.public_provider == 'aws-s3' || inputs.channel == 'beta'
+        if: (inputs.public_provider == 'aws-s3' || inputs.channel == 'beta') && (github.event_name != 'pull_request' || github.event.pull_request.head.repo.full_name == github.repository)
         run: |
           cd ./src-tauri/target/release/bundle/nsis
 


### PR DESCRIPTION
This pull request updates the GitHub Actions workflows for building and releasing the app on nightly, macOS, Linux, and Windows. The main goal is to improve security and reliability for builds triggered by pull requests from forked repositories, ensuring secrets are not exposed and builds behave correctly in those scenarios. It also adds robustness to signature handling for release artifacts.

**Workflow logic and security improvements:**

* Updated conditional checks in `.github/workflows/jan-tauri-build-nightly.yaml` to prevent jobs from running with secrets on forked pull requests by removing broad `if` statements and handling the logic within steps instead. [[1]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L44) [[2]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L78) [[3]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L91) [[4]](diffhunk://#diff-c73bb690084a4665cc08b6284b17198fee69a0beb198b4229e0a91fdf5357382L102)
* Added explicit handling for forked pull request builds in all platform build templates (`template-tauri-build-macos.yml`, `template-tauri-build-linux-x64.yml`, `template-tauri-build-windows-x64.yml`), separating internal builds (with secrets) from fork PR builds (without secrets). [[1]](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L147-L164) [[2]](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383R157-R171) [[3]](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L178-R179) [[4]](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8R199-R204)

**Artifact signature robustness:**

* Improved signature extraction for release artifacts by checking if signature files exist before reading them, and setting signature variables to empty strings if missing, across all platforms. [[1]](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03R205-R227) [[2]](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383R215-R228) [[3]](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8R219-R230)

**S3 upload restrictions:**

* Restricted S3 uploads for nightly and beta channels to internal builds only, preventing uploads from forked pull requests. [[1]](diffhunk://#diff-b032eb74f9bb98a93a376d45866902748184f497210e043d7845caa9571cca03L207-R237) [[2]](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L222-R241) [[3]](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L225-R240)

**Public provider output logic:**

* Refined logic for setting the public provider output in the nightly workflow, ensuring forked PRs set it to `none` and do not attempt to publish.

These changes collectively strengthen build security and reliability, especially around handling forked pull requests and artifact signing.