### PR TITLE
fix: new extension settings aren't populated properly

### DIFF
--- a/core/src/browser/extension.ts
+++ b/core/src/browser/extension.ts
@@ -125,16 +125,17 @@ export abstract class BaseExtension implements ExtensionType {
         settings.forEach((setting) => {
           // Keep setting value
           if (setting.controllerProps && Array.isArray(oldSettings))
-            setting.controllerProps.value = oldSettings.find(
-              (e: any) => e.key === setting.key
-            )?.controllerProps?.value
+            setting.controllerProps.value =
+              oldSettings.find((e: any) => e.key === setting.key)?.controllerProps?.value ??
+              setting.controllerProps.value
           if ('options' in setting.controllerProps)
             setting.controllerProps.options = setting.controllerProps.options?.length
               ? setting.controllerProps.options
               : oldSettings.find((e: any) => e.key === setting.key)?.controllerProps?.options
           if ('recommended' in setting.controllerProps) {
-            const oldRecommended = oldSettings.find((e: any) => e.key === setting.key)?.controllerProps?.recommended
-            if (oldRecommended !== undefined && oldRecommended !== "") {
+            const oldRecommended = oldSettings.find((e: any) => e.key === setting.key)
+              ?.controllerProps?.recommended
+            if (oldRecommended !== undefined && oldRecommended !== '') {
               setting.controllerProps.recommended = oldRecommended
             }
           }


### PR DESCRIPTION
## Describe Your Changes

This PR fixes the issue where new added settings do not have default value populated properly.

Root cause: 
When the same extension has persisted settings, it always retrieves the value from the old settings, even if there's no key for the persisted setting.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes default value population for new extension settings and updates build scripts, UI components, and localization files.
> 
>   - **Behavior**:
>     - Fixes default value population for new extension settings in `BaseExtension` in `extension.ts`.
>     - Updates logic to handle missing keys in persisted settings.
>   - **Build**:
>     - Removes `rustup target add x86_64-apple-darwin` from `template-tauri-build-macos-external.yml` and `template-tauri-build-macos.yml`.
>     - Adds `install-rust-targets` to `Makefile` for macOS universal builds.
>   - **UI**:
>     - Adds keyboard accessibility to buttons in `DeleteMessageDialog.tsx`, `EditMessageDialog.tsx`, `ErrorDialog.tsx`, `LoadModelErrorDialog.tsx`, `MessageMetadataDialog.tsx`, and `ToolApproval.tsx`.
>     - Updates `DropdownModelProvider.tsx` to handle model selection and vision capability checks asynchronously.
>     - Enhances `ThreadContent.tsx` to support editing messages with images.
>   - **Localization**:
>     - Updates translation files for multiple languages to reflect changes in tool approval and server settings.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 20b1d7b99b7081b802b61fbdde750e48af79f093. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->