### PR TITLE
docs: add clean output dir step

### DIFF
--- a/.github/workflows/jan-docs.yml
+++ b/.github/workflows/jan-docs.yml
@@ -53,6 +53,9 @@ jobs:
       - name: Install dependencies
         working-directory: docs
         run: yarn install
+      - name: Clean output directory
+        working-directory: docs
+        run: rm -rf out/* .next/*
       - name: Build website
         working-directory: docs
         run: export NODE_ENV=production && yarn build && cp _redirects out/_redirects && cp _headers out/_headers


### PR DESCRIPTION
This pull request makes a small update to the documentation build workflow. Before building the website, it now ensures that any previous build artifacts are removed, preventing potential conflicts or stale files in the output.

* Added a step to clean the `out` and `.next` directories before building the website in the `.github/workflows/jan-docs.yml` workflow.