### PR TITLE
refactor: clean up empty folders

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,7 @@ core/lib/**
 .yarnrc
 *.tsbuildinfo
 test_results.html
+pre-install
 
 # docs
 docs/yarn.lock

--- a/scripts/download-bin.mjs
+++ b/scripts/download-bin.mjs
@@ -231,11 +231,6 @@ async function main() {
   console.log('Downloads completed.')
 }
 
-// Ensure the downloads directory exists
-if (!fs.existsSync('downloads')) {
-  fs.mkdirSync('downloads')
-}
-
 main().catch((err) => {
   console.error('Error:', err)
   process.exit(1)


### PR DESCRIPTION
This pull request includes a small cleanup to the `scripts/download-bin.mjs` script. The change removes redundant code that ensured the existence of the `downloads` directory, likely because this logic is no longer needed or handled elsewhere.
pre-install folder also removed.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove redundant directory creation code in `scripts/download-bin.mjs` and delete empty `.gitkeep` file from `pre-install`.
> 
>   - **Code Removal**:
>     - Remove redundant code in `scripts/download-bin.mjs` that ensured the existence of the `downloads` directory.
>   - **File Deletion**:
>     - Delete empty `.gitkeep` file from `pre-install`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for e2bc0675c87d8bbd9e9359b4d0e356a0a86c3b3b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->