### PR TITLE
fix: prevent consecutive messages with same role

### DIFF
--- a/web-app/src/components/ui/__tests__/sheet.test.tsx
+++ b/web-app/src/components/ui/__tests__/sheet.test.tsx
@@ -52,11 +52,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Sheet Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const content = document.querySelector('[data-slot="sheet-content"]')
     expect(content).toBeInTheDocument()
     expect(content).toHaveClass('inset-y-0', 'right-0')
@@ -67,11 +68,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent side="left">
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Sheet Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const content = document.querySelector('[data-slot="sheet-content"]')
     expect(content).toHaveClass('inset-y-0', 'left-0')
   })
@@ -81,11 +83,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent side="top">
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Sheet Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const content = document.querySelector('[data-slot="sheet-content"]')
     expect(content).toHaveClass('inset-x-0', 'top-0')
   })
@@ -95,11 +98,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent side="bottom">
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Sheet Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const content = document.querySelector('[data-slot="sheet-content"]')
     expect(content).toHaveClass('inset-x-0', 'bottom-0')
   })
@@ -109,13 +113,14 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <SheetHeader>
             <div>Header Content</div>
           </SheetHeader>
         </SheetContent>
       </Sheet>
     )
-    
+
     const header = document.querySelector('[data-slot="sheet-header"]')
     expect(header).toBeInTheDocument()
     expect(header).toHaveClass('flex', 'flex-col', 'gap-1.5', 'p-4')
@@ -126,13 +131,14 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <SheetFooter>
             <div>Footer Content</div>
           </SheetFooter>
         </SheetContent>
       </Sheet>
     )
-    
+
     const footer = document.querySelector('[data-slot="sheet-footer"]')
     expect(footer).toBeInTheDocument()
     expect(footer).toHaveClass('mt-auto', 'flex', 'flex-col', 'gap-2', 'p-4')
@@ -143,10 +149,11 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Sheet Title</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
         </SheetContent>
       </Sheet>
     )
-    
+
     const title = document.querySelector('[data-slot="sheet-title"]')
     expect(title).toBeInTheDocument()
     expect(title).toHaveTextContent('Sheet Title')
@@ -174,11 +181,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const closeButton = document.querySelector('.absolute.top-4.right-4')
     expect(closeButton).toBeInTheDocument()
     expect(closeButton).toHaveClass('rounded-xs', 'opacity-70', 'transition-opacity')
@@ -189,11 +197,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const overlay = document.querySelector('[data-slot="sheet-overlay"]')
     expect(overlay).toBeInTheDocument()
     expect(overlay).toHaveClass('fixed', 'inset-0', 'z-50', 'bg-main-view/50', 'backdrop-blur-xs')
@@ -204,11 +213,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent>
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <SheetClose>Close</SheetClose>
         </SheetContent>
       </Sheet>
     )
-    
+
     const close = document.querySelector('[data-slot="sheet-close"]')
     expect(close).toBeInTheDocument()
     expect(close).toHaveTextContent('Close')
@@ -219,11 +229,12 @@ describe('Sheet Components', () => {
       <Sheet defaultOpen>
         <SheetContent className="custom-sheet">
           <SheetTitle>Test Sheet</SheetTitle>
+          <SheetDescription>Test description</SheetDescription>
           <div>Content</div>
         </SheetContent>
       </Sheet>
     )
-    
+
     const content = document.querySelector('[data-slot="sheet-content"]')
     expect(content).toHaveClass('custom-sheet')
   })

--- a/web-app/src/containers/__tests__/ChatInput.test.tsx
+++ b/web-app/src/containers/__tests__/ChatInput.test.tsx
@@ -188,39 +188,39 @@ describe('ChatInput', () => {
     mockAppState.tools = []
   })
 
