### PR TITLE
fix: mcp json  validation structure and serverName

### DIFF
--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -291,15 +291,28 @@ export default function AddEditMCPServer({
           return
         }
 
-        // For each server in the JSON, validate serverName and call onSave
-        Object.entries(parsedData).forEach(([serverName, config]) => {
+        // For each server in the JSON, validate serverName and config
+        for (const [serverName, config] of Object.entries(parsedData)) {
           const trimmedServerName = serverName.trim()
           if (!trimmedServerName) {
             setError(t('mcp-servers:editJson.errorServerName'))
             return
           }
-          onSave(trimmedServerName, config as MCPServerConfig)
-        })
+
+          // Validate the config object
+          const serverConfig = config as MCPServerConfig
+
+          // Validate type field if present
+          if (serverConfig.type && !['stdio', 'http', 'sse'].includes(serverConfig.type)) {
+            setError(t('mcp-servers:editJson.errorInvalidType', {
+              serverName: trimmedServerName,
+              type: serverConfig.type
+            }))
+            return
+          }
+
+          onSave(trimmedServerName, serverConfig as MCPServerConfig)
+        }
         onOpenChange(false)
         resetForm()
         setError(null)

--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -285,9 +285,20 @@ export default function AddEditMCPServer({
           setError(t('mcp-servers:editJson.errorFormat'))
           return
         }
-        // For each server in the JSON, call onSave
+        // Check if this looks like a server config object instead of the expected format
+        if (parsedData.command || parsedData.url) {
+          setError(t('mcp-servers:editJson.errorMissingServerNameKey'))
+          return
+        }
+
+        // For each server in the JSON, validate serverName and call onSave
         Object.entries(parsedData).forEach(([serverName, config]) => {
-          onSave(serverName.trim(), config as MCPServerConfig)
+          const trimmedServerName = serverName.trim()
+          if (!trimmedServerName) {
+            setError(t('mcp-servers:editJson.errorServerName'))
+            return
+          }
+          onSave(trimmedServerName, config as MCPServerConfig)
         })
         onOpenChange(false)
         resetForm()

--- a/web-app/src/locales/de-DE/mcp-servers.json
+++ b/web-app/src/locales/de-DE/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "Ungültiges JSON Format",
     "errorServerName": "Servername ist erforderlich und darf nicht leer sein",
     "errorMissingServerNameKey": "JSON muss als {\"serverName\": {config}} strukturiert sein - fehlender Servername-Schlüssel",
+    "errorInvalidType": "Ungültiger Typ '{{type}}' für Server '{{serverName}}'. Typ muss 'stdio', 'http' oder 'sse' sein",
     "save": "Speichern"
   },
   "checkParams": "Bitte überprüfe die Parameter gemäß dem Tutorial.",

--- a/web-app/src/locales/de-DE/mcp-servers.json
+++ b/web-app/src/locales/de-DE/mcp-servers.json
@@ -26,6 +26,8 @@
     "errorParse": "Fehler beim Parsen der initialen Daten",
     "errorPaste": "Ungültiges JSON Format in dem eingefügten Inhalt",
     "errorFormat": "Ungültiges JSON Format",
+    "errorServerName": "Servername ist erforderlich und darf nicht leer sein",
+    "errorMissingServerNameKey": "JSON muss als {\"serverName\": {config}} strukturiert sein - fehlender Servername-Schlüssel",
     "save": "Speichern"
   },
   "checkParams": "Bitte überprüfe die Parameter gemäß dem Tutorial.",

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -26,6 +26,12 @@
     "errorParse": "Failed to parse initial data",
     "errorPaste": "Invalid JSON format in pasted content",
     "errorFormat": "Invalid JSON format",
+    "errorServerName": "Server name is required and cannot be empty",
+    "errorMissingServerNameKey": "JSON must be structured as {\"serverName\": {config}} - missing server name key",
+    "errorServerConfig": "Invalid server configuration for '{{serverName}}'",
+    "errorMissingCommand": "Missing required 'command' field for server '{{serverName}}'",
+    "errorMissingUrl": "Missing required 'url' field for server '{{serverName}}'",
+    "errorInvalidType": "Invalid transport type for server '{{serverName}}'. Must be 'stdio', 'http', or 'sse'",
     "save": "Save"
   },
   "checkParams": "Please check the parameters according to the tutorial.",

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -28,10 +28,6 @@
     "errorFormat": "Invalid JSON format",
     "errorServerName": "Server name is required and cannot be empty",
     "errorMissingServerNameKey": "JSON must be structured as {\"serverName\": {config}} - missing server name key",
-    "errorServerConfig": "Invalid server configuration for '{{serverName}}'",
-    "errorMissingCommand": "Missing required 'command' field for server '{{serverName}}'",
-    "errorMissingUrl": "Missing required 'url' field for server '{{serverName}}'",
-    "errorInvalidType": "Invalid transport type for server '{{serverName}}'. Must be 'stdio', 'http', or 'sse'",
     "save": "Save"
   },
   "checkParams": "Please check the parameters according to the tutorial.",

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "Invalid JSON format",
     "errorServerName": "Server name is required and cannot be empty",
     "errorMissingServerNameKey": "JSON must be structured as {\"serverName\": {config}} - missing server name key",
