### PR TITLE
feat: add vulkan runtime for window installer

### DIFF
--- a/scripts/download-lib.mjs
+++ b/scripts/download-lib.mjs
@@ -96,6 +96,23 @@ async function main() {
     }
   }
 
+  // Download Vulkan Runtime Installer
+    const vulkanRtFilename = 'VulkanRT-X64-1.4.321.0-Installer.exe'
+    const vulkanRtUrl = 'https://sdk.lunarg.com/sdk/download/1.4.321.0/windows/VulkanRT-X64-1.4.321.0-Installer.exe'
+
+    console.log(`Downloading Vulkan Runtime Installer...`)
+    const vulkanRtSavePath = path.join(tempDir, vulkanRtFilename)
+    if (!fs.existsSync(vulkanRtSavePath)) {
+      await download(vulkanRtUrl, vulkanRtSavePath)
+    }
+
+    // copy to tauri resources
+    try {
+      copySync(vulkanRtSavePath, libDir)
+    } catch (err) {
+      // Expect EEXIST error
+    }
+
   console.log('Downloads completed.')
 }
 

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -1,7 +1,13 @@
 {
   "bundle": {
     "targets": ["nsis"],
-    "resources": ["resources/pre-install/**/*", "resources/lib/vulkan-1.dll", "resources/lib/vc_redist.x64.exe", "resources/LICENSE"],
+    "resources": [
+      "resources/pre-install/**/*", 
+      "resources/lib/vulkan-1.dll", 
+      "resources/lib/vc_redist.x64.exe",
+      "resources/lib/VulkanRT-X64-1.4.321.0-Installer.exe",
+      "resources/LICENSE"
+    ],
     "externalBin": ["resources/bin/bun", "resources/bin/uv"],
     "windows": {
       "nsis": {

--- a/src-tauri/windows/hooks.nsh
+++ b/src-tauri/windows/hooks.nsh
@@ -38,6 +38,36 @@
     DetailPrint "Visual C++ Redistributable already installed (version: $0)"
   ${EndIf}
 
+  ; ---- Install Vulkan Runtime if not present ----
+  ; Check if Vulkan Runtime is installed (registry key exists)
+  ReadRegStr $2 HKLM "SOFTWARE\Khronos\Vulkan\InstalledVersions" ""
+  ${If} $2 == ""
+    ReadRegStr $2 HKLM "SOFTWARE\WOW6432Node\Khronos\Vulkan\InstalledVersions" ""
+  ${EndIf}
+
+  ${If} $2 == ""
+    DetailPrint "Vulkan Runtime not found, installing from bundled file..."
+
+    ${If} ${FileExists} "$INSTDIR\resources\lib\VulkanRT-X64-1.4.321.0-Installer.exe"
+      DetailPrint "Installing Vulkan Runtime..."
+      CopyFiles "$INSTDIR\resources\lib\VulkanRT-X64-1.4.321.0-Installer.exe" "$TEMP\VulkanRT-X64-1.4.321.0-Installer.exe"
+      ExecWait '"$TEMP\VulkanRT-X64-1.4.321.0-Installer.exe" /quiet /norestart' $3
+
+      ${If} $3 == 0
+        DetailPrint "Vulkan Runtime installed successfully"
+      ${Else}
+        DetailPrint "Vulkan Runtime installation failed with exit code: $3"
+      ${EndIf}
+
+      Delete "$TEMP\VulkanRT-X64-1.4.321.0-Installer.exe"
+      Delete "$INSTDIR\resources\lib\VulkanRT-X64-1.4.321.0-Installer.exe"
+    ${Else}
+      DetailPrint "Vulkan Runtime installer not found at expected location: $INSTDIR\resources\lib\VulkanRT-X64-1.4.321.0-Installer.exe"
+    ${EndIf}
+  ${Else}
+    DetailPrint "Vulkan Runtime already installed"
+  ${EndIf}
+
   ; ---- Copy LICENSE to install root ----
   ${If} ${FileExists} "$INSTDIR\resources\LICENSE"
     CopyFiles /SILENT "$INSTDIR\resources\LICENSE" "$INSTDIR\LICENSE"


### PR DESCRIPTION
## Describe Your Changes

This pull request adds support for automatically installing the Vulkan Runtime during Windows application setup. The changes ensure the Vulkan Runtime installer is downloaded, bundled with the app, and installed if not already present on the user's system.

## Fixes Issues

- Worked on #5979 
- Still need to bundle backends along with installer

## Self Checklist
