### PR TITLE
chore: add ci for web stag

### DIFF
--- a/.github/workflows/jan-server-web-ci-dev.yml
+++ b/.github/workflows/jan-server-web-ci-dev.yml
@@ -11,6 +11,8 @@ on:
 jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
+    env:
+      JAN_API_BASE: "https://api-dev.jan.ai/v1"
     permissions:
       pull-requests: write
       contents: write
@@ -50,7 +52,7 @@ jobs:
 
       - name: Build docker image
         run: |
-          docker build -t ${{ steps.vars.outputs.FULL_IMAGE }} .
+          docker build --build-arg JAN_API_BASE=${{ env.JAN_API_BASE }} -t ${{ steps.vars.outputs.FULL_IMAGE }} .
 
       - name: Push docker image
         if: github.event_name == 'push'

--- a/.github/workflows/jan-server-web-ci-prod.yml
+++ b/.github/workflows/jan-server-web-ci-prod.yml
@@ -13,7 +13,7 @@ jobs:
       deployments: write
       pull-requests: write
     env:
-      JAN_API_BASE: "https://api.jan.ai/jan/v1"
+      JAN_API_BASE: "https://api.jan.ai/v1"
       GA_MEASUREMENT_ID: "G-YK53MX8M8M"
       CLOUDFLARE_PROJECT_NAME: "jan-server-web"
     steps:
@@ -42,6 +42,9 @@ jobs:
 
       - name: Install dependencies
         run: make config-yarn && yarn install && yarn build:core && make build-web-app
+        env:
+          JAN_API_BASE: ${{ env.JAN_API_BASE }}
+          GA_MEASUREMENT_ID: ${{ env.GA_MEASUREMENT_ID }}
 
       - name: Publish to Cloudflare Pages Production
         uses: cloudflare/pages-action@v1

--- a/.github/workflows/jan-server-web-ci-stag.yml
+++ b/.github/workflows/jan-server-web-ci-stag.yml
@@ -1,0 +1,60 @@
+name: Jan Web Server build image and push to Harbor Registry
+
+on:
+  push:
+    branches:
+      - stag-web
+  pull_request:
+    branches:
+      - stag-web
+
+jobs:
+  build-and-preview:
+    runs-on: [ubuntu-24-04-docker]
+    env:
+      JAN_API_BASE: "https://api-stag.jan.ai/v1"
+    permissions:
+      pull-requests: write
+      contents: write
+    steps:
+      - name: Checkout source repo
+        uses: actions/checkout@v4
+
+      - name: Login to Harbor Registry
+        uses: docker/login-action@v3
+        with:
+          registry: registry.menlo.ai
+          username: ${{ secrets.HARBOR_USERNAME }}
+          password: ${{ secrets.HARBOR_PASSWORD }}
+
+      - name: Install dependencies
+        run: |
+          (type -p wget >/dev/null || (sudo apt update && sudo apt install wget -y)) \
+            && sudo mkdir -p -m 755 /etc/apt/keyrings \
+            && out=$(mktemp) && wget -nv -O$out https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+            && cat $out | sudo tee /etc/apt/keyrings/githubcli-archive-keyring.gpg > /dev/null \
+            && sudo chmod go+r /etc/apt/keyrings/githubcli-archive-keyring.gpg \
+            && sudo mkdir -p -m 755 /etc/apt/sources.list.d \
+            && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null \
+            && sudo apt update
+          sudo apt-get install -y jq gettext
+      
+      - name: Set image tag
+        id: vars
+        run: |
+          if [[ "${{ github.event_name }}" == "pull_request" ]]; then
+            IMAGE_TAG="web:preview-${{ github.sha }}"
+          else
+            IMAGE_TAG="web:stag-${{ github.sha }}"
+          fi
+          echo "IMAGE_TAG=${IMAGE_TAG}" >> $GITHUB_OUTPUT
+          echo "FULL_IMAGE=registry.menlo.ai/jan-server/${IMAGE_TAG}" >> $GITHUB_OUTPUT
+
+      - name: Build docker image
+        run: |
+          docker build --build-arg JAN_API_BASE=${{ env.JAN_API_BASE }} -t ${{ steps.vars.outputs.FULL_IMAGE }} .
+
+      - name: Push docker image
+        if: github.event_name == 'push'
+        run: |
+          docker push ${{ steps.vars.outputs.FULL_IMAGE }}

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
 # Stage 1: Build stage with Node.js and Yarn v4
 FROM node:20-alpine AS builder
 