+    "errorInvalidType": "Invalid type '{{type}}' for server '{{serverName}}'. Type must be 'stdio', 'http', or 'sse'",
     "save": "Save"
   },
   "checkParams": "Please check the parameters according to the tutorial.",

--- a/web-app/src/locales/id/mcp-servers.json
+++ b/web-app/src/locales/id/mcp-servers.json
@@ -26,6 +26,8 @@
     "errorParse": "Gagal mengurai data awal",
     "errorPaste": "Format JSON tidak valid pada konten yang ditempel",
     "errorFormat": "Format JSON tidak valid",
+    "errorServerName": "Nama server wajib diisi dan tidak boleh kosong",
+    "errorMissingServerNameKey": "JSON harus berstruktur sebagai {\"serverName\": {config}} - kunci nama server hilang",
     "save": "Simpan"
   },
   "checkParams": "Silakan periksa parameter sesuai dengan tutorial.",

--- a/web-app/src/locales/id/mcp-servers.json
+++ b/web-app/src/locales/id/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "Format JSON tidak valid",
     "errorServerName": "Nama server wajib diisi dan tidak boleh kosong",
     "errorMissingServerNameKey": "JSON harus berstruktur sebagai {\"serverName\": {config}} - kunci nama server hilang",
+    "errorInvalidType": "Tipe '{{type}}' untuk server '{{serverName}}' tidak valid. Tipe harus 'stdio', 'http', atau 'sse'",
     "save": "Simpan"
   },
   "checkParams": "Silakan periksa parameter sesuai dengan tutorial.",

--- a/web-app/src/locales/pl/mcp-servers.json
+++ b/web-app/src/locales/pl/mcp-servers.json
@@ -26,6 +26,8 @@
     "errorParse": "Błąd parsowania wstępnych danych",
     "errorPaste": "Wprowadzono JSON o niepoprawnym formacie",
     "errorFormat": "Niepoprawny format JSON",
+    "errorServerName": "Nazwa serwera jest wymagana i nie może być pusta",
+    "errorMissingServerNameKey": "JSON musi być w formacie {\"serverName\": {config}} - brakuje klucza nazwy serwera",
     "save": "Zapisz"
   },
   "checkParams": "Proszę sprawdzić parametry we wprowadzeniu.",

--- a/web-app/src/locales/pl/mcp-servers.json
+++ b/web-app/src/locales/pl/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "Niepoprawny format JSON",
     "errorServerName": "Nazwa serwera jest wymagana i nie może być pusta",
     "errorMissingServerNameKey": "JSON musi być w formacie {\"serverName\": {config}} - brakuje klucza nazwy serwera",
+    "errorInvalidType": "Niepoprawny typ '{{type}}' dla serwera '{{serverName}}'. Typ musi być 'stdio', 'http' lub 'sse'",
     "save": "Zapisz"
   },
   "checkParams": "Proszę sprawdzić parametry we wprowadzeniu.",

--- a/web-app/src/locales/vn/mcp-servers.json
+++ b/web-app/src/locales/vn/mcp-servers.json
@@ -26,6 +26,8 @@
     "errorParse": "Không thể phân tích cú pháp dữ liệu ban đầu",
     "errorPaste": "Định dạng JSON không hợp lệ trong nội dung đã dán",
     "errorFormat": "Định dạng JSON không hợp lệ",
+    "errorServerName": "Tên máy chủ là bắt buộc và không được để trống",
+    "errorMissingServerNameKey": "JSON phải có cấu trúc {\"serverName\": {config}} - thiếu khóa tên máy chủ",
     "save": "Lưu"
   },
   "checkParams": "Vui lòng kiểm tra các tham số theo hướng dẫn.",

--- a/web-app/src/locales/vn/mcp-servers.json
+++ b/web-app/src/locales/vn/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "Định dạng JSON không hợp lệ",
     "errorServerName": "Tên máy chủ là bắt buộc và không được để trống",
     "errorMissingServerNameKey": "JSON phải có cấu trúc {\"serverName\": {config}} - thiếu khóa tên máy chủ",
+    "errorInvalidType": "Loại '{{type}}' cho máy chủ '{{serverName}}' không hợp lệ. Loại phải là 'stdio', 'http' hoặc 'sse'",
     "save": "Lưu"
   },
   "checkParams": "Vui lòng kiểm tra các tham số theo hướng dẫn.",

--- a/web-app/src/locales/zh-CN/mcp-servers.json
+++ b/web-app/src/locales/zh-CN/mcp-servers.json
@@ -26,6 +26,12 @@
     "errorParse": "解析初始数据失败",
     "errorPaste": "粘贴内容中的 JSON 格式无效",
     "errorFormat": "JSON 格式无效",
