### PR TITLE
chore: fix redirect

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -683,16 +683,17 @@ docs/guides/fine-tuning/what-models-can-be-fine-tuned/ /docs 302
 /docs/server-installation/aws /docs/desktop 302
 /docs/server-installation/gcp /docs/desktop 302
 /docs/server-installation/azure /docs/desktop 302
-/about 302 /docs
-/api-server 302 /docs/api-server
-/cdn-cgi/l/email-protection 302 
-/docs/built-in/tensorrt-llm 302 
-/docs/desktop/beta 302 /docs
-/docs/docs/data-folder 302 /docs/data-folder
-/docs/docs/desktop/linux 302 /docs/desktop/linux
-/docs/docs/troubleshooting 302 /docs/troubleshooting
-/docs/local-engines/llama-cpp 302 
-/docs/models/model-parameters 302 
-/mcp 302 /docs/mcp
-/quickstart 302 /docs/quickstart
-/server-examples/continue-dev 302 /docs/server-examples/continue-dev
+/about /docs 302
+/api-server /docs/api-server 302
+/cdn-cgi/l/email-protection 302
+/docs/built-in/tensorrt-llm 302
+/docs/desktop/beta /docs 302
+/docs/docs/data-folder /docs/data-folder 302
+/docs/docs/desktop/linux /docs/desktop/linux 302
+/docs/docs/troubleshooting /docs/troubleshooting 302
+/docs/local-engines/llama-cpp 302
+/docs/models/model-parameters 302
+/mcp /docs/mcp 302
+/quickstart /docs/quickstart 302
+/server-examples/continue-dev /docs/server-examples/continue-dev 302
+


### PR DESCRIPTION
This pull request updates the URL redirect rules in the `docs/_redirects` file to standardize the order of redirect target and HTTP status code, ensuring consistency across the documentation site.

Redirect formatting standardization:

* Changed the order of redirect rules so that the redirect target comes before the HTTP status code (e.g., `/about /docs 302` instead of `/about 302 /docs`) for several routes, improving clarity and consistency.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Standardizes redirect rule format in `docs/_redirects` by placing redirect target before HTTP status code for consistency.
> 
>   - **Redirect Formatting**:
>     - Standardizes redirect rule format in `docs/_redirects` by placing redirect target before HTTP status code (e.g., `/about /docs 302` instead of `/about 302 /docs`).
>     - Applied to routes such as `/about`, `/api-server`, and `/quickstart` among others.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 37b2cf4e13c8a51d8fe663c7da24c9b0ce1c561f. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->