### PR TITLE
enhancement: toaster delete mcp server

### DIFF
--- a/web-app/src/locales/de-DE/mcp-servers.json
+++ b/web-app/src/locales/de-DE/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "MCP Server löschen",
     "description": "Bist Du sicher, dass Du den MCP Server {{serverName}} löschen möchtest? Diese Aktion kann nicht rückgängig gemacht werden.",
-    "delete": ""
+    "delete": "Löschen",
+    "success": "MCP Server {{serverName}} erfolgreich gelöscht"
   },
   "editJson": {
     "title": "JSON für den MCP Server bearbeiten: {{serverName}}",

--- a/web-app/src/locales/en/mcp-servers.json
+++ b/web-app/src/locales/en/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "Delete MCP Server",
     "description": "Are you sure you want to delete the MCP server {{serverName}}? This action cannot be undone.",
-    "delete": "Delete"
+    "delete": "Delete",
+    "success": "MCP server {{serverName}} deleted successfully"
   },
   "editJson": {
     "title": "Edit JSON for MCP Server: {{serverName}}",

--- a/web-app/src/locales/id/mcp-servers.json
+++ b/web-app/src/locales/id/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "Hapus Server MCP",
     "description": "Apakah Anda yakin ingin menghapus server MCP {{serverName}}? Tindakan ini tidak dapat dibatalkan.",
-    "delete": "Hapus"
+    "delete": "Hapus",
+    "success": "Server MCP {{serverName}} berhasil dihapus"
   },
   "editJson": {
     "title": "Edit JSON untuk Server MCP: {{serverName}}",

--- a/web-app/src/locales/pl/mcp-servers.json
+++ b/web-app/src/locales/pl/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "Usuń Serwer MCP",
     "description": "Na pewno chcesz usunąć serwer MCP {{serverName}}? Tej operacji nie można cofnąć.",
-    "delete": "Usuń"
+    "delete": "Usuń",
+    "success": "Serwer MCP {{serverName}} został pomyślnie usunięty"
   },
   "editJson": {
     "title": "Edytuj JSON Serwera MCP: {{serverName}}",

--- a/web-app/src/locales/vn/mcp-servers.json
+++ b/web-app/src/locales/vn/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "Xóa máy chủ MCP",
     "description": "Bạn có chắc chắn muốn xóa máy chủ MCP {{serverName}} không? Hành động này không thể hoàn tác.",
-    "delete": "Xóa"
+    "delete": "Xóa",
+    "success": "Máy chủ MCP {{serverName}} đã được xóa thành công"
   },
   "editJson": {
     "title": "Chỉnh sửa JSON cho máy chủ MCP: {{serverName}}",

--- a/web-app/src/locales/zh-CN/mcp-servers.json
+++ b/web-app/src/locales/zh-CN/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "删除 MCP 服务器",
     "description": "您确定要删除 MCP 服务器 {{serverName}} 吗？此操作无法撤销。",
-    "delete": "删除"
+    "delete": "删除",
+    "success": "MCP 服务器 {{serverName}} 删除成功"
   },
   "editJson": {
     "title": "编辑 MCP 服务器的 JSON：{{serverName}}",

--- a/web-app/src/locales/zh-TW/mcp-servers.json
+++ b/web-app/src/locales/zh-TW/mcp-servers.json
@@ -17,7 +17,8 @@
   "deleteServer": {
     "title": "刪除 MCP 伺服器",
     "description": "您確定要刪除 MCP 伺服器 {{serverName}} 嗎？此操作無法復原。",
-    "delete": "刪除"
+    "delete": "刪除",
+    "success": "MCP 伺服器 {{serverName}} 刪除成功"
   },
   "editJson": {
     "title": "編輯 MCP 伺服器的 JSON：{{serverName}}",

--- a/web-app/src/routes/settings/mcp-servers.tsx
+++ b/web-app/src/routes/settings/mcp-servers.tsx
@@ -190,6 +190,7 @@ function MCPServersDesktop() {
       }
 
       deleteServer(serverToDelete)
+      toast.success(t('mcp-servers:deleteServer.success', { serverName: serverToDelete }))
       setServerToDelete(null)
       syncServersAndRestart()
     }


### PR DESCRIPTION
## Describe Your Changes

This pull request enhances the user experience when deleting MCP servers by adding localized success messages across all supported languages and updating the UI to show a toast notification after a successful deletion. This makes the deletion process clearer and more informative for users.

**Localization improvements:**

* Added a `"success"` message for MCP server deletion in all supported language files (`mcp-servers.json`), including English, German, Indonesian, Polish, Vietnamese, Simplified Chinese, and Traditional Chinese. [[1]](diffhunk://#diff-e37970d2e5475a4432b98ae88c58630f732ca5da482862570b70b7604d1cd8c4L20-R21) [[2]](diffhunk://#diff-9c1314bb4a07ad5f2d7fa414d068c211a41b839873b7896d05a6fa7f5cb7da63L20-R21) [[3]](diffhunk://#diff-125bc0edd915a5d473a460cdf7a92419df722dcd3ef822f9161eb93d2c7aa302L20-R21) [[4]](diffhunk://#diff-8d7bbb77df2d6c49676da6593da067a3bb8e6d17f35f65102e042df2ce9398ecL20-R21) [[5]](diffhunk://#diff-6170127f430a64e0707a2caa0c64cfa218236ceb0b2c65e38cd644251230dd92L20-R21) [[6]](diffhunk://#diff-848c116e18b769c759251c2831f8405f576175004b274d20170c65a5d4a601d4L20-R21) [[7]](diffhunk://#diff-51676dc27b9df0a08aaeaaca24081a3c401906354c289ecaceb97ef7ae94f85fL20-R21)

**UI/UX enhancements:**

* Updated the MCP server deletion flow in `mcp-servers.tsx` to display a toast notification with the localized success message after a server is deleted.

## Fixes Issues

- Closes #6508 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhances MCP server deletion by adding localized success messages and a toast notification in `mcp-servers.tsx`.
> 
>   - **Localization**:
>     - Added `"success"` message for MCP server deletion in `mcp-servers.json` for English, German, Indonesian, Polish, Vietnamese, Simplified Chinese, and Traditional Chinese.
>   - **UI/UX**:
>     - Updated `mcp-servers.tsx` to show a toast notification with localized success message after MCP server deletion.
>   - **Misc**:
>     - Closes #6508.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ec425163d3d73f67a734772f2b1fffc5c14fb935. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->