### PR TITLE
Add custom retry mechanism for MCP on web

### DIFF
--- a/extensions-web/package.json
+++ b/extensions-web/package.json
@@ -32,6 +32,7 @@
     "zustand": "^5.0.0"
   },
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.17.5"
+    "@modelcontextprotocol/sdk": "^1.17.5",
+    "hash-wasm": "^4.12.0"
   }
 }

--- a/extensions-web/src/mcp-web/const.ts
+++ b/extensions-web/src/mcp-web/const.ts
@@ -1,0 +1,13 @@
+/**
+ * MCP Web Extension Constants
+ */
+
+export const MCP_RETRY_CONFIG = {
+  maxRetries: 1,
+  resetTimeMs: 300000, // 5 minutes
+  enableJitter: true // Enable jitter to prevent thundering herd
+} as const
+
+export const MCP_ENDPOINTS = {
+  mcp: '/mcp'
+} as const

--- a/extensions-web/src/mcp-web/error.ts
+++ b/extensions-web/src/mcp-web/error.ts
@@ -1,0 +1,83 @@
+/**
+ * Error formatting utilities for MCP Tool Calls
+ * Provides functions to format error messages with retry information
+ */
+
+import { MCPToolCallResult } from '@janhq/core'
+import { MCPRetryManager } from './retry-manager'
+
+/**
+ * Format error message with retry information
+ */
+function formatErrorWithRetryInfo(
+  errorMessage: string,
+  callKey: string,
+  retryManager: MCPRetryManager
+): string {
+  const retryInfo = retryManager.getRetryInfo(callKey)
+
+  if (retryInfo.isExhausted) {
+    return errorMessage // Don't add retry info if exhausted
+  }
+
+  const retryMessage = retryInfo.remainingRetries > 0
+    ? ` (${retryInfo.remainingRetries} ${retryInfo.remainingRetries === 1 ? 'retry' : 'retries'} remaining for this arguments)`
+    : ' (no more retries available for this arguments)'
+
+  return `${errorMessage}${retryMessage}`
+}
+
+/**
+ * Get error response for when retries are exhausted
+ */
+export function getExhaustedErrorResponse(
+  toolName: string,
+  callKey: string,
+  retryManager: MCPRetryManager
+): MCPToolCallResult {
+  const retryInfo = retryManager.getRetryInfo(callKey)
+  const attemptsText = retryInfo.attemptsUsed > 0
+    ? `after ${retryInfo.attemptsUsed} failed ${retryInfo.attemptsUsed === 1 ? 'attempt' : 'attempts'}`
+    : ''
+
+  return {
+    error: `Tool "${toolName}" has exceeded maximum retry attempts and is temporarily disabled`,
+    content: [{
+      type: 'text',
+      text: `Tool "${toolName}" has failed ${attemptsText} and will not be retried. This tool may be experiencing server issues. Please try a different approach or wait before using this tool again.`
+    }]
+  }
+}
+
+/**
+ * Create error response with retry info
+ */
+export function createErrorResponse(
+  errorText: string,
+  callKey: string,
+  retryManager: MCPRetryManager
+): MCPToolCallResult {
+  return {
+    error: errorText,
+    content: [{
+      type: 'text',
+      text: formatErrorWithRetryInfo(errorText, callKey, retryManager)
+    }]
+  }
+}
+
+/**
+ * Create a simple error response without retry tracking
+ */
+export function createSimpleErrorResponse(
+  error: string,
+  message?: string
+): MCPToolCallResult {
+  return {
+    error,
+    content: [{
+      type: 'text',
+      text: message || error
+    }]
+  }
+}