-  it('renders chat input textarea', () => {
-    act(() => {
+  it('renders chat input textarea', async () => {
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     const textarea = screen.getByRole('textbox')
     expect(textarea).toBeInTheDocument()
     expect(textarea).toHaveAttribute('placeholder', 'common:placeholder.chatInput')
   })
 
-  it('renders send button', () => {
-    act(() => {
+  it('renders send button', async () => {
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     const sendButton = document.querySelector('[data-test-id="send-message-button"]')
     expect(sendButton).toBeInTheDocument()
   })
 
-  it('disables send button when prompt is empty', () => {
-    act(() => {
+  it('disables send button when prompt is empty', async () => {
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     const sendButton = document.querySelector('[data-test-id="send-message-button"]')
     expect(sendButton).toBeDisabled()
   })
 
-  it('enables send button when prompt has content', () => {
+  it('enables send button when prompt has content', async () => {
     // Set prompt content
     mockPromptState.prompt = 'Hello world'
 
-    act(() => {
+    await act(async () => {
       renderWithRouter()
     })
 
@@ -230,10 +230,14 @@ describe('ChatInput', () => {
 
   it('calls setPrompt when typing in textarea', async () => {
     const user = userEvent.setup()
-    renderWithRouter()
+    await act(async () => {
+      renderWithRouter()
+    })
 
     const textarea = screen.getByRole('textbox')
-    await user.type(textarea, 'Hello')
+    await act(async () => {
+      await user.type(textarea, 'Hello')
+    })
 
     // setPrompt is called for each character typed
     expect(mockPromptState.setPrompt).toHaveBeenCalledTimes(5)
@@ -246,10 +250,14 @@ describe('ChatInput', () => {
     // Set prompt content
     mockPromptState.prompt = 'Hello world'
 
-    renderWithRouter()
+    await act(async () => {
+      renderWithRouter()
+    })
 
     const sendButton = document.querySelector('[data-test-id="send-message-button"]')
-    await user.click(sendButton)
+    await act(async () => {
+      await user.click(sendButton)
+    })
 
     // Note: Since useChat now returns the sendMessage function directly, we need to mock it differently
     // For now, we'll just check that the button was clicked successfully
@@ -262,10 +270,14 @@ describe('ChatInput', () => {
     // Set prompt content
     mockPromptState.prompt = 'Hello world'
 
-    renderWithRouter()
+    await act(async () => {
+      renderWithRouter()
+    })
 
     const textarea = screen.getByRole('textbox')
-    await user.type(textarea, '{Enter}')
+    await act(async () => {
+      await user.type(textarea, '{Enter}')
+    })
 
     // Just verify the textarea exists and Enter was processed
     expect(textarea).toBeInTheDocument()
@@ -277,34 +289,38 @@ describe('ChatInput', () => {
     // Set prompt content
     mockPromptState.prompt = 'Hello world'
 
-    renderWithRouter()
+    await act(async () => {
+      renderWithRouter()
+    })
 
     const textarea = screen.getByRole('textbox')
-    await user.type(textarea, '{Shift>}{Enter}{/Shift}')
+    await act(async () => {
+      await user.type(textarea, '{Shift>}{Enter}{/Shift}')
+    })
 
     // Just verify the textarea exists
     expect(textarea).toBeInTheDocument()
   })
 
-  it('shows stop button when streaming', () => {
+  it('shows stop button when streaming', async () => {
     // Mock streaming state
     mockAppState.streamingContent = { thread_id: 'test-thread' }
-    
-    act(() => {
+
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     // Stop button should be rendered (as SVG with tabler-icon-player-stop-filled class)
     const stopButton = document.querySelector('.tabler-icon-player-stop-filled')
     expect(stopButton).toBeInTheDocument()
   })
 
 
-  it('shows model selection dropdown', () => {
-    act(() => {
+  it('shows model selection dropdown', async () => {
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     // Model selection dropdown should be rendered (look for popover trigger)
     const modelDropdown = document.querySelector('[data-slot="popover-trigger"]')
     expect(modelDropdown).toBeInTheDocument()
@@ -316,10 +332,14 @@ describe('ChatInput', () => {
     // Mock no selected model and prompt with content
     mockPromptState.prompt = 'Hello world'
 
-    renderWithRouter()
+    await act(async () => {
+      renderWithRouter()
+    })
 
     const sendButton = document.querySelector('[data-test-id="send-message-button"]')
-    await user.click(sendButton)
+    await act(async () => {
+      await user.click(sendButton)
+    })
 
     // The component should still render without crashing when no model is selected
     expect(sendButton).toBeInTheDocument()
@@ -327,8 +347,10 @@ describe('ChatInput', () => {
 
   it('handles file upload', async () => {
     const user = userEvent.setup()
-    renderWithRouter()
-    
+    await act(async () => {
+      renderWithRouter()
+    })
+
     // Wait for async effects to complete (mmproj check)
     await waitFor(() => {
       // File upload is rendered as hidden input element
@@ -337,14 +359,14 @@ describe('ChatInput', () => {
     })
   })
 
-  it('disables input when streaming', () => {
+  it('disables input when streaming', async () => {
     // Mock streaming state
     mockAppState.streamingContent = { thread_id: 'test-thread' }
-    
-    act(() => {
+
+    await act(async () => {
       renderWithRouter()
     })
-    
+
     const textarea = screen.getByTestId('chat-input')
     expect(textarea).toBeDisabled()
   })
@@ -352,9 +374,11 @@ describe('ChatInput', () => {
   it('shows tools dropdown when model supports tools and MCP servers are connected', async () => {
     // Mock connected servers
     mockGetConnectedServers.mockResolvedValue(['server1'])
-    
-    renderWithRouter()
-    
+
+    await act(async () => {
+      renderWithRouter()
+    })
+
     await waitFor(() => {
       // Tools dropdown should be rendered (as SVG icon with tabler-icon-tool class)
       const toolsIcon = document.querySelector('.tabler-icon-tool')
@@ -362,8 +386,10 @@ describe('ChatInput', () => {
     })
   })
 
-  it('uses selectedProvider for provider checks', () => {
+  it('uses selectedProvider for provider checks', async () => {
     // This test ensures the component renders without errors when using selectedProvider
-    expect(() => renderWithRouter()).not.toThrow()
+    await act(async () => {
+      expect(() => renderWithRouter()).not.toThrow()
+    })
   })
 })

--- a/web-app/src/hooks/__tests__/useChat.test.ts
+++ b/web-app/src/hooks/__tests__/useChat.test.ts
@@ -57,21 +57,37 @@ vi.mock('../useAssistant', () => ({
 }))
 
 vi.mock('../useModelProvider', () => ({
-  useModelProvider: (selector: any) => {
-    const state = {
-      getProviderByName: vi.fn(() => ({
-        provider: 'openai',
-        models: [],
-      })),
-      selectedModel: {
-        id: 'test-model',
-        capabilities: ['tools'],
-      },
-      selectedProvider: 'openai',
-      updateProvider: vi.fn(),
+  useModelProvider: Object.assign(
+    (selector: any) => {
+      const state = {
+        getProviderByName: vi.fn(() => ({
+          provider: 'openai',
+          models: [],
+        })),
+        selectedModel: {
+          id: 'test-model',
+          capabilities: ['tools'],
+        },
+        selectedProvider: 'openai',
+        updateProvider: vi.fn(),
+      }
+      return selector ? selector(state) : state
+    },
+    {
+      getState: () => ({
+        getProviderByName: vi.fn(() => ({
+          provider: 'openai',
+          models: [],
+        })),
+        selectedModel: {
+          id: 'test-model',
+          capabilities: ['tools'],
+        },
+        selectedProvider: 'openai',
+        updateProvider: vi.fn(),
+      })
     }
-    return selector ? selector(state) : state
-  },
+  ),
 }))
 
 vi.mock('../useThreads', () => ({

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -19,7 +19,6 @@ import {
 import { CompletionMessagesBuilder } from '@/lib/messages'
 import { renderInstructions } from '@/lib/instructionTemplate'
 import { ChatCompletionMessageToolCall } from 'openai/resources'
-import { useAssistant } from './useAssistant'
 
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useToolApproval } from '@/hooks/useToolApproval'
@@ -31,22 +30,29 @@ import {
   ReasoningProcessor,
   extractReasoningFromMessage,
 } from '@/utils/reasoning'
+import { useAssistant } from './useAssistant'
+import { useShallow } from 'zustand/shallow'
 
 export const useChat = () => {
-  const tools = useAppState((state) => state.tools)
-  const updateTokenSpeed = useAppState((state) => state.updateTokenSpeed)
-  const resetTokenSpeed = useAppState((state) => state.resetTokenSpeed)
-  const updateStreamingContent = useAppState(
-    (state) => state.updateStreamingContent
+  const [
+    updateTokenSpeed,
+    resetTokenSpeed,
+    updateStreamingContent,
+    updateLoadingModel,
+    setAbortController,
+  ] = useAppState(
+    useShallow((state) => [
+      state.updateTokenSpeed,
+      state.resetTokenSpeed,
+      state.updateStreamingContent,
+      state.updateLoadingModel,
+      state.setAbortController,
+    ])
   )
-  const updateLoadingModel = useAppState((state) => state.updateLoadingModel)
-  const setAbortController = useAppState((state) => state.setAbortController)
-  const assistants = useAssistant((state) => state.assistants)
-  const currentAssistant = useAssistant((state) => state.currentAssistant)
+
   const updateProvider = useModelProvider((state) => state.updateProvider)
   const serviceHub = useServiceHub()
 
-  const approvedTools = useToolApproval((state) => state.approvedTools)
   const showApprovalModal = useToolApproval((state) => state.showApprovalModal)
   const allowAllMCPPermissions = useToolApproval(
     (state) => state.allowAllMCPPermissions
@@ -59,13 +65,13 @@ export const useChat = () => {
   )
 
   const getProviderByName = useModelProvider((state) => state.getProviderByName)
-  const selectedModel = useModelProvider((state) => state.selectedModel)
-  const selectedProvider = useModelProvider((state) => state.selectedProvider)
 
-  const createThread = useThreads((state) => state.createThread)
-  const retrieveThread = useThreads((state) => state.getCurrentThread)
-  const updateThreadTimestamp = useThreads(
-    (state) => state.updateThreadTimestamp
+  const [createThread, retrieveThread, updateThreadTimestamp] = useThreads(
+    useShallow((state) => [
+      state.createThread,
+      state.getCurrentThread,
+      state.updateThreadTimestamp,
+    ])
   )
 
   const getMessages = useMessages((state) => state.getMessages)
@@ -73,30 +79,23 @@ export const useChat = () => {
   const setModelLoadError = useModelLoad((state) => state.setModelLoadError)
   const router = useRouter()
 
-  const provider = useMemo(() => {
-    return getProviderByName(selectedProvider)
-  }, [selectedProvider, getProviderByName])
-
-  const currentProviderId = useMemo(() => {
-    return provider?.provider || selectedProvider
-  }, [provider, selectedProvider])
-
-  const selectedAssistant =
-    assistants.find((a) => a.id === currentAssistant?.id) || assistants[0]
-
   const getCurrentThread = useCallback(async () => {
     let currentThread = retrieveThread()
 
     if (!currentThread) {
       // Get prompt directly from store when needed
       const currentPrompt = usePrompt.getState().prompt
+      const currentAssistant = useAssistant.getState().currentAssistant
+      const assistants = useAssistant.getState().assistants
+      const selectedModel = useModelProvider.getState().selectedModel
+      const selectedProvider = useModelProvider.getState().selectedProvider
       currentThread = await createThread(
         {
           id: selectedModel?.id ?? defaultModel(selectedProvider),
           provider: selectedProvider,
         },
         currentPrompt,
-        selectedAssistant
+        assistants.find((a) => a.id === currentAssistant?.id) || assistants[0]
       )
       router.navigate({
         to: route.threadsDetail,
@@ -104,14 +103,7 @@ export const useChat = () => {
       })
     }
     return currentThread
-  }, [
-    createThread,
-    retrieveThread,
-    router,
-    selectedModel?.id,
-    selectedProvider,
-    selectedAssistant,
-  ])
+  }, [createThread, retrieveThread, router])
 
   const restartModel = useCallback(
     async (provider: ProviderObject, modelId: string) => {
@@ -228,11 +220,10 @@ export const useChat = () => {
       }>
     ) => {
       const activeThread = await getCurrentThread()
+      const selectedProvider = useModelProvider.getState().selectedProvider
+      let activeProvider = getProviderByName(selectedProvider)
 
       resetTokenSpeed()
-      let activeProvider = currentProviderId
-        ? getProviderByName(currentProviderId)
-        : provider
       if (!activeThread || !activeProvider) return
       const messages = getMessages(activeThread.id)
       const abortController = new AbortController()
@@ -243,13 +234,14 @@ export const useChat = () => {
         addMessage(newUserThreadContent(activeThread.id, message, attachments))
       updateThreadTimestamp(activeThread.id)
       usePrompt.getState().setPrompt('')
+      const selectedModel = useModelProvider.getState().selectedModel
       try {
         if (selectedModel?.id) {
           updateLoadingModel(true)
           await serviceHub.models().startModel(activeProvider, selectedModel.id)
           updateLoadingModel(false)
         }
-
+        const currentAssistant = useAssistant.getState().currentAssistant
         const builder = new CompletionMessagesBuilder(
           messages,
           currentAssistant
@@ -262,7 +254,7 @@ export const useChat = () => {
 
         // Filter tools based on model capabilities and available tools for this thread
         let availableTools = selectedModel?.capabilities?.includes('tools')
-          ? tools.filter((tool) => {
+          ? useAppState.getState().tools.filter((tool) => {
               const disabledTools = getDisabledToolsForThread(activeThread.id)
               return !disabledTools.includes(tool.name)
             })
@@ -491,7 +483,7 @@ export const useChat = () => {
             accumulatedText.length === 0 &&
             toolCalls.length === 0 &&
             activeThread.model?.id &&
-            provider?.provider === 'llamacpp'
+            activeProvider?.provider === 'llamacpp'
           ) {
             await serviceHub
               .models()
@@ -515,7 +507,7 @@ export const useChat = () => {
             builder,
             finalContent,
             abortController,
-            approvedTools,
+            useToolApproval.getState().approvedTools,
             allowAllMCPPermissions ? undefined : showApprovalModal,
             allowAllMCPPermissions
           )
@@ -547,20 +539,14 @@ export const useChat = () => {
     [
       getCurrentThread,
       resetTokenSpeed,
-      currentProviderId,
       getProviderByName,
-      provider,
       getMessages,
       setAbortController,
       updateStreamingContent,
       addMessage,
       updateThreadTimestamp,
-      selectedModel,
-      currentAssistant,
-      tools,
       updateLoadingModel,
       getDisabledToolsForThread,
-      approvedTools,
       allowAllMCPPermissions,
       showApprovalModal,
       updateTokenSpeed,

--- a/web-app/src/lib/__tests__/messages.test.ts
+++ b/web-app/src/lib/__tests__/messages.test.ts
@@ -43,10 +43,14 @@ describe('CompletionMessagesBuilder', () => {
       const builder = new CompletionMessagesBuilder(messages, systemInstruction)
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
         role: 'system',
         content: systemInstruction,
+      })
+      expect(result[1]).toEqual({
+        role: 'user',
+        content: '.',
       })
     })
 
@@ -78,8 +82,9 @@ describe('CompletionMessagesBuilder', () => {
       const builder = new CompletionMessagesBuilder(messages)
       const result = builder.getMessages()
 
-      expect(result).toHaveLength(1)
-      expect(result[0].content).toBe('Hello there!')
+      expect(result).toHaveLength(2)
+      expect(result[0].content).toBe('.')
+      expect(result[1].content).toBe('Hello there!')
     })
 
     it('should preserve user message content without normalization', () => {
@@ -171,8 +176,12 @@ describe('CompletionMessagesBuilder', () => {
       builder.addAssistantMessage('<think>Processing...</think>Hello!')
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1]).toEqual({
         role: 'assistant',
         content: 'Hello!',
         refusal: undefined,
@@ -189,8 +198,12 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1]).toEqual({
         role: 'assistant',
         content: 'I cannot help with that',
         refusal: 'Content policy violation',
@@ -218,8 +231,12 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1]).toEqual({
         role: 'assistant',
         content: 'Let me check the weather',
         refusal: undefined,
@@ -247,8 +264,12 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1]).toEqual({
         role: 'assistant',
         content: 'Here are the results',
         refusal: 'Cannot search sensitive content',
@@ -264,8 +285,12 @@ describe('CompletionMessagesBuilder', () => {
       builder.addToolMessage('Weather data: 72°F', 'call_123')
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1]).toEqual({
         role: 'tool',
         content: 'Weather data: 72°F',
         tool_call_id: 'call_123',
@@ -280,10 +305,11 @@ describe('CompletionMessagesBuilder', () => {
 
       const result = builder.getMessages()
       // getMessages() inserts a filler message between consecutive tool messages
-      expect(result).toHaveLength(3)
-      expect(result[0].tool_call_id).toBe('call_1')
-      expect(result[1].role).toBe('assistant') // filler message
-      expect(result[2].tool_call_id).toBe('call_2')
+      expect(result).toHaveLength(4)
+      expect(result[0].role).toBe('user') // initial filler message
+      expect(result[1].tool_call_id).toBe('call_1')
+      expect(result[2].role).toBe('assistant') // filler message
+      expect(result[3].tool_call_id).toBe('call_2')
     })
 
     it('should handle empty tool content', () => {
@@ -292,9 +318,13 @@ describe('CompletionMessagesBuilder', () => {
       builder.addToolMessage('', 'call_123')
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(1)
-      expect(result[0].content).toBe('')
-      expect(result[0].tool_call_id).toBe('call_123')
+      expect(result).toHaveLength(2)
+      expect(result[0]).toEqual({
+        role: 'user',
+        content: '.',
+      })
+      expect(result[1].content).toBe('')
+      expect(result[1].tool_call_id).toBe('call_123')
     })
   })
 
@@ -345,7 +375,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('The answer is 42.')
+      expect(result[1].content).toBe('The answer is 42.')
     })
 
     it('should handle nested thinking tags', () => {
@@ -356,7 +386,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('More thinking</think>Final answer')
+      expect(result[1].content).toBe('More thinking</think>Final answer')
     })
 
     it('should handle multiple thinking blocks', () => {
@@ -367,7 +397,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('Answer<think>Second</think>More content')
+      expect(result[1].content).toBe('Answer<think>Second</think>More content')
     })
 
     it('should handle content without thinking tags', () => {
@@ -376,7 +406,7 @@ describe('CompletionMessagesBuilder', () => {
       builder.addAssistantMessage('Just a normal response')
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('Just a normal response')
+      expect(result[1].content).toBe('Just a normal response')
     })
 
     it('should handle empty content after removing thinking', () => {
@@ -385,7 +415,7 @@ describe('CompletionMessagesBuilder', () => {
       builder.addAssistantMessage('<think>Only thinking content</think>')
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('')
+      expect(result[1].content).toBe('')
     })
 
     it('should handle unclosed thinking tags', () => {
@@ -396,7 +426,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe(
+      expect(result[1].content).toBe(
         '<think>Unclosed thinking tag... Regular content'
       )
     })
@@ -409,7 +439,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('Clean answer')
+      expect(result[1].content).toBe('Clean answer')
     })
 
     it('should remove analysis channel reasoning content', () => {
@@ -420,7 +450,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('The final answer is 42.')
+      expect(result[1].content).toBe('The final answer is 42.')
     })
 
     it('should handle analysis channel without final message', () => {
@@ -431,7 +461,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('<|channel|>analysis<|message|>Only analysis content here...')
+      expect(result[1].content).toBe('<|channel|>analysis<|message|>Only analysis content here...')
     })
 
     it('should handle analysis channel with multiline content', () => {
@@ -442,7 +472,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('Based on my analysis, here is the result.')
+      expect(result[1].content).toBe('Based on my analysis, here is the result.')
     })
 
     it('should handle both think and analysis channel tags', () => {
@@ -453,7 +483,7 @@ describe('CompletionMessagesBuilder', () => {
       )
 
       const result = builder.getMessages()
-      expect(result[0].content).toBe('Final response')
+      expect(result[1].content).toBe('Final response')
     })
   })
 
@@ -518,10 +548,14 @@ describe('CompletionMessagesBuilder', () => {
 
       const result = builder.getMessages()
 
-      expect(result).toHaveLength(1)
+      expect(result).toHaveLength(2)
       expect(result[0]).toEqual({
         role: 'system',
         content: 'System instruction',
+      })
+      expect(result[1]).toEqual({
+        role: 'user',
+        content: '.',
       })
     })
   })

--- a/web-app/src/lib/__tests__/messages.test.ts
+++ b/web-app/src/lib/__tests__/messages.test.ts
@@ -60,9 +60,11 @@ describe('CompletionMessagesBuilder', () => {
       const builder = new CompletionMessagesBuilder(messages)
       const result = builder.getMessages()
 
-      expect(result).toHaveLength(2)
+      // getMessages() inserts a filler message between consecutive user messages
+      expect(result).toHaveLength(3)
       expect(result[0].content).toBe('Hello')
-      expect(result[1].content).toBe('How are you?')
+      expect(result[1].role).toBe('assistant') // filler message
+      expect(result[2].content).toBe('How are you?')
     })
 
     it('should normalize assistant message content', () => {
@@ -277,9 +279,11 @@ describe('CompletionMessagesBuilder', () => {
       builder.addToolMessage('Second tool result', 'call_2')
 
       const result = builder.getMessages()
-      expect(result).toHaveLength(2)
+      // getMessages() inserts a filler message between consecutive tool messages
+      expect(result).toHaveLength(3)
       expect(result[0].tool_call_id).toBe('call_1')
-      expect(result[1].tool_call_id).toBe('call_2')
+      expect(result[1].role).toBe('assistant') // filler message
+      expect(result[2].tool_call_id).toBe('call_2')
     })
 
     it('should handle empty tool content', () => {
@@ -325,10 +329,10 @@ describe('CompletionMessagesBuilder', () => {
       builder.addAssistantMessage('Response')
       const result2 = builder.getMessages()
 
-      // Both should reference the same array and have 2 messages now
-      expect(result1).toBe(result2) // Same reference
-      expect(result1).toHaveLength(2)
-      expect(result2).toHaveLength(2)
+      // getMessages() creates a new array each time, so references will be different
+      expect(result1).not.toBe(result2) // Different references because getMessages creates new array
+      expect(result1).toHaveLength(1) // First call had only 1 message
+      expect(result2).toHaveLength(2) // Second call has 2 messages
     })
   })
 
@@ -495,16 +499,18 @@ describe('CompletionMessagesBuilder', () => {
 
       const result = builder.getMessages()
 
-      expect(result).toHaveLength(6)
+      // getMessages() adds filler messages between consecutive assistant messages
+      expect(result).toHaveLength(7)
       expect(result[0].role).toBe('system')
       expect(result[1].role).toBe('user')
       expect(result[2].role).toBe('assistant')
       expect(result[2].content).toBe('Let me check the weather for you.')
-      expect(result[3].role).toBe('assistant')
-      expect(result[3].tool_calls).toEqual(toolCalls)
-      expect(result[4].role).toBe('tool')
-      expect(result[5].role).toBe('assistant')
-      expect(result[5].content).toBe('The weather is 72°F and sunny!')
+      expect(result[3].role).toBe('user') // filler message inserted between consecutive assistant messages
+      expect(result[4].role).toBe('assistant')
+      expect(result[4].tool_calls).toEqual(toolCalls)
+      expect(result[5].role).toBe('tool')
+      expect(result[6].role).toBe('assistant')
+      expect(result[6].content).toBe('The weather is 72°F and sunny!')
     })
 
     it('should handle empty thread messages with system instruction', () => {

--- a/web-app/src/lib/messages.ts
+++ b/web-app/src/lib/messages.ts
@@ -159,7 +159,21 @@ export class CompletionMessagesBuilder {
    * @returns The array of chat completion messages.
    */
   getMessages(): ChatCompletionMessageParam[] {
-    return this.messages
+    const result: ChatCompletionMessageParam[] = []
+    let prevRole: string | undefined
+
+    // Avoiding duplication and flipping roles dynamically
+    for (const msg of this.messages) {
+      if (msg.role === prevRole) {
+        const oppositeRole = prevRole === 'assistant' ? 'user' : 'assistant'
+        result.push({ role: oppositeRole, content: '.' })
+        prevRole = oppositeRole
+      }
+      result.push(msg)
+      prevRole = msg.role
+    }
+
+    return result
   }
 
   /**


### PR DESCRIPTION
## Describe Your Changes

This PR fixes an issue where two consecutive messages with the same role (user or assistant) could appear in the conversation history.

Changes
- Insert a fallback message (".") with the opposite role when two consecutive messages share the same role.
- Ensures the message sequence always alternates between user and assistant.

## Fixes Issues

- Closes #6234 

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fixes consecutive message role issue by inserting fallback messages to ensure alternation between user and assistant roles in `CompletionMessagesBuilder`.
> 
>   - **Behavior**:
>     - In `CompletionMessagesBuilder` in `messages.ts`, insert a fallback message `.` with the opposite role when two consecutive messages share the same role.
>     - Ensures message sequence alternates between user and assistant roles.
>   - **Tests**:
>     - Update tests in `messages.test.ts` to verify insertion of fallback messages between consecutive messages of the same role.
>     - Modify tests in `useChat.test.ts` and `useChat.instructions.test.ts` to align with new message alternation behavior.
>     - Adjust tests in `ChatInput.test.tsx` and `sheet.test.tsx` to ensure consistent behavior with new message handling.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for a749b05bd998a858fabe6e1a9e753e3486490f3e. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->