### PR TITLE
chore: makefile rust targets macos

### DIFF
--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -89,7 +89,6 @@ jobs:
 
       - name: Build app
         run: |
-          rustup target add x86_64-apple-darwin
           make build
         env:
           APP_PATH: '.'

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -167,7 +167,6 @@ jobs:
 
       - name: Build app
         run: |
-          rustup target add x86_64-apple-darwin
           make build
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -92,31 +92,6 @@ jobs:
         run: |
           cargo install ctoml
 
-      - name: Create bun and uv universal
-        run: |
-          mkdir -p ./src-tauri/resources/bin/
-          cd ./src-tauri/resources/bin/
-          curl -L -o bun-darwin-x64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-x64.zip
-          curl -L -o bun-darwin-aarch64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-aarch64.zip
-          unzip bun-darwin-x64.zip
-          unzip bun-darwin-aarch64.zip
-          lipo -create -output bun-universal-apple-darwin bun-darwin-x64/bun bun-darwin-aarch64/bun
-          cp -f bun-darwin-aarch64/bun bun-aarch64-apple-darwin 
-          cp -f bun-darwin-x64/bun bun-x86_64-apple-darwin
-          cp -f bun-universal-apple-darwin bun
-
-          curl -L -o uv-x86_64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-x86_64-apple-darwin.tar.gz
-          curl -L -o uv-arm64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-aarch64-apple-darwin.tar.gz
-          tar -xzf uv-x86_64.tar.gz
-          tar -xzf uv-arm64.tar.gz
-          mv uv-x86_64-apple-darwin uv-x86_64
-          mv uv-aarch64-apple-darwin uv-aarch64
-          lipo -create -output uv-universal-apple-darwin uv-x86_64/uv uv-aarch64/uv
-          cp -f uv-x86_64/uv uv-x86_64-apple-darwin
-          cp -f uv-aarch64/uv uv-aarch64-apple-darwin
-          cp -f uv-universal-apple-darwin uv
-          ls -la
-
       - name: Update app version based on latest release tag with build number
         run: |
           echo "Version: ${{ inputs.new_version }}"

--- a/Makefile
+++ b/Makefile
@@ -84,6 +84,7 @@ build-and-publish: install-and-build install-rust-targets
 
 # Build
 build: install-and-build install-rust-targets
+	yarn download:bin
 	yarn download:lib
 	yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -84,7 +84,6 @@ build-and-publish: install-and-build install-rust-targets
 
 # Build
 build: install-and-build install-rust-targets
-	install-rust-targets
 	yarn download:lib
 	yarn build
 

--- a/Makefile
+++ b/Makefile
@@ -30,6 +30,17 @@ endif
 	yarn build:core
 	yarn build:extensions && yarn build:extensions-web
 
+# Install required Rust targets for macOS universal builds
+install-rust-targets:
+ifeq ($(shell uname -s),Darwin)
+	@echo "Detected macOS, installing universal build targets..."
+	rustup target add x86_64-apple-darwin
+	rustup target add aarch64-apple-darwin
+	@echo "Rust targets installed successfully!"
+else
+	@echo "Not macOS; skipping Rust target installation."
+endif
+
 dev: install-and-build
 	yarn download:bin
 	yarn download:lib
@@ -68,11 +79,12 @@ test: lint
 	cargo test --manifest-path src-tauri/utils/Cargo.toml
 
 # Builds and publishes the app
-build-and-publish: install-and-build
+build-and-publish: install-and-build install-rust-targets
 	yarn build
 
 # Build
-build: install-and-build
+build: install-and-build install-rust-targets
+	install-rust-targets
 	yarn download:lib
 	yarn build
 


### PR DESCRIPTION
This pull request refactors the macOS build process for the Tauri app, moving platform-specific Rust target installation from the GitHub workflow files into the `Makefile` for improved maintainability and cross-platform compatibility. It also removes manual steps for creating universal binaries for `bun` and `uv` from the workflow, streamlining the build pipeline.

<img width="2060" height="1620" alt="image" src="https://github.com/user-attachments/assets/cec49f82-a943-4210-9d4f-33e17cc3f344" />

<img width="2038" height="1610" alt="image" src="https://github.com/user-attachments/assets/5f49b5bd-6907-44e0-8e60-7685e69f448f" />


**Build process improvements:**

* Added a new `install-rust-targets` target to the `Makefile` to install both `x86_64-apple-darwin` and `aarch64-apple-darwin` Rust targets on macOS, with conditional logic for non-macOS systems.
* Updated `build` and `build-and-publish` targets in the `Makefile` to depend on `install-rust-targets`, ensuring required Rust targets are always installed before building.

**Workflow simplification:**

* Removed the explicit `rustup target add x86_64-apple-darwin` step from both `.github/workflows/template-tauri-build-macos.yml` and `.github/workflows/template-tauri-build-macos-external.yml`, delegating this responsibility to the `Makefile`. [[1]](diffhunk://#diff-938c70ee45d61b19b8b0e2ed8e81008191c9c4dab6cfcdfc89d3dcefcc014383L170) [[2]](diffhunk://#diff-0e10da65acc43b30a9487e8cd07433c59b8a9f4c568c382529099ceb54f6008cL92)
* Eliminated the complex manual steps for downloading, extracting, and combining `bun` and `uv` universal binaries from the macOS workflow, likely in favor of a more automated or prebuilt approach.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor macOS build process by moving Rust target installation to `Makefile` and simplifying workflows for Tauri app.
> 
>   - **Build Process Improvements:**
>     - Added `install-rust-targets` target in `Makefile` for macOS Rust targets `x86_64-apple-darwin` and `aarch64-apple-darwin`.
>     - Updated `build` and `build-and-publish` targets in `Makefile` to depend on `install-rust-targets`.
>   - **Workflow Simplification:**
>     - Removed `rustup target add x86_64-apple-darwin` from `.github/workflows/template-tauri-build-macos.yml` and `.github/workflows/template-tauri-build-macos-external.yml`.
>     - Eliminated manual steps for `bun` and `uv` universal binaries in `.github/workflows/template-tauri-build-macos.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1db67ea9a2d2638d866cd77eb86c32c2e2d9d234. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->