### PR TITLE
chore: test webview2 installer

### DIFF
--- a/.github/workflows/jan-tauri-build-nightly-external.yaml
+++ b/.github/workflows/jan-tauri-build-nightly-external.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     branches:
       - dev
+      - release/**
     paths:
       - '.github/workflows/jan-tauri-build-nightly-external.yaml'
       - '.github/workflows/template-tauri-build-*-external.yml'


### PR DESCRIPTION
This is intended to test nightly build for external contributors. I will not add it to the release
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `release/**` branch pattern to trigger nightly builds for external contributors in `jan-tauri-build-nightly-external.yaml`.
> 
>   - **Workflow Trigger**:
>     - Adds `release/**` branch pattern to `jan-tauri-build-nightly-external.yaml` to trigger builds on release branches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 62d7f615cc449af4fddbfb34a185ad8c5107dffc. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->