### PR TITLE
fix: jan server api base url for prod

### DIFF
--- a/.github/workflows/jan-server-web-cicd-prod.yml
+++ b/.github/workflows/jan-server-web-cicd-prod.yml
@@ -12,7 +12,7 @@ jobs:
       deployments: write
       pull-requests: write
     env:
-      JAN_API_BASE: "https://api.jan.ai"
+      JAN_API_BASE: "https://api.jan.ai/jan/v1"
       CLOUDFLARE_PROJECT_NAME: "jan-server-web"
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
This pull request makes a small update to the production CI/CD workflow configuration for the Jan Server Web project. The change updates the `JAN_API_BASE` environment variable to use a more specific API endpoint.

* Updated the `JAN_API_BASE` environment variable in `.github/workflows/jan-server-web-cicd-prod.yml` to point to `https://api.jan.ai/jan/v1` instead of the previous base URL.