### PR TITLE
fix: allow users to download the same model from different authors

### DIFF
--- a/core/src/browser/extensions/engines/AIEngine.ts
+++ b/core/src/browser/extensions/engines/AIEngine.ts
@@ -241,6 +241,12 @@ export abstract class AIEngine extends BaseExtension {
   }
 
   /**
+   * Gets model info
+   * @param modelId
+   */
+  abstract get(modelId: string): Promise<modelInfo | undefined>
+
+  /**
    * Lists available models
    */
   abstract list(): Promise<modelInfo[]>

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -1,0 +1,150 @@
+import { Button } from '@/components/ui/button'
+import { Progress } from '@/components/ui/progress'
+import { useDownloadStore } from '@/hooks/useDownloadStore'
+import { useGeneralSetting } from '@/hooks/useGeneralSetting'
+import { useModelProvider } from '@/hooks/useModelProvider'
+import { useServiceHub } from '@/hooks/useServiceHub'
+import { useTranslation } from '@/i18n'
+import { extractModelName } from '@/lib/models'
+import { cn } from '@/lib/utils'
+import { CatalogModel } from '@/services/models/types'
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { useShallow } from 'zustand/shallow'
+
+type ModelProps = {
+  model: CatalogModel
+  handleUseModel: (modelId: string) => void
+}
+const defaultModelQuantizations = ['iq4_xs', 'q4_k_m']
+
+export function DownloadButtonPlaceholder({
+  model,
+  handleUseModel,
+}: ModelProps) {
+  const { downloads, localDownloadingModels, addLocalDownloadingModel } =
+    useDownloadStore(
+      useShallow((state) => ({
+        downloads: state.downloads,
+        localDownloadingModels: state.localDownloadingModels,
+        addLocalDownloadingModel: state.addLocalDownloadingModel,
+      }))
+    )
+  const { t } = useTranslation()
+  const getProviderByName = useModelProvider((state) => state.getProviderByName)
+  const llamaProvider = getProviderByName('llamacpp')
+  const [modelId, setModelId] = useState<string | ''>('')
+
+  const serviceHub = useServiceHub()
+  const huggingfaceToken = useGeneralSetting((state) => state.huggingfaceToken)
+
+  const quant =
+    model.quants.find((e) =>
+      defaultModelQuantizations.some((m) =>
+        e.model_id.toLowerCase().includes(m)
+      )
+    ) ?? model.quants[0]
+
+  useEffect(() => {
+    const baseModelId = quant?.model_id || model.model_name
+    serviceHub
+      .models()
+      .getModel(baseModelId)
+      .then((config) => {
+        if (config) {
+          // Model exists - add repo prefix
+          setModelId(`${model.developer}/${baseModelId}`)
+        } else {
+          setModelId(baseModelId)
+        }
+      })
+  }, [serviceHub, quant, setModelId, model])
+
+  const downloadProcesses = useMemo(
+    () =>
+      Object.values(downloads).map((download) => ({
+        id: download.name,
+        name: download.name,
+        progress: download.progress,
+        current: download.current,
+        total: download.total,
+      })),
+    [downloads]
+  )
+
+  const isRecommendedModel = useCallback((modelId: string) => {
+    return (extractModelName(modelId)?.toLowerCase() ===
+      'jan-nano-gguf') as boolean
+  }, [])
+
+  if (model.quants.length === 0) {
+    return (
+      <div className="flex items-center gap-2">
+        <Button
+          size="sm"
+          onClick={() => {
+            window.open(`https://huggingface.co/${model.model_name}`, '_blank')
+          }}
+        >
+          View on HuggingFace
+        </Button>
+      </div>
+    )
+  }
+
+  const modelUrl = quant?.path || modelId
+  const isDownloading =
+    localDownloadingModels.has(modelId) ||
+    downloadProcesses.some((e) => e.id === modelId)
+
+  const downloadProgress =
+    downloadProcesses.find((e) => e.id === modelId)?.progress || 0
+  const isDownloaded = llamaProvider?.models.some(
+    (m: { id: string }) => m.id === modelId
+  )
+  const isRecommended = isRecommendedModel(model.model_name)
+
+  const handleDownload = () => {
+    // Immediately set local downloading state
+    addLocalDownloadingModel(modelId)
+    const mmprojPath = model.mmproj_models?.[0]?.path
+    serviceHub
+      .models()
+      .pullModelWithMetadata(modelId, modelUrl, mmprojPath, huggingfaceToken)
+  }
+
+  return (
+    <div
+      className={cn(
+        'flex items-center',
+        isRecommended && 'hub-download-button-step'
+      )}
+    >
+      {isDownloading && !isDownloaded && (
+        <div className={cn('flex items-center gap-2 w-20')}>
+          <Progress value={downloadProgress * 100} />
+          <span className="text-xs text-center text-main-view-fg/70">
+            {Math.round(downloadProgress * 100)}%
+          </span>
+        </div>
+      )}
+      {isDownloaded ? (
+        <Button
+          size="sm"
+          onClick={() => handleUseModel(modelId)}
+          data-test-id={`hub-model-${modelId}`}
+        >
+          {t('hub:use')}
+        </Button>
+      ) : (
+        <Button
+          data-test-id={`hub-model-${modelId}`}
+          size="sm"
+          onClick={handleDownload}
+          className={cn(isDownloading && 'hidden')}
+        >
+          {t('hub:download')}
+        </Button>
+      )}
+    </div>
+  )
+}

--- a/web-app/src/containers/DownloadButton.tsx
+++ b/web-app/src/containers/DownloadButton.tsx
@@ -94,7 +94,11 @@ export function DownloadButtonPlaceholder({
   const handleDownload = () => {
     // Immediately set local downloading state
     addLocalDownloadingModel(modelId)
-    const mmprojPath = model.mmproj_models?.[0]?.path
+    const mmprojPath = (
+      model.mmproj_models?.find(
+        (e) => e.model_id.toLowerCase() === 'mmproj-f16'
+      ) || model.mmproj_models?.[0]
+    )?.path
     serviceHub
       .models()
       .pullModelWithMetadata(modelId, modelUrl, mmprojPath, huggingfaceToken)

--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -1,4 +1,3 @@
-/* eslint-disable react-hooks/exhaustive-deps */
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkEmoji from 'remark-emoji'
@@ -7,7 +6,14 @@ import remarkBreaks from 'remark-breaks'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import * as prismStyles from 'react-syntax-highlighter/dist/cjs/styles/prism'
-import { memo, useState, useMemo, useCallback } from 'react'
+import {
+  memo,
+  useState,
+  useMemo,
+  useCallback,
+  DetailedHTMLProps,
+  HTMLAttributes,
+} from 'react'
 import { getReadableLanguageName } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { useCodeblock } from '@/hooks/useCodeblock'
@@ -23,6 +29,12 @@ interface MarkdownProps {
   enableRawHtml?: boolean
   isUser?: boolean
   isWrapping?: boolean
+}
+interface CodeBlockProps {
+  codeBlockStyle?: string
+  showLineNumbers?: boolean
+  copiedId?: string
+  onCopy: (code: string, codeId: string) => void
 }
 
 // Cache for normalized LaTeX content
@@ -89,7 +101,9 @@ const CodeComponent = memo(
     onCopy,
     copiedId,
     ...props
-  }: any) => {
+  }: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> &
+    MarkdownProps &
+    CodeBlockProps) => {
     const { t } = useTranslation()
     const match = /language-(\w+)/.exec(className || '')
     const language = match ? match[1] : ''

--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -1,3 +1,4 @@
+/* eslint-disable react-hooks/exhaustive-deps */
 import ReactMarkdown, { Components } from 'react-markdown'
 import remarkGfm from 'remark-gfm'
 import remarkEmoji from 'remark-emoji'
@@ -6,14 +7,7 @@ import remarkBreaks from 'remark-breaks'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import * as prismStyles from 'react-syntax-highlighter/dist/cjs/styles/prism'
-import {
-  memo,
-  useState,
-  useMemo,
-  useCallback,
-  DetailedHTMLProps,
-  HTMLAttributes,
-} from 'react'
+import { memo, useState, useMemo, useCallback } from 'react'
 import { getReadableLanguageName } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { useCodeblock } from '@/hooks/useCodeblock'
@@ -29,12 +23,6 @@ interface MarkdownProps {
   enableRawHtml?: boolean
   isUser?: boolean
   isWrapping?: boolean
-}
-interface CodeBlockProps {
-  codeBlockStyle?: string
-  showLineNumbers?: boolean
-  copiedId?: string
-  onCopy: (code: string, codeId: string) => void
 }
 
 // Cache for normalized LaTeX content
@@ -101,9 +89,8 @@ const CodeComponent = memo(
     onCopy,
     copiedId,
     ...props
-  }: DetailedHTMLProps<HTMLAttributes<HTMLElement>, HTMLElement> &
-    MarkdownProps &
-    CodeBlockProps) => {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  }: any) => {
     const { t } = useTranslation()
     const match = /language-(\w+)/.exec(className || '')
     const language = match ? match[1] : ''

--- a/web-app/src/routes/hub/$modelId.tsx
+++ b/web-app/src/routes/hub/$modelId.tsx
@@ -21,10 +21,7 @@ import { useEffect, useMemo, useCallback, useState } from 'react'
 import { useModelProvider } from '@/hooks/useModelProvider'
 import { useDownloadStore } from '@/hooks/useDownloadStore'
 import { useServiceHub } from '@/hooks/useServiceHub'
-import type {
-  CatalogModel,
-  ModelQuant,
-} from '@/services/models/types'
+import type { CatalogModel, ModelQuant } from '@/services/models/types'
 import { Progress } from '@/components/ui/progress'
 import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
@@ -80,12 +77,13 @@ function HubModelDetailContent() {
   }, [fetchSources])
 
   const fetchRepo = useCallback(async () => {
-    const repoInfo = await serviceHub.models().fetchHuggingFaceRepo(
-      search.repo || modelId,
-      huggingfaceToken
-    )
+    const repoInfo = await serviceHub
+      .models()
+      .fetchHuggingFaceRepo(search.repo || modelId, huggingfaceToken)
     if (repoInfo) {
-      const repoDetail = serviceHub.models().convertHfRepoToCatalogModel(repoInfo)
+      const repoDetail = serviceHub
+        .models()
+        .convertHfRepoToCatalogModel(repoInfo)
       setRepoData(repoDetail || undefined)
     }
   }, [serviceHub, modelId, search, huggingfaceToken])
@@ -168,7 +166,9 @@ function HubModelDetailContent() {
       try {
         // Use the HuggingFace path for the model
         const modelPath = variant.path
-        const supported = await serviceHub.models().isModelSupported(modelPath, 8192)
+        const supported = await serviceHub
+          .models()
+          .isModelSupported(modelPath, 8192)
         setModelSupportStatus((prev) => ({
           ...prev,
           [modelKey]: supported,
@@ -473,12 +473,20 @@ function HubModelDetailContent() {
                                         addLocalDownloadingModel(
                                           variant.model_id
                                         )
-                                        serviceHub.models().pullModelWithMetadata(
-                                          variant.model_id,
-                                          variant.path,
-                                          modelData.mmproj_models?.[0]?.path,
-                                          huggingfaceToken
-                                        )
+                                        serviceHub
+                                          .models()
+                                          .pullModelWithMetadata(
+                                            variant.model_id,
+                                            variant.path,
+                                            (
+                                              modelData.mmproj_models?.find(
+                                                (e) =>
+                                                  e.model_id.toLowerCase() ===
+                                                  'mmproj-f16'
+                                              ) || modelData.mmproj_models?.[0]
+                                            )?.path,
+                                            huggingfaceToken
+                                          )
                                       }}
                                       className={cn(isDownloading && 'hidden')}
                                     >

--- a/web-app/src/routes/hub/index.tsx
+++ b/web-app/src/routes/hub/index.tsx
@@ -777,10 +777,19 @@ function HubContent() {
                                                     .pullModelWithMetadata(
                                                       variant.model_id,
                                                       variant.path,
-                                                      filteredModels[
-                                                        virtualItem.index
-                                                      ].mmproj_models?.[0]
-                                                        ?.path,
+
+                                                      (
+                                                        filteredModels[
+                                                          virtualItem.index
+                                                        ].mmproj_models?.find(
+                                                          (e) =>
+                                                            e.model_id.toLowerCase() ===
+                                                            'mmproj-f16'
+                                                        ) ||
+                                                        filteredModels[
+                                                          virtualItem.index
+                                                        ].mmproj_models?.[0]
+                                                      )?.path,
                                                       huggingfaceToken
                                                     )
                                                 }}

--- a/web-app/src/services/__tests__/models.test.ts
+++ b/web-app/src/services/__tests__/models.test.ts
@@ -22,7 +22,7 @@ Object.defineProperty(global, 'MODEL_CATALOG_URL', {
 
 describe('DefaultModelsService', () => {
   let modelsService: DefaultModelsService
-  
+
   const mockEngine = {
     list: vi.fn(),
     updateSettings: vi.fn(),
@@ -246,7 +246,9 @@ describe('DefaultModelsService', () => {
       })
       mockEngine.load.mockRejectedValue(error)
 
-      await expect(modelsService.startModel(provider, model)).rejects.toThrow(error)
+      await expect(modelsService.startModel(provider, model)).rejects.toThrow(
+        error
+      )
     })
     it('should not load model again', async () => {
       const mockSettings = {
@@ -263,7 +265,9 @@ describe('DefaultModelsService', () => {
         includes: () => true,
       })
       expect(mockEngine.load).toBeCalledTimes(0)
-      await expect(modelsService.startModel(provider, model)).resolves.toBe(undefined)
+      await expect(modelsService.startModel(provider, model)).resolves.toBe(
+        undefined
+      )
     })
   })
 
@@ -312,7 +316,9 @@ describe('DefaultModelsService', () => {
         json: vi.fn().mockResolvedValue(mockRepoData),
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toEqual(mockRepoData)
       expect(fetch).toHaveBeenCalledWith(
@@ -342,7 +348,9 @@ describe('DefaultModelsService', () => {
       )
 
       // Test with domain prefix
-      await modelsService.fetchHuggingFaceRepo('huggingface.co/microsoft/DialoGPT-medium')
+      await modelsService.fetchHuggingFaceRepo(
+        'huggingface.co/microsoft/DialoGPT-medium'
+      )
       expect(fetch).toHaveBeenCalledWith(
         'https://huggingface.co/api/models/microsoft/DialoGPT-medium?blobs=true&files_metadata=true',
         {
@@ -365,7 +373,9 @@ describe('DefaultModelsService', () => {
       expect(await modelsService.fetchHuggingFaceRepo('')).toBeNull()
 
       // Test string without slash
-      expect(await modelsService.fetchHuggingFaceRepo('invalid-repo')).toBeNull()
+      expect(
+        await modelsService.fetchHuggingFaceRepo('invalid-repo')
+      ).toBeNull()
 
       // Test whitespace only
       expect(await modelsService.fetchHuggingFaceRepo('   ')).toBeNull()
@@ -378,7 +388,8 @@ describe('DefaultModelsService', () => {
         statusText: 'Not Found',
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('nonexistent/model')
+      const result =
+        await modelsService.fetchHuggingFaceRepo('nonexistent/model')
 
       expect(result).toBeNull()
       expect(fetch).toHaveBeenCalledWith(
@@ -398,7 +409,9 @@ describe('DefaultModelsService', () => {
         statusText: 'Internal Server Error',
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toBeNull()
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -414,7 +427,9 @@ describe('DefaultModelsService', () => {
 
       ;(fetch as any).mockRejectedValue(new Error('Network error'))
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toBeNull()
       expect(consoleSpy).toHaveBeenCalledWith(
@@ -448,7 +463,9 @@ describe('DefaultModelsService', () => {
         json: vi.fn().mockResolvedValue(mockRepoData),
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toEqual(mockRepoData)
     })
@@ -487,7 +504,9 @@ describe('DefaultModelsService', () => {
         json: vi.fn().mockResolvedValue(mockRepoData),
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toEqual(mockRepoData)
     })
@@ -531,7 +550,9 @@ describe('DefaultModelsService', () => {
         json: vi.fn().mockResolvedValue(mockRepoData),
       })
 
-      const result = await modelsService.fetchHuggingFaceRepo('microsoft/DialoGPT-medium')
+      const result = await modelsService.fetchHuggingFaceRepo(
+        'microsoft/DialoGPT-medium'
+      )
 
       expect(result).toEqual(mockRepoData)
       // Verify the GGUF file is present in siblings
@@ -576,7 +597,8 @@ describe('DefaultModelsService', () => {
     }
 
     it('should convert HuggingFace repo to catalog model format', () => {
-      const result = modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
 
       const expected: CatalogModel = {
         model_name: 'microsoft/DialoGPT-medium',
@@ -586,12 +608,12 @@ describe('DefaultModelsService', () => {
         num_quants: 2,
         quants: [
           {
-            model_id: 'model-q4_0',
+            model_id: 'microsoft/model-q4_0',
             path: 'https://huggingface.co/microsoft/DialoGPT-medium/resolve/main/model-q4_0.gguf',
             file_size: '2.0 GB',
           },
           {
-            model_id: 'model-q8_0',
+            model_id: 'microsoft/model-q8_0',
             path: 'https://huggingface.co/microsoft/DialoGPT-medium/resolve/main/model-q8_0.GGUF',
             file_size: '4.0 GB',
           },
@@ -635,7 +657,8 @@ describe('DefaultModelsService', () => {
         siblings: undefined,
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithoutSiblings)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithoutSiblings)
 
       expect(result.num_quants).toBe(0)
       expect(result.quants).toEqual([])
@@ -663,7 +686,9 @@ describe('DefaultModelsService', () => {
         ],
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithVariousFileSizes)
+      const result = modelsService.convertHfRepoToCatalogModel(
+        repoWithVariousFileSizes
+      )
 
       expect(result.quants[0].file_size).toBe('500.0 MB')
       expect(result.quants[1].file_size).toBe('3.5 GB')
@@ -676,7 +701,8 @@ describe('DefaultModelsService', () => {
         tags: [],
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithEmptyTags)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithEmptyTags)
 
       expect(result.description).toBe('**Tags**: ')
     })
@@ -687,7 +713,8 @@ describe('DefaultModelsService', () => {
         downloads: undefined as any,
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithoutDownloads)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithoutDownloads)
 
       expect(result.downloads).toBe(0)
     })
@@ -714,15 +741,17 @@ describe('DefaultModelsService', () => {
         ],
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithVariousGGUF)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithVariousGGUF)
 
-      expect(result.quants[0].model_id).toBe('model')
-      expect(result.quants[1].model_id).toBe('MODEL')
-      expect(result.quants[2].model_id).toBe('complex-model-name')
+      expect(result.quants[0].model_id).toBe('microsoft/model')
+      expect(result.quants[1].model_id).toBe('microsoft/MODEL')
+      expect(result.quants[2].model_id).toBe('microsoft/complex-model-name')
     })
 
     it('should generate correct download paths', () => {
-      const result = modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
 
       expect(result.quants[0].path).toBe(
         'https://huggingface.co/microsoft/DialoGPT-medium/resolve/main/model-q4_0.gguf'
@@ -733,7 +762,8 @@ describe('DefaultModelsService', () => {
     })
 
     it('should generate correct readme URL', () => {
-      const result = modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(mockHuggingFaceRepo)
 
       expect(result.readme).toBe(
         'https://huggingface.co/microsoft/DialoGPT-medium/resolve/main/README.md'
@@ -767,13 +797,14 @@ describe('DefaultModelsService', () => {
         ],
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithMixedCase)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithMixedCase)
 
       expect(result.num_quants).toBe(3)
       expect(result.quants).toHaveLength(3)
-      expect(result.quants[0].model_id).toBe('model-1')
-      expect(result.quants[1].model_id).toBe('model-2')
-      expect(result.quants[2].model_id).toBe('model-3')
+      expect(result.quants[0].model_id).toBe('microsoft/model-1')
+      expect(result.quants[1].model_id).toBe('microsoft/model-2')
+      expect(result.quants[2].model_id).toBe('microsoft/model-3')
     })
 
     it('should handle edge cases with file size formatting', () => {
@@ -798,7 +829,8 @@ describe('DefaultModelsService', () => {
         ],
       }
 
-      const result = modelsService.convertHfRepoToCatalogModel(repoWithEdgeCases)
+      const result =
+        modelsService.convertHfRepoToCatalogModel(repoWithEdgeCases)
 
       expect(result.quants[0].file_size).toBe('0.0 MB')
       expect(result.quants[1].file_size).toBe('1.0 GB')
@@ -850,7 +882,10 @@ describe('DefaultModelsService', () => {
 
       mockEngineManager.get.mockReturnValue(mockEngineWithSupport)
 
-      const result = await modelsService.isModelSupported('/path/to/model.gguf', 4096)
+      const result = await modelsService.isModelSupported(
+        '/path/to/model.gguf',
+        4096
+      )
 
       expect(result).toBe('GREEN')
       expect(mockEngineWithSupport.isModelSupported).toHaveBeenCalledWith(
@@ -867,7 +902,10 @@ describe('DefaultModelsService', () => {
 
       mockEngineManager.get.mockReturnValue(mockEngineWithSupport)
 
-      const result = await modelsService.isModelSupported('/path/to/model.gguf', 8192)
+      const result = await modelsService.isModelSupported(
+        '/path/to/model.gguf',
+        8192
+      )
 
       expect(result).toBe('YELLOW')
       expect(mockEngineWithSupport.isModelSupported).toHaveBeenCalledWith(
@@ -884,7 +922,9 @@ describe('DefaultModelsService', () => {
 
       mockEngineManager.get.mockReturnValue(mockEngineWithSupport)
 
-      const result = await modelsService.isModelSupported('/path/to/large-model.gguf')
+      const result = await modelsService.isModelSupported(
+        '/path/to/large-model.gguf'
+      )
 
       expect(result).toBe('RED')
       expect(mockEngineWithSupport.isModelSupported).toHaveBeenCalledWith(

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -131,7 +131,7 @@ export class DefaultModelsService implements ModelsService {
       const modelId = file.rfilename.replace(/\.gguf$/i, '')
 
       return {
-        model_id: sanitizeModelId(modelId),
+        model_id: `${repo.modelId}/${sanitizeModelId(modelId)}`,
         path: `https://huggingface.co/${repo.modelId}/resolve/main/${file.rfilename}`,
         file_size: formatFileSize(file.size),
       }

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -131,7 +131,7 @@ export class DefaultModelsService implements ModelsService {
       const modelId = file.rfilename.replace(/\.gguf$/i, '')
 
       return {
-        model_id: `${repo.modelId}/${sanitizeModelId(modelId)}`,
+        model_id: `${repo.author}/${sanitizeModelId(modelId)}`,
         path: `https://huggingface.co/${repo.modelId}/resolve/main/${file.rfilename}`,
         file_size: formatFileSize(file.size),
       }

--- a/web-app/src/services/models/default.ts
+++ b/web-app/src/services/models/default.ts
@@ -30,6 +30,10 @@ export class DefaultModelsService implements ModelsService {
     return EngineManager.instance().get(provider) as AIEngine | undefined
   }
 
+  async getModel(modelId: string): Promise<modelInfo | undefined> {
+    return this.getEngine()?.get(modelId)
+  }
+
   async fetchModels(): Promise<modelInfo[]> {
     return this.getEngine()?.list() ?? []
   }

--- a/web-app/src/services/models/types.ts
+++ b/web-app/src/services/models/types.ts
@@ -90,6 +90,7 @@ export interface ModelPlan {
 }
 
 export interface ModelsService {
+  getModel(modelId: string): Promise<modelInfo | undefined>
   fetchModels(): Promise<modelInfo[]>
   fetchModelCatalog(): Promise<ModelCatalog>
   fetchHuggingFaceRepo(


### PR DESCRIPTION
## Describe Your Changes

This PR supports downloading the same model name from different repositories.

### Context:

Users can't download the same model name from different authors or quantizers, like Qwen3-0.6B from Qwen and Unsloth.

Fix: As soon as it downloads an existing model name, it appends the repository author as a prefix to the model ID.

<img width="2272" height="1826" alt="CleanShot 2025-09-24 at 12 08 39@2x" src="https://github.com/user-attachments/assets/635cddc5-d704-4298-946a-c878edc0427e" />

<img width="2272" height="1826" alt="CleanShot 2025-09-24 at 12 08 55@2x" src="https://github.com/user-attachments/assets/7e64f5fd-317f-413c-a46d-e0e4aa28956d" />

Notes:
It works better with #5329. FE checks for existing models and shows the Use/Download button accordingly. We don't add the author's name to the model ID by default (otherwise, it'd create a complex ID), so users can change the model name if they want the Download button to show properly.
This PR also fixed the issue where app download mmproj-bf16 instead of mmproj-f16 by default. (later can remove this if model catalog returns only 1 mmproj file)

## Fixes Issues

- Closes #6218
- Closes #6539

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Allows downloading models with the same name from different authors by appending the author's name to the model ID and fixes a default download format issue.
> 
>   - **Behavior**:
>     - Allows downloading models with the same name from different authors by appending the author's name to the model ID in `default.ts`.
>     - Fixes issue where `mmproj-bf16` was downloaded instead of `mmproj-f16` by default in `DownloadButton.tsx`.
>   - **Functions**:
>     - Updates `getModel()` in `AIEngine` to handle author-prefixed model IDs.
>     - Modifies `pullModelWithMetadata()` in `default.ts` to fetch and use metadata for model downloads.
>   - **UI**:
>     - Adds `DownloadButtonPlaceholder` in `DownloadButton.tsx` to handle new download logic.
>     - Updates `HubModelDetailContent` in `$modelId.tsx` to reflect changes in model ID handling.
>   - **Tests**:
>     - Updates tests in `models.test.ts` to cover new model ID logic and downloading behavior.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for ac319b23c789dded12f4de35bdef256d3864af70. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->