### PR TITLE
feat: Prompt progress when streaming

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -54,6 +54,7 @@ export type ToolChoice = 'none' | 'auto' | 'required' | ToolCallSpec
 export interface chatCompletionRequest {
   model: string // Model ID, though for local it might be implicit via sessionInfo
   messages: chatCompletionRequestMessage[]
+  return_progress: boolean
   tools?: Tool[]
   tool_choice?: ToolChoice
   // Core sampling parameters
@@ -119,6 +120,13 @@ export interface chatCompletionChunkChoice {
   finish_reason?: 'stop' | 'length' | 'tool_calls' | 'content_filter' | 'function_call' | null
 }
 
+export interface chatCompletionPromptProgress {
+  cache: number
+  processed: number
+  time_ms: number
+  total: number
+}
+
 export interface chatCompletionChunk {
   id: string
   object: 'chat.completion.chunk'
@@ -126,6 +134,7 @@ export interface chatCompletionChunk {
   model: string
   choices: chatCompletionChunkChoice[]
   system_fingerprint?: string
+  prompt_progress?: chatCompletionPromptProgress
 }
 
 export interface chatCompletionChoice {

--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -54,7 +54,7 @@ export type ToolChoice = 'none' | 'auto' | 'required' | ToolCallSpec
 export interface chatCompletionRequest {
   model: string // Model ID, though for local it might be implicit via sessionInfo
   messages: chatCompletionRequestMessage[]
-  return_progress: boolean
+  return_progress?: boolean
   tools?: Tool[]
   tool_choice?: ToolChoice
   // Core sampling parameters

--- a/extensions/llamacpp-extension/src/index.ts
+++ b/extensions/llamacpp-extension/src/index.ts
@@ -1802,6 +1802,13 @@ export default class llamacpp_extension extends AIEngine {
       'Content-Type': 'application/json',
       'Authorization': `Bearer ${sessionInfo.api_key}`,
     }
+    // always enable prompt progress return if stream is true
+    // Requires llamacpp version > b6399
+    // Example json returned from server
+    // {"choices":[{"finish_reason":null,"index":0,"delta":{"role":"assistant","content":null}}],"created":1758113912,"id":"chatcmpl-UwZwgxQKyJMo7WzMzXlsi90YTUK2BJro","model":"qwen","system_fingerprint":"b1-e4912fc","object":"chat.completion.chunk","prompt_progress":{"total":36,"cache":0,"processed":36,"time_ms":5706760300}}
+    // (chunk.prompt_progress?.processed / chunk.prompt_progress?.total) * 100
+    // chunk.prompt_progress?.cache is for past tokens already in kv cache
+    opts.return_progress = true
 
     const body = JSON.stringify(opts)
     if (opts.stream) {

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -1,27 +1,22 @@
 import { useAppState } from '@/hooks/useAppState'
-import { useEffect, useState } from 'react'
 
 export function PromptProgress() {
   const promptProgress = useAppState((state) => state.promptProgress)
-  const [hideTimeout, setHideTimeout] = useState(false)
 
   const percentage =
     promptProgress && promptProgress.total > 0
       ? Math.round((promptProgress.processed / promptProgress.total) * 100)
       : 0
 
-  useEffect(() => {
-    if (percentage >= 100) {
-      const timer = setTimeout(() => {
-        setHideTimeout(true)
-      }, 500)
-      return () => clearTimeout(timer)
-    } else {
-      setHideTimeout(false)
-    }
-  }, [percentage])
-
-  if (!promptProgress || hideTimeout) return null
+  // Show progress only when promptProgress exists and has valid data, and not completed
+  if (
+    !promptProgress ||
+    !promptProgress.total ||
+    promptProgress.total <= 0 ||
+    percentage >= 100
+  ) {
+    return null
+  }
 
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -1,0 +1,19 @@
+import { useAppState } from '@/hooks/useAppState'
+
+export function PromptProgress() {
+  const promptProgress = useAppState((state) => state.promptProgress)
+
+  if (!promptProgress) return null
+
+  const percentage =
+    promptProgress.total > 0
+      ? Math.round((promptProgress.processed / promptProgress.total) * 100)
+      : 0
+
+  return (
+    <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
+      <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>
+      <span>Reading: {percentage}%</span>
+    </div>
+  )
+}

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -10,7 +10,7 @@ export function PromptProgress() {
       ? Math.round((promptProgress.processed / promptProgress.total) * 100)
       : 0
 
-  if (percentage === 100) return null
+  if (percentage >= 100) return null
 
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -1,16 +1,27 @@
 import { useAppState } from '@/hooks/useAppState'
+import { useEffect, useState } from 'react'
 
 export function PromptProgress() {
   const promptProgress = useAppState((state) => state.promptProgress)
-
-  if (!promptProgress) return null
+  const [hideTimeout, setHideTimeout] = useState(false)
 
   const percentage =
-    promptProgress.total > 0
+    promptProgress && promptProgress.total > 0
       ? Math.round((promptProgress.processed / promptProgress.total) * 100)
       : 0
 
-  if (percentage >= 100) return null
+  useEffect(() => {
+    if (percentage >= 100) {
+      const timer = setTimeout(() => {
+        setHideTimeout(true)
+      }, 500)
+      return () => clearTimeout(timer)
+    } else {
+      setHideTimeout(false)
+    }
+  }, [percentage])
+
+  if (!promptProgress || hideTimeout) return null
 
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">

--- a/web-app/src/components/PromptProgress.tsx
+++ b/web-app/src/components/PromptProgress.tsx
@@ -10,6 +10,8 @@ export function PromptProgress() {
       ? Math.round((promptProgress.processed / promptProgress.total) * 100)
       : 0
 
+  if (percentage === 100) return null
+
   return (
     <div className="flex items-center gap-2 text-sm text-muted-foreground mb-2">
       <div className="animate-spin rounded-full h-4 w-4 border-b-2 border-primary"></div>

--- a/web-app/src/components/__tests__/PromptProgress.test.tsx
+++ b/web-app/src/components/__tests__/PromptProgress.test.tsx
@@ -63,8 +63,9 @@ describe('PromptProgress', () => {
 
     mockUseAppState.mockReturnValue(mockProgress)
 
-    render(<PromptProgress />)
+    const { container } = render(<PromptProgress />)
 
-    expect(screen.getByText('Reading: 0%')).toBeInTheDocument()
+    // Component should not render when total is 0
+    expect(container.firstChild).toBeNull()
   })
 })

--- a/web-app/src/components/__tests__/PromptProgress.test.tsx
+++ b/web-app/src/components/__tests__/PromptProgress.test.tsx
@@ -1,0 +1,70 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen } from '@testing-library/react'
+import { PromptProgress } from '../PromptProgress'
+import { useAppState } from '@/hooks/useAppState'
+
+// Mock the useAppState hook
+vi.mock('@/hooks/useAppState', () => ({
+  useAppState: vi.fn(),
+}))
+
+const mockUseAppState = useAppState as ReturnType<typeof vi.fn>
+
+describe('PromptProgress', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('should not render when promptProgress is undefined', () => {
+    mockUseAppState.mockReturnValue(undefined)
+
+    const { container } = render(<PromptProgress />)
+    expect(container.firstChild).toBeNull()
+  })
+
+  it('should render progress when promptProgress is available', () => {
+    const mockProgress = {
+      cache: 0,
+      processed: 50,
+      time_ms: 1000,
+      total: 100,
+    }
+
+    mockUseAppState.mockReturnValue(mockProgress)
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Reading: 50%')).toBeInTheDocument()
+    expect(document.querySelector('.animate-spin')).toBeInTheDocument()
+  })
+
+  it('should calculate percentage correctly', () => {
+    const mockProgress = {
+      cache: 0,
+      processed: 75,
+      time_ms: 1500,
+      total: 150,
+    }
+
+    mockUseAppState.mockReturnValue(mockProgress)
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Reading: 50%')).toBeInTheDocument()
+  })
+
+  it('should handle zero total gracefully', () => {
+    const mockProgress = {
+      cache: 0,
+      processed: 0,
+      time_ms: 0,
+      total: 0,
+    }
+
+    mockUseAppState.mockReturnValue(mockProgress)
+
+    render(<PromptProgress />)
+
+    expect(screen.getByText('Reading: 0%')).toBeInTheDocument()
+  })
+})

--- a/web-app/src/containers/StreamingContent.tsx
+++ b/web-app/src/containers/StreamingContent.tsx
@@ -2,7 +2,6 @@ import { useAppState } from '@/hooks/useAppState'
 import { ThreadContent } from './ThreadContent'
 import { memo, useMemo } from 'react'
 import { useMessages } from '@/hooks/useMessages'
-import { PromptProgress } from '@/components/PromptProgress'
 
 type Props = {
   threadId: string
@@ -58,26 +57,23 @@ export const StreamingContent = memo(({ threadId }: Props) => {
   // Pass a new object to ThreadContent to avoid reference issues
   // The streaming content is always the last message
   return (
-    <>
-      <PromptProgress />
-      <ThreadContent
-        streamTools={{
-          tool_calls: {
-            function: {
-              name: streamingTools?.[0]?.function?.name as string,
-              arguments: streamingTools?.[0]?.function?.arguments as string,
-            },
+    <ThreadContent
+      streamTools={{
+        tool_calls: {
+          function: {
+            name: streamingTools?.[0]?.function?.name as string,
+            arguments: streamingTools?.[0]?.function?.arguments as string,
           },
-        }}
-        {...streamingContent}
-        isLastMessage={true}
-        streamingThread={streamingContent.thread_id}
-        showAssistant={
-          messages.length > 0
-            ? messages[messages.length - 1].role !== 'assistant'
-            : true
-        }
-      />
-    </>
+        },
+      }}
+      {...streamingContent}
+      isLastMessage={true}
+      streamingThread={streamingContent.thread_id}
+      showAssistant={
+        messages.length > 0
+          ? messages[messages.length - 1].role !== 'assistant'
+          : true
+      }
+    />
   )
 })

--- a/web-app/src/containers/StreamingContent.tsx
+++ b/web-app/src/containers/StreamingContent.tsx
@@ -2,6 +2,7 @@ import { useAppState } from '@/hooks/useAppState'
 import { ThreadContent } from './ThreadContent'
 import { memo, useMemo } from 'react'
 import { useMessages } from '@/hooks/useMessages'
+import { PromptProgress } from '@/components/PromptProgress'
 
 type Props = {
   threadId: string
@@ -57,23 +58,26 @@ export const StreamingContent = memo(({ threadId }: Props) => {
   // Pass a new object to ThreadContent to avoid reference issues
   // The streaming content is always the last message
   return (
-    <ThreadContent
-      streamTools={{
-        tool_calls: {
-          function: {
-            name: streamingTools?.[0]?.function?.name as string,
-            arguments: streamingTools?.[0]?.function?.arguments as string,
+    <>
+      <PromptProgress />
+      <ThreadContent
+        streamTools={{
+          tool_calls: {
+            function: {
+              name: streamingTools?.[0]?.function?.name as string,
+              arguments: streamingTools?.[0]?.function?.arguments as string,
+            },
           },
-        },
-      }}
-      {...streamingContent}
-      isLastMessage={true}
-      streamingThread={streamingContent.thread_id}
-      showAssistant={
-        messages.length > 0
-          ? messages[messages.length - 1].role !== 'assistant'
-          : true
-      }
-    />
+        }}
+        {...streamingContent}
+        isLastMessage={true}
+        streamingThread={streamingContent.thread_id}
+        showAssistant={
+          messages.length > 0
+            ? messages[messages.length - 1].role !== 'assistant'
+            : true
+        }
+      />
+    </>
   )
 })

--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -26,6 +26,7 @@ import TokenSpeedIndicator from '@/containers/TokenSpeedIndicator'
 
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useModelProvider } from '@/hooks/useModelProvider'
+import { PromptProgress } from '@/components/PromptProgress'
 
 const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false)
@@ -72,7 +73,11 @@ export const ThreadContent = memo(
 
       streamTools?: any
       contextOverflowModal?: React.ReactNode | null
-      updateMessage?: (item: ThreadMessage, message: string, imageUrls?: string[]) => void
+      updateMessage?: (
+        item: ThreadMessage,
+        message: string,
+        imageUrls?: string[]
+      ) => void
     }
   ) => {
     const { t } = useTranslation()
@@ -281,7 +286,12 @@ export const ThreadContent = memo(
                   item.content?.find((c) => c.type === 'text')?.text?.value ||
                   ''
                 }
-                imageUrls={item.content?.filter((c) => c.type === 'image_url' && c.image_url?.url).map((c) => c.image_url!.url).filter((url): url is string => url !== undefined) || []}
+                imageUrls={
+                  item.content
+                    ?.filter((c) => c.type === 'image_url' && c.image_url?.url)
+                    .map((c) => c.image_url!.url)
+                    .filter((url): url is string => url !== undefined) || []
+                }
                 onSave={(message, imageUrls) => {
                   if (item.updateMessage) {
                     item.updateMessage(item, message, imageUrls)
@@ -320,6 +330,8 @@ export const ThreadContent = memo(
                 </div>
               </div>
             )}
+
+            <PromptProgress />
 
             {reasoningSegment && (
               <ThinkingBlock
@@ -397,7 +409,9 @@ export const ThreadContent = memo(
                   </div>
 
                   <TokenSpeedIndicator
-                    streaming={Boolean(item.isLastMessage && isStreamingThisThread)}
+                    streaming={Boolean(
+                      item.isLastMessage && isStreamingThisThread
+                    )}
                     metadata={item.metadata}
                   />
                 </div>

--- a/web-app/src/containers/ThreadContent.tsx
+++ b/web-app/src/containers/ThreadContent.tsx
@@ -26,7 +26,6 @@ import TokenSpeedIndicator from '@/containers/TokenSpeedIndicator'
 
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { useModelProvider } from '@/hooks/useModelProvider'
-import { PromptProgress } from '@/components/PromptProgress'
 
 const CopyButton = ({ text }: { text: string }) => {
   const [copied, setCopied] = useState(false)
@@ -330,8 +329,6 @@ export const ThreadContent = memo(
                 </div>
               </div>
             )}
-
-            <PromptProgress />
 
             {reasoningSegment && (
               <ThinkingBlock

--- a/web-app/src/hooks/__tests__/useChat.instructions.test.ts
+++ b/web-app/src/hooks/__tests__/useChat.instructions.test.ts
@@ -35,6 +35,7 @@ vi.mock('../../hooks/useAppState', () => ({
         resetTokenSpeed: vi.fn(),
         updateTools: vi.fn(),
         updateStreamingContent: vi.fn(),
+        updatePromptProgress: vi.fn(),
         updateLoadingModel: vi.fn(),
         setAbortController: vi.fn(),
       }
@@ -106,7 +107,11 @@ vi.mock('../../hooks/useMessages', () => ({
 
 vi.mock('../../hooks/useToolApproval', () => ({
   useToolApproval: (selector: any) => {
-    const state = { approvedTools: [], showApprovalModal: vi.fn(), allowAllMCPPermissions: false }
+    const state = {
+      approvedTools: [],
+      showApprovalModal: vi.fn(),
+      allowAllMCPPermissions: false,
+    }
     return selector ? selector(state) : state
   },
 }))
@@ -132,14 +137,24 @@ vi.mock('@tanstack/react-router', () => ({
 vi.mock('@/lib/completion', () => ({
   emptyThreadContent: { thread_id: 'test-thread', content: '' },
   extractToolCall: vi.fn(),
-  newUserThreadContent: vi.fn(() => ({ thread_id: 'test-thread', content: 'user message' })),
-  newAssistantThreadContent: vi.fn(() => ({ thread_id: 'test-thread', content: 'assistant message' })),
-  sendCompletion: vi.fn(() => Promise.resolve({ choices: [{ message: { content: '' } }] })),
+  newUserThreadContent: vi.fn(() => ({
+    thread_id: 'test-thread',
+    content: 'user message',
+  })),
+  newAssistantThreadContent: vi.fn(() => ({
+    thread_id: 'test-thread',
+    content: 'assistant message',
+  })),
+  sendCompletion: vi.fn(() =>
+    Promise.resolve({ choices: [{ message: { content: '' } }] })
+  ),
   postMessageProcessing: vi.fn(),
   isCompletionResponse: vi.fn(() => true),
 }))
 
-vi.mock('@/services/mcp', () => ({ getTools: vi.fn(() => Promise.resolve([])) }))
+vi.mock('@/services/mcp', () => ({
+  getTools: vi.fn(() => Promise.resolve([])),
+}))
 
 vi.mock('@/services/models', () => ({
   startModel: vi.fn(() => Promise.resolve()),
@@ -147,9 +162,13 @@ vi.mock('@/services/models', () => ({
   stopAllModels: vi.fn(() => Promise.resolve()),
 }))
 
-vi.mock('@/services/providers', () => ({ updateSettings: vi.fn(() => Promise.resolve()) }))
+vi.mock('@/services/providers', () => ({
+  updateSettings: vi.fn(() => Promise.resolve()),
+}))
 
-vi.mock('@tauri-apps/api/event', () => ({ listen: vi.fn(() => Promise.resolve(vi.fn())) }))
+vi.mock('@tauri-apps/api/event', () => ({
+  listen: vi.fn(() => Promise.resolve(vi.fn())),
+}))
 
 vi.mock('@/hooks/useServiceHub', () => ({
   useServiceHub: () => ({

--- a/web-app/src/hooks/__tests__/useChat.test.ts
+++ b/web-app/src/hooks/__tests__/useChat.test.ts
@@ -25,6 +25,7 @@ vi.mock('../useAppState', () => ({
         resetTokenSpeed: vi.fn(),
         updateTools: vi.fn(),
         updateStreamingContent: vi.fn(),
+        updatePromptProgress: vi.fn(),
         updateLoadingModel: vi.fn(),
         setAbortController: vi.fn(),
       }

--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -4,6 +4,13 @@ import { MCPTool } from '@/types/completion'
 import { useAssistant } from './useAssistant'
 import { ChatCompletionMessageToolCall } from 'openai/resources'
 
+type PromptProgress = {
+  cache: number
+  processed: number
+  time_ms: number
+  total: number
+}
+
 type AppErrorMessage = {
   message?: string
   title?: string
@@ -20,6 +27,7 @@ type AppState = {
   currentToolCall?: ChatCompletionMessageToolCall
   showOutOfContextDialog?: boolean
   errorMessage?: AppErrorMessage
+  promptProgress?: PromptProgress
   cancelToolCall?: () => void
   setServerStatus: (value: 'running' | 'stopped' | 'pending') => void
   updateStreamingContent: (content: ThreadMessage | undefined) => void
@@ -34,6 +42,7 @@ type AppState = {
   setOutOfContextDialog: (show: boolean) => void
   setCancelToolCall: (cancel: (() => void) | undefined) => void
   setErrorMessage: (error: AppErrorMessage | undefined) => void
+  updatePromptProgress: (progress: PromptProgress | undefined) => void
 }
 
 export const useAppState = create<AppState>()((set) => ({
@@ -44,6 +53,7 @@ export const useAppState = create<AppState>()((set) => ({
   abortControllers: {},
   tokenSpeed: undefined,
   currentToolCall: undefined,
+  promptProgress: undefined,
   cancelToolCall: undefined,
   updateStreamingContent: (content: ThreadMessage | undefined) => {
     const assistants = useAssistant.getState().assistants
@@ -131,6 +141,11 @@ export const useAppState = create<AppState>()((set) => ({
   setErrorMessage: (error) => {
     set(() => ({
       errorMessage: error,
+    }))
+  },
+  updatePromptProgress: (progress) => {
+    set(() => ({
+      promptProgress: progress,
     }))
   },
 }))

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -49,6 +49,9 @@ export const useChat = () => {
       state.setAbortController,
     ])
   )
+  const updatePromptProgress = useAppState(
+    (state) => state.updatePromptProgress
+  )
 
   const updateProvider = useModelProvider((state) => state.updateProvider)
   const serviceHub = useServiceHub()
@@ -229,6 +232,7 @@ export const useChat = () => {
       const abortController = new AbortController()
       setAbortController(activeThread.id, abortController)
       updateStreamingContent(emptyThreadContent)
+      updatePromptProgress(undefined)
       // Do not add new message on retry
       if (troubleshooting)
         addMessage(newUserThreadContent(activeThread.id, message, attachments))
@@ -397,6 +401,13 @@ export const useChat = () => {
                     break
                   }
 
+                  console.log(part)
+
+                  // Handle prompt progress if available
+                  if ('prompt_progress' in part && part.prompt_progress) {
+                    updatePromptProgress(part.prompt_progress)
+                  }
+
                   // Error message
                   if (!part.choices) {
                     throw new Error(
@@ -513,6 +524,7 @@ export const useChat = () => {
           )
           addMessage(updatedMessage ?? finalContent)
           updateStreamingContent(emptyThreadContent)
+          updatePromptProgress(undefined)
           updateThreadTimestamp(activeThread.id)
 
           isCompleted = !toolCalls.length
@@ -534,6 +546,7 @@ export const useChat = () => {
       } finally {
         updateLoadingModel(false)
         updateStreamingContent(undefined)
+        updatePromptProgress(undefined)
       }
     },
     [
@@ -543,6 +556,7 @@ export const useChat = () => {
       getMessages,
       setAbortController,
       updateStreamingContent,
+      updatePromptProgress,
       addMessage,
       updateThreadTimestamp,
       updateLoadingModel,

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -1,4 +1,5 @@
 import { useCallback, useMemo } from 'react'
+import { flushSync } from 'react-dom'
 import { usePrompt } from './usePrompt'
 import { useModelProvider } from './useModelProvider'
 import { useThreads } from './useThreads'
@@ -403,7 +404,12 @@ export const useChat = () => {
 
                   // Handle prompt progress if available
                   if ('prompt_progress' in part && part.prompt_progress) {
-                    updatePromptProgress(part.prompt_progress)
+                    // Force immediate state update to ensure we see intermediate values
+                    flushSync(() => {
+                      updatePromptProgress(part.prompt_progress)
+                    })
+                    // Add a small delay to make progress visible
+                    await new Promise((resolve) => setTimeout(resolve, 100))
                   }
 
                   // Error message

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -401,8 +401,6 @@ export const useChat = () => {
                     break
                   }
 
-                  console.log(part)
-
                   // Handle prompt progress if available
                   if ('prompt_progress' in part && part.prompt_progress) {
                     updatePromptProgress(part.prompt_progress)

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -20,6 +20,7 @@ import { useSmallScreen } from '@/hooks/useMediaQuery'
 import { PlatformFeatures } from '@/lib/platform/const'
 import { PlatformFeature } from '@/lib/platform/types'
 import ScrollToBottom from '@/containers/ScrollToBottom'
+import { PromptProgress } from '@/components/PromptProgress'
 
 // as route.threadsDetail
 export const Route = createFileRoute('/threads/$threadId')({
@@ -170,6 +171,7 @@ function ThreadDetail() {
                   </div>
                 )
               })}
+            <PromptProgress />
             <StreamingContent
               threadId={threadId}
               data-test-id="thread-content-text"


### PR DESCRIPTION
## Describe Your Changes

- BE changes:
    - Add a `return_progress` flag to `chatCompletionRequest` and a corresponding `prompt_progress` payload in `chatCompletionChunk`. Introduce `chatCompletionPromptProgress` interface to capture cache, processed, time, and total token counts.
    - Update the Llamacpp extension to always request progress data when streaming, enabling UI components to display real‑time generation progress and leverage llama.cpp’s built‑in progress reporting.


## TODO in FE
 - Design prompt progress UI to display realtime prompt progress. The progress reported is dependent on ubatch size value, i.e a lower ubatch size will report more prompt progress but the time to process the prompt will be slow.

Requires llamacpp > b6399

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add prompt progress tracking and display during streaming in chat application with backend and frontend updates.
> 
>   - **Backend Changes**:
>     - Add `return_progress` flag to `chatCompletionRequest` and `prompt_progress` payload to `chatCompletionChunk` in `AIEngine.ts`.
>     - Update `llamacpp_extension` to always request progress data when streaming.
>   - **Frontend Changes**:
>     - Add `PromptProgress` component in `PromptProgress.tsx` to display real-time prompt progress.
>     - Integrate `PromptProgress` component into `ThreadContent.tsx` and `$threadId.tsx`.
>     - Update `useChat.ts` to handle `prompt_progress` updates and manage state with `useAppState.ts`.
>   - **Testing**:
>     - Add tests for `PromptProgress` component in `PromptProgress.test.tsx`.
>     - Update `useChat` tests in `useChat.test.ts` and `useChat.instructions.test.ts` to mock `updatePromptProgress`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for facd2cc83345e1f7b719b58bf71c5f268235bed7. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->