### PR TITLE
chore: embed webview2 bootstrapper in tauri windows

### DIFF
--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -4,7 +4,11 @@
     "resources": ["resources/pre-install/**/*"],
     "externalBin": ["resources/bin/bun", "resources/bin/uv"],
     "windows": {
-      "signCommand": "powershell -ExecutionPolicy Bypass -File ./sign.ps1 %1"
+      "signCommand": "powershell -ExecutionPolicy Bypass -File ./sign.ps1 %1",
+      "webviewInstallMode": {
+        "silent": true,
+        "type": "downloadBootstrapper"
+      }
     }
   }
 }


### PR DESCRIPTION
This pull request updates the Windows configuration for the Tauri application by adding new options for the webview installation process. The most important change is the introduction of a silent install mode for the webview component, which improves the user experience during installation.

Windows installer improvements:

* Added a `webviewInstallMode` configuration to the Windows settings in `tauri.windows.conf.json`, enabling silent installation and specifying the use of a download bootstrapper for the webview component.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds silent install mode for webview in Tauri Windows configuration using `downloadBootstrapper`.
> 
>   - **Windows Installer**:
>     - Adds `webviewInstallMode` to `tauri.windows.conf.json` for silent webview installation.
>     - Uses `downloadBootstrapper` for webview component installation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 022048f5772cdede3531f67c01b19e004cb817f0. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->