### PR TITLE
fix: prevent relocation to root directories

### DIFF
--- a/web-app/src/locales/en/settings.json
+++ b/web-app/src/locales/en/settings.json
@@ -207,6 +207,8 @@
     "showInFileExplorer": "Show in File Explorer",
     "openContainingFolder": "Open Containing Folder",
     "failedToRelocateDataFolder": "Failed to relocate data folder",
+    "couldNotRelocateToRoot": "Cannot relocate data folder to root directory. Please choose another location.",
+    "couldNotResetRootDirectory": "Cannot reset data folder when it's set to a root directory. Please delete the data folder manually.",
     "failedToRelocateDataFolderDesc": "Failed to relocate data folder. Please try again.",
     "devVersion": "Development version detected",
     "noUpdateAvailable": "You're running the latest version",

--- a/web-app/src/locales/id/settings.json
+++ b/web-app/src/locales/id/settings.json
@@ -203,6 +203,8 @@
     "showInFinder": "Tampilkan di Finder",
     "showInFileExplorer": "Tampilkan di File Explorer",
     "openContainingFolder": "Buka Folder Induk",
+    "couldNotRelocateToRoot": "Tidak dapat memindahkan folder data ke direktori root. Silakan pilih lokasi lain.",
+    "couldNotResetRootDirectory": "Tidak dapat mengatur ulang folder data saat diatur ke direktori root. Silakan hapus folder data secara manual.",
     "failedToRelocateDataFolder": "Gagal memindahkan folder data",
     "failedToRelocateDataFolderDesc": "Gagal memindahkan folder data. Silakan coba lagi.",
     "devVersion": "Versi pengembangan terdeteksi",

--- a/web-app/src/locales/pl/settings.json
+++ b/web-app/src/locales/pl/settings.json
@@ -206,6 +206,8 @@
     "showInFinder": "Pokaż w Finderze",
     "showInFileExplorer": "Pokaż w Explorerze",
     "openContainingFolder": "Otwórz Katalog Nadrzędny",
+    "couldNotRelocateToRoot": "Nie można przenieść folderu danych do katalogu głównego. Proszę wybrać inną lokalizację.",
+    "couldNotResetRootDirectory": "Nie można zresetować folderu danych, gdy jest ustawiony na katalog główny. Proszę ręcznie usunąć folder danych.",
     "failedToRelocateDataFolder": "Błąd zmiany katalogu danych",
     "failedToRelocateDataFolderDesc": "Nie udało się przenieść katalogu danych. Proszę spróbować później.",
     "devVersion": "Wykryto wersję deweloperską",

--- a/web-app/src/locales/vn/settings.json
+++ b/web-app/src/locales/vn/settings.json
@@ -203,6 +203,8 @@
     "showInFinder": "Hiển thị trong Finder",
     "showInFileExplorer": "Hiển thị trong File Explorer",
     "openContainingFolder": "Mở Thư mục Chứa",
+    "couldNotRelocateToRoot": "Không thể di chuyển thư mục dữ liệu đến thư mục gốc. Vui lòng chọn vị trí khác.",
+    "couldNotResetRootDirectory": "Không thể đặt lại thư mục dữ liệu khi nó được đặt thành thư mục gốc. Vui lòng xóa thư mục dữ liệu thủ công.",
     "failedToRelocateDataFolder": "Không thể di chuyển thư mục dữ liệu",
     "failedToRelocateDataFolderDesc": "Không thể di chuyển thư mục dữ liệu. Vui lòng thử lại.",
     "devVersion": "Đã phát hiện phiên bản phát triển",

--- a/web-app/src/locales/zh-CN/settings.json
+++ b/web-app/src/locales/zh-CN/settings.json
@@ -203,6 +203,8 @@
     "showInFinder": "在 Finder 中显示",
     "showInFileExplorer": "在文件资源管理器中显示",
     "openContainingFolder": "打开包含文件夹",
+    "couldNotRelocateToRoot": "无法将数据文件夹重新定位到根目录。请选择其他位置。",
+    "couldNotResetRootDirectory": "当数据文件夹设置为根目录时，无法重置。请手动删除数据文件夹。",
     "failedToRelocateDataFolder": "无法重新定位数据文件夹",
     "failedToRelocateDataFolderDesc": "无法重新定位数据文件夹。请重试。",
     "devVersion": "检测到开发版本",

