### PR TITLE
fix: detect allocation failures as out-of-memory errors

### DIFF
--- a/src-tauri/plugins/tauri-plugin-llamacpp/src/error.rs
+++ b/src-tauri/plugins/tauri-plugin-llamacpp/src/error.rs
@@ -48,6 +48,7 @@ impl LlamacppError {
         let lower_stderr = stderr.to_lowercase();
         // TODO: add others
         let is_out_of_memory = lower_stderr.contains("out of memory")
+            || lower_stderr.contains("failed to allocate")
             || lower_stderr.contains("insufficient memory")
             || lower_stderr.contains("erroroutofdevicememory") // vulkan specific
             || lower_stderr.contains("kiogpucommandbuffercallbackerroroutofmemory") // Metal-specific error code


### PR DESCRIPTION
## Describe Your Changes
The Llama.cpp backend can emit the phrase “failed to allocate” when it runs out of memory. Adding this check ensures such messages are correctly classified as out‑of‑memory errors, providing more accurate error handling CPU backends.


## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds detection for "failed to allocate" in `stderr` to classify as `OutOfMemory` error in `LlamacppError::from_stderr`.
> 
>   - **Behavior**:
>     - In `LlamacppError::from_stderr`, added detection for "failed to allocate" in `stderr` to classify as `OutOfMemory` error.
>   - **Error Handling**:
>     - Enhances error classification for memory allocation failures in `tauri-plugin-llamacpp`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 77a92f2fd964a543af629283cec5b4efdcd055db. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->