### PR TITLE
chore: revert back old docs

### DIFF
--- a/docs/src/pages/_meta.json
+++ b/docs/src/pages/_meta.json
@@ -9,13 +9,7 @@
   },
   "docs": {
     "type": "page",
-    "title": "Docs",
-    "display": "hidden"
-  },
-  "Documentation": {
-    "type": "page",
-    "title": "Documentation",
-    "href": "https://docs.jan.ai"
+    "title": "Docs"
   },
   "platforms": {
     "type": "page",


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small change to the documentation navigation metadata by removing the hidden "Docs" and external "Documentation" links, and updating the "Docs" page entry to be visible.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverted documentation navigation by making 'Docs' visible and removing external link in `_meta.json`.
> 
>   - **Documentation Navigation**:
>     - Removed hidden attribute from `"docs"` entry in `_meta.json`.
>     - Deleted external `"Documentation"` link from `_meta.json`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 1ca765476ec6d6ce250d3aa2db93a3ddc83246e4. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->