--- a/web-app/src/locales/zh-TW/settings.json
+++ b/web-app/src/locales/zh-TW/settings.json
@@ -203,6 +203,8 @@
     "showInFinder": "在 Finder 中顯示",
     "showInFileExplorer": "在檔案總管中顯示",
     "openContainingFolder": "打開包含資料夾",
+    "couldNotRelocateToRoot": "無法將資料檔案夾重新定位到根目錄。請選擇其他位置。",
+    "couldNotResetRootDirectory": "當資料檔案夾設定為根目錄時，無法重置。請手動刪除資料檔案夾。",
     "failedToRelocateDataFolder": "無法重新定位資料夾",
     "failedToRelocateDataFolderDesc": "無法重新定位資料夾。請重試。",
     "devVersion": "檢測到開發版本",

--- a/web-app/src/utils/path.ts
+++ b/web-app/src/utils/path.ts
@@ -1,0 +1,29 @@
+/**
+ * Determines if the given path is a root directory.
+ *
+ * On Windows, this checks for drive roots such as `C:\` or `D:\`.
+ * On Mac/Linux, this checks if the path is `/`.
+ *
+ * @param selectedNewPath - The path to check.
+ * @returns `true` if the path is a root directory, otherwise `false`.
+ */
+export const isRootDir = (selectedNewPath: string) => {
+  // Windows root: C:\, D:\, etc.
+  if (IS_WINDOWS) {
+    return /^[a-zA-Z]:\\?$/.test(selectedNewPath)
+  }
+  // Linux/Mac root: /, /mnt, /media, etc.
+  const linuxRoots = [
+    '/',
+    '/mnt',
+    '/media',
+    '/boot',
+    '/home',
+    '/opt',
+    '/var',
+    '/usr',
+  ]
+  const normalized =
+    selectedNewPath.replace(/\\/g, '/').replace(/\/+$/, '') || '/'
+  return linuxRoots.some((root) => normalized === root)
+}


### PR DESCRIPTION
## Describe Your Changes

Prevent relocation to root directories.

Disallows users from selecting root-level paths (e.g. C:\, /, /mnt) as relocation targets to avoid permission issues, data loss risks, and unintended system-level operations.

This pull request adds safeguards to prevent users from relocating or resetting the data folder to a root directory, improving data safety and user experience. It introduces a utility function to detect root directories across platforms and updates UI messages in multiple languages to inform users of these restrictions.

<img width="1026" height="820" alt="image" src="https://github.com/user-attachments/assets/0acc81e6-4ed6-4de7-8443-a1bda86ff21a" />

<img width="1026" height="820" alt="image" src="https://github.com/user-attachments/assets/48e7139c-a72b-426e-8d1b-98a8e194bf49" />

**Core functionality and validation:**

* Added a new utility function `isRootDir` in `web-app/src/utils/path.ts` to reliably detect root directories on Windows, Mac, and Linux systems.
* Updated `web-app/src/routes/settings/general.tsx` to:
  * Prevent relocating the data folder to a root directory, showing a localized error message if attempted.
  * Prevent resetting the app if the data folder is set to a root directory, also showing a localized error message.
  * Import the new `isRootDir` utility.

**Localization and user feedback:**

* Added new localized error messages for these scenarios in English, Indonesian, Polish, Vietnamese, Simplified Chinese, and Traditional Chinese settings locales. [[1]](diffhunk://#diff-985c59bb9bb9485f871e29274828be5b7102b54f92d75d7dab2d4c6146eb8cf1R210-R211) [[2]](diffhunk://#diff-a9bec10bcca710a18f5009cb043c0dcd81b7402f080b8a1630fefa922168848dR206-R207) [[3]](diffhunk://#diff-4c7969407afeeaf088fb3d3ccac6fed21677b75dac5f35d84eb588f43c79cef7R209-R210) [[4]](diffhunk://#diff-28c3a9e41ee07428d0d909d00cc802421ba57be0f652a49b89e0098f3b136740R206-R207) [[5]](diffhunk://#diff-f7e245d67763c31c23c238f3b5d04fa9f1eac959099bed77f9a68fcd5568181eR206-R207) [[6]](diffhunk://#diff-8599dbbede1809d1d5d656170c47bcf2748e3b4fb9230c41c245f53588fe6d64R206-R207)

## Fixes Issues

- Closes #4988