+ARG JAN_API_BASE=https://api-dev.jan.ai/v1
+ENV JAN_API_BASE=$JAN_API_BASE
+
 # Install build dependencies
 RUN apk add --no-cache \
     make \


### PR DESCRIPTION
This pull request updates the CI/CD workflows for the Jan Web Server to better support multiple deployment environments (development, staging, and production) and improves the Docker build process to use environment-specific API base URLs. The changes include renaming workflow files for clarity, adding a new staging workflow, and ensuring environment variables are consistently passed into Docker builds and build steps.

**Workflow environment separation and configuration:**

* Added a new workflow file, `jan-server-web-ci-stag.yml`, to handle builds and Docker image pushes for the staging environment, including setting the `JAN_API_BASE` for staging and configuring image tagging and registry login.
* Renamed workflow files for clarity: the production workflow is now `jan-server-web-cicd-prod.yml` (from `jan-server-web-ci-prod.yml`), and the development workflow is now `jan-server-web-ci-dev.yml` (from `jan-server-web-ci.yml`). [[1]](diffhunk://#diff-e5944ee9eae613a938aae5fd95c8ee51fecef747e680db85225d6a791c1bcb88L16-R16) [[2]](diffhunk://#diff-3dfffdac0f201e7724190f27ec1eab4031c5c3809e0685731edd3ad0235225d5R14-R15)

**Environment variable handling and Docker build improvements:**

* Updated all workflows to explicitly set the `JAN_API_BASE` environment variable for their respective environments and to pass it as a build argument to the Docker build command, ensuring the correct API endpoint is used in each environment. [[1]](diffhunk://#diff-3dfffdac0f201e7724190f27ec1eab4031c5c3809e0685731edd3ad0235225d5L53-R55) [[2]](diffhunk://#diff-cc1de0bb01d1b5847f62331a7136a55dc81af85fdec5028f2f3c231078099f8eR1-R60) [[3]](diffhunk://#diff-dd2c0eb6ea5cfc6c4bd4eac30934e2d5746747af48fef6da689e85b752f39557R4-R6)
* Updated the `Dockerfile` to define `JAN_API_BASE` as a build argument and environment variable, so it can be properly injected during image builds.
* Ensured that additional environment variables (e.g., `GA_MEASUREMENT_ID`) are passed to build steps in the production workflow for consistency and correct configuration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> This PR updates CI/CD workflows for different environments and improves Docker build processes by adding a staging workflow, renaming existing workflows, and ensuring environment variables are correctly handled.
> 
>   - **Workflows**:
>     - Added `jan-server-web-ci-stag.yml` for staging builds and Docker image pushes, setting `JAN_API_BASE` for staging.
>     - Renamed `jan-server-web-ci-prod.yml` to `jan-server-web-cicd-prod.yml` and `jan-server-web-ci.yml` to `jan-server-web-ci-dev.yml` for clarity.
>   - **Environment Variables**:
>     - Set `JAN_API_BASE` in all workflows and passed as a build argument in Docker builds.
>     - Passed additional environment variables like `GA_MEASUREMENT_ID` in production workflow.
>   - **Dockerfile**:
>     - Added `JAN_API_BASE` as a build argument and environment variable.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 207f216f52c1c12abf083fe0a25a0b4bab0ebd1b. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->