--- a/extensions-web/src/mcp-web/retry-manager.ts
+++ b/extensions-web/src/mcp-web/retry-manager.ts
@@ -1,0 +1,192 @@
+/**
+ * Retry Manager for MCP Tool Calls
+ * Manages retry logic with exponential backoff and failure tracking
+ */
+
+import { sha1 } from 'hash-wasm'
+
+export interface RetryConfig {
+  maxRetries: number
+  resetTimeMs: number
+  enableJitter?: boolean // Adds random delay (0-1000ms) to prevent thundering herd when multiple clients retry simultaneously
+}
+
+interface FailureRecord {
+  count: number
+  lastFailure: number
+  firstFailure: number
+}
+
+export class MCPRetryManager {
+  private failureCache: Map<string, FailureRecord> = new Map()
+  private readonly config: Required<RetryConfig>
+
+  constructor(config?: Partial<RetryConfig>) {
+    this.config = {
+      maxRetries: config?.maxRetries ?? 1,
+      resetTimeMs: config?.resetTimeMs ?? 300000, // 5 minutes default
+      enableJitter: config?.enableJitter ?? false
+    }
+  }
+
+  /**
+   * Generate a unique key for a tool call based on name and arguments
+   */
+  async generateCallKey(toolName: string, args: Record<string, unknown>): Promise<string> {
+    // Sort keys for consistent hashing regardless of property order
+    const sortedArgs = this.sortObjectKeys(args)
+    const input = `${toolName}:${JSON.stringify(sortedArgs)}`
+
+    // Create a fast SHA-1 hash using hash-wasm
+    return await sha1(input)
+  }
+
+  /**
+   * Check if a tool call should be retried
+   * If jitter is enabled and retry is allowed, applies a random delay
+   */
+  async shouldRetry(callKey: string): Promise<boolean> {
+    const failure = this.failureCache.get(callKey)
+    if (!failure) {
+      return true // First attempt
+    }
+
+    const now = Date.now()
+
+    // Reset if enough time has passed since first failure
+    if (now - failure.firstFailure > this.config.resetTimeMs) {
+      this.failureCache.delete(callKey)
+      return true
+    }
+
+    const canRetry = failure.count <= this.config.maxRetries
+
+    // Apply jitter if enabled and retry is allowed
+    if (canRetry && this.config.enableJitter && failure.count > 0) {
+      await this.applyJitter(failure.count)
+    }
+
+    return canRetry
+  }
+
+  /**
+   * Apply random jitter delay to prevent thundering herd
+   * Delay increases with attempt number: base 100-500ms for attempt 1, up to 500-1500ms for later attempts
+   */
+  private async applyJitter(attemptNumber: number): Promise<void> {
+    // Base delay increases with attempt number
+    const baseDelay = Math.min(100 * attemptNumber, 500)
+    // Random additional delay up to 1000ms
+    const randomDelay = Math.random() * 1000
+    const totalDelay = baseDelay + randomDelay
+
+    console.log(`Applying jitter delay of ${Math.round(totalDelay)}ms before retry attempt ${attemptNumber}`)
+    return new Promise(resolve => setTimeout(resolve, totalDelay))
+  }
+
+  /**
+   * Record a failure for a tool call
+   */
+  recordFailure(callKey: string): void {
+    const now = Date.now()
+    const failure = this.failureCache.get(callKey)
+
+    if (failure) {
+      failure.count++
+      failure.lastFailure = now
+    } else {
+      this.failureCache.set(callKey, {
+        count: 1,
+        lastFailure: now,
+        firstFailure: now
+      })
+    }
+  }
+
+  /**
+   * Record a successful tool call, clearing any failure history
+   */
+  recordSuccess(callKey: string): void {
+    this.failureCache.delete(callKey)
+  }
+
+  /**
+   * Get retry information for error messages
+   */
+  getRetryInfo(callKey: string): {
+    attemptsUsed: number
+    remainingRetries: number
+    isExhausted: boolean
+  } {
+    const failure = this.failureCache.get(callKey)
+    const attemptsUsed = failure?.count || 0
+    const remainingRetries = Math.max(0, this.config.maxRetries - attemptsUsed + 1)
+
+    return {
+      attemptsUsed,
+      remainingRetries,
+      isExhausted: attemptsUsed > this.config.maxRetries
+    }
+  }
+
+
+  /**
+   * Clear all failure records
+   */
+  clear(): void {
+    this.failureCache.clear()
+  }
+
+  /**
+   * Get statistics about current failures
+   */
+  getStats(): {
+    totalFailures: number
+    exhaustedTools: number
+    activeFailures: Array<{ key: string; count: number; timeUntilReset: number }>
+  } {
+    const now = Date.now()
+    const activeFailures: Array<{ key: string; count: number; timeUntilReset: number }> = []
+    let exhaustedCount = 0
+
+    for (const [key, failure] of this.failureCache.entries()) {
+      const timeUntilReset = Math.max(0, this.config.resetTimeMs - (now - failure.firstFailure))
+
+      if (failure.count > this.config.maxRetries) {
+        exhaustedCount++
+      }
+
+      activeFailures.push({
+        key,
+        count: failure.count,
+        timeUntilReset
+      })
+    }
+
+    return {
+      totalFailures: this.failureCache.size,
+      exhaustedTools: exhaustedCount,
+      activeFailures
+    }
+  }
+
+  /**
+   * Sort object keys recursively for consistent hashing
+   */
+  private sortObjectKeys(obj: any): any {
+    if (obj === null || typeof obj !== 'object') {
+      return obj
+    }
+
+    if (Array.isArray(obj)) {
+      return obj.map(item => this.sortObjectKeys(item))
+    }
+
+    const sortedObj: any = {}
+    Object.keys(obj).sort().forEach(key => {
+      sortedObj[key] = this.sortObjectKeys(obj[key])
+    })
+
+    return sortedObj
+  }
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3465,6 +3465,7 @@ __metadata:
   dependencies:
     "@janhq/core": "workspace:*"
     "@modelcontextprotocol/sdk": "npm:^1.17.5"
+    hash-wasm: "npm:^4.12.0"
     typescript: "npm:^5.3.3"
     vite: "npm:^5.0.0"
     vitest: "npm:^2.0.0"
@@ -12453,6 +12454,13 @@ __metadata:
     inherits: "npm:^2.0.4"
     safe-buffer: "npm:^5.2.1"
   checksum: 10c0/6dc185b79bad9b6d525cd132a588e4215380fdc36fec6f7a8a58c5db8e3b642557d02ad9c367f5e476c7c3ad3ccffa3607f308b124e1ed80e3b80a1b254db61e
+  languageName: node
+  linkType: hard
+
+"hash-wasm@npm:^4.12.0":
+  version: 4.12.0
+  resolution: "hash-wasm@npm:4.12.0"
+  checksum: 10c0/6cb95055319810b6f673de755289960683a9831807690795f0e8918b2fd7e6ae5b82a9dc47cbace171cf2814b412ef68c315a0ead0b4d96bd3e56a05e4bde136
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Describe Your Changes

- Retry the same (arguments + tools = a hash) have limits (setting to 1 retry)
- Will let the tool know retry has reached a end if it fails
- Implement jitter so there would be a random progressive delay to prevent thundering herd

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
