### PR TITLE
fix: Catch local API server various errors #6546

### DIFF
--- a/src-tauri/src/core/server/proxy.rs
+++ b/src-tauri/src/core/server/proxy.rs
@@ -749,7 +749,13 @@ pub async fn start_server(
         }
     });
 
-    let server = Server::bind(&addr).serve(make_svc);
+    let server = match Server::try_bind(&addr) {
+        Ok(builder) => builder.serve(make_svc),
+        Err(e) => {
+            log::error!("Failed to bind to {}: {}", addr, e);
+            return Err(Box::new(e));
+        }
+    };
     log::info!("Jan API server started on http://{}", addr);
 
     let server_task = tokio::spawn(async move {


### PR DESCRIPTION
## Describe Your Changes

Add various error catching during the start of Local API server
- Catch occupied port
- Catch model file path invalid

## Fixes Issues

- Closes #6546

## Test plan
![Port error](https://github.com/user-attachments/assets/46f666bd-21fc-4f28-b533-9c3a4c9c676c)
Port occupation error catch

![Model_path_error](https://github.com/user-attachments/assets/537ac293-217e-406f-8a85-056c432ae7ae)
Model path error catch

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