+    "errorServerName": "服务器名称为必填项，不能为空",
+    "errorMissingServerNameKey": "JSON 必须按 {\"serverName\": {config}} 格式结构化 - 缺少服务器名称键",
+    "errorServerConfig": "服务器 '{{serverName}}' 的配置无效",
+    "errorMissingCommand": "服务器 '{{serverName}}' 缺少必需的 'command' 字段",
+    "errorMissingUrl": "服务器 '{{serverName}}' 缺少必需的 'url' 字段",
+    "errorInvalidType": "服务器 '{{serverName}}' 的传输类型无效。必须为 'stdio'、'http' 或 'sse'",
     "save": "保存"
   },
   "checkParams": "请根据教程检查参数。",

--- a/web-app/src/locales/zh-CN/mcp-servers.json
+++ b/web-app/src/locales/zh-CN/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "JSON 格式无效",
     "errorServerName": "服务器名称为必填项，不能为空",
     "errorMissingServerNameKey": "JSON 必须按 {\"serverName\": {config}} 格式结构化 - 缺少服务器名称键",
+    "errorInvalidType": "服务器 '{{serverName}}' 的类型 '{{type}}' 无效。类型必须是 'stdio'、'http' 或 'sse'",
     "save": "保存"
   },
   "checkParams": "请根据教程检查参数。",

--- a/web-app/src/locales/zh-CN/mcp-servers.json
+++ b/web-app/src/locales/zh-CN/mcp-servers.json
@@ -28,10 +28,6 @@
     "errorFormat": "JSON 格式无效",
     "errorServerName": "服务器名称为必填项，不能为空",
     "errorMissingServerNameKey": "JSON 必须按 {\"serverName\": {config}} 格式结构化 - 缺少服务器名称键",
-    "errorServerConfig": "服务器 '{{serverName}}' 的配置无效",
-    "errorMissingCommand": "服务器 '{{serverName}}' 缺少必需的 'command' 字段",
-    "errorMissingUrl": "服务器 '{{serverName}}' 缺少必需的 'url' 字段",
-    "errorInvalidType": "服务器 '{{serverName}}' 的传输类型无效。必须为 'stdio'、'http' 或 'sse'",
     "save": "保存"
   },
   "checkParams": "请根据教程检查参数。",

--- a/web-app/src/locales/zh-TW/mcp-servers.json
+++ b/web-app/src/locales/zh-TW/mcp-servers.json
@@ -26,6 +26,8 @@
     "errorParse": "解析初始資料失敗",
     "errorPaste": "貼上內容的 JSON 格式無效",
     "errorFormat": "JSON 格式無效",
+    "errorServerName": "伺服器名稱為必填項目，不能為空",
+    "errorMissingServerNameKey": "JSON 必須依照 {\"serverName\": {config}} 結構 - 缺少伺服器名稱鍵值",
     "save": "儲存"
   },
   "checkParams": "請根據教學檢查參數。",

--- a/web-app/src/locales/zh-TW/mcp-servers.json
+++ b/web-app/src/locales/zh-TW/mcp-servers.json
@@ -28,6 +28,7 @@
     "errorFormat": "JSON 格式無效",
     "errorServerName": "伺服器名稱為必填項目，不能為空",
     "errorMissingServerNameKey": "JSON 必須依照 {\"serverName\": {config}} 結構 - 缺少伺服器名稱鍵值",
+    "errorInvalidType": "伺服器 '{{serverName}}' 的類型 '{{type}}' 無效。類型必須是 'stdio'、'http' 或 'sse'",
     "save": "儲存"
   },
   "checkParams": "請根據教學檢查參數。",


### PR DESCRIPTION
## Describe Your Changes

This pull request improves the validation and error handling when adding or editing MCP server configurations via JSON input. It adds checks to ensure the JSON structure is correct and provides more descriptive error messages for various validation failures.

**Validation improvements:**

* Added a check to detect if the pasted JSON is a single server config object (missing the server name key) and show an appropriate error message.
* Added validation to ensure each server entry has a non-empty server name before saving, with a specific error message if missing.

**Internationalization updates:**

* Added new error message strings for server name, missing server name key, invalid server config, missing command/url fields, and invalid transport type in both English and Chinese locale files (`mcp-servers.json`). [[1]](diffhunk://#diff-e37970d2e5475a4432b98ae88c58630f732ca5da482862570b70b7604d1cd8c4R29-R34) [[2]](diffhunk://#diff-848c116e18b769c759251c2831f8405f576175004b274d20170c65a5d4a601d4R29-R34)

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Improves JSON validation and error handling for MCP server configurations and updates internationalization files with new error messages.
> 
>   - **Validation Improvements**:
>     - In `AddEditMCPServer.tsx`, added checks for JSON structure to ensure it is not a single server config object without a server name key.
>     - Validates each server entry for non-empty server names and valid transport types ('stdio', 'http', 'sse').
>   - **Internationalization Updates**:
>     - Added new error messages for server name, missing server name key, and invalid transport type in `mcp-servers.json` for English, Chinese, German, Indonesian, Polish, and Vietnamese locales.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a3c2c1aa3b0b15c29c56d86ffd04071c55915d45. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->