### PR TITLE
feat: add cleanup logic for windows installer

### DIFF
--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -42,6 +42,11 @@
   ${If} ${FileExists} "$INSTDIR\resources\LICENSE"
     CopyFiles /SILENT "$INSTDIR\resources\LICENSE" "$INSTDIR\LICENSE"
     DetailPrint "Copied LICENSE to install root"
+
+    ; Optional cleanup - remove from resources folder
+    Delete "$INSTDIR\resources\LICENSE"
+  ${Else}
+    DetailPrint "LICENSE not found at expected location: $INSTDIR\resources\LICENSE"
   ${EndIf}
 
   ; ---- Copy vulkan-1.dll to install root ----
@@ -51,6 +56,7 @@
     
     ; Optional cleanup - remove from resources folder
     Delete "$INSTDIR\resources\lib\vulkan-1.dll"
+
     ; Only remove the lib directory if it's empty after removing both files
     RMDir "$INSTDIR\resources\lib"
   ${Else}


### PR DESCRIPTION
This pull request introduces improvements to the installer cleanup process in the Windows NSIS hooks script. The main focus is on ensuring that unnecessary files are removed from the installation directories after they have been copied to their final locations.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add cleanup logic to `hooks.nsh` for removing unnecessary files post-installation in Windows installer.
> 
>   - **Cleanup Logic**:
>     - In `hooks.nsh`, delete `$INSTDIR\resources\LICENSE` after copying to `$INSTDIR\LICENSE`.
>     - Delete `$INSTDIR\resources\lib\vulkan-1.dll` after copying to `$INSTDIR\vulkan-1.dll`.
>     - Remove `$INSTDIR\resources\lib` directory if empty after deletions.
>   - **Logging**:
>     - Add `DetailPrint` messages for successful deletions and missing files.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 9568ff12e86401eb0c8d5321953f8bcee12d37ee. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->