### PR TITLE
fix: allow users cancel backend download

### DIFF
--- a/extensions/llamacpp-extension/src/backend.ts
+++ b/extensions/llamacpp-extension/src/backend.ts
@@ -319,7 +319,10 @@ export async function downloadBackend(
     events.emit('onFileDownloadSuccess', { modelId: taskId, downloadType })
   } catch (error) {
     // Fallback: if GitHub fails, retry once with CDN
-    if (source === 'github') {
+    if (
+      source === 'github' &&
+      error?.toString() !== 'Error: Download cancelled'
+    ) {
       console.warn(`GitHub download failed, falling back to CDN:`, error)
       return await downloadBackend(backend, version, 'cdn')
     }

--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -400,6 +400,7 @@ export function DownloadManagement() {
                           className="text-main-view-fg/70 cursor-pointer"
                           title="Cancel download"
                           onClick={() => {
+                            // TODO: Consolidate cancellation logic
                             if (download.id.startsWith('llamacpp')) {
                               const downloadManager =
                                 window.core.extensionManager.getByName(

--- a/web-app/src/containers/DownloadManegement.tsx
+++ b/web-app/src/containers/DownloadManegement.tsx
@@ -400,23 +400,32 @@ export function DownloadManagement() {
                           className="text-main-view-fg/70 cursor-pointer"
                           title="Cancel download"
                           onClick={() => {
-                            serviceHub
-                              .models()
-                              .abortDownload(download.name)
-                              .then(() => {
-                                toast.info(
-                                  t('common:toast.downloadCancelled.title'),
-                                  {
-                                    id: 'cancel-download',
-                                    description: t(
-                                      'common:toast.downloadCancelled.description'
-                                    ),
-                                  }
+                            if (download.id.startsWith('llamacpp')) {
+                              const downloadManager =
+                                window.core.extensionManager.getByName(
+                                  '@janhq/download-extension'
                                 )
-                                if (downloadProcesses.length === 0) {
-                                  setIsPopoverOpen(false)
-                                }
-                              })
+
+                              downloadManager.cancelDownload(download.id)
+                            } else {
+                              serviceHub
+                                .models()
+                                .abortDownload(download.name)
+                                .then(() => {
+                                  toast.info(
+                                    t('common:toast.downloadCancelled.title'),
+                                    {
+                                      id: 'cancel-download',
+                                      description: t(
+                                        'common:toast.downloadCancelled.description'
+                                      ),
+                                    }
+                                  )
+                                  if (downloadProcesses.length === 0) {
+                                    setIsPopoverOpen(false)
+                                  }
+                                })
+                            }
                           }}
                         />
                       </div>


### PR DESCRIPTION
## Describe Your Changes

This PR allows users to cancel a backend download.

https://github.com/user-attachments/assets/abd951c5-8101-4958-bb0a-9dc611df20ab


This pull request introduces improvements to the download management and error handling logic for backend downloads. The main changes enhance the user experience by ensuring that download cancellations and fallback mechanisms work more reliably and intuitively.

**Download cancellation logic:**

* Updated the download cancellation handler in `DownloadManagement` so that downloads with IDs starting with `'llamacpp'` are cancelled using the `@janhq/download-extension`'s `cancelDownload` method, while other downloads continue to use the existing `serviceHub.models().abortDownload` method. This ensures the correct cancellation mechanism is used for different types of downloads. [[1]](diffhunk://#diff-3f20b1fc2c81e2b1ad736c8382f24d27627a894a8f7ddd6483a5df7acf3d494dR403-R410) [[2]](diffhunk://#diff-3f20b1fc2c81e2b1ad736c8382f24d27627a894a8f7ddd6483a5df7acf3d494dR428)

**Backend download fallback and error handling:**

* Improved error handling in the `downloadBackend` function to prevent unnecessary fallback attempts: now, if a GitHub download fails due to cancellation (specifically, if the error message is `'Error: Download cancelled'`), it will not retry the download via the CDN. This avoids redundant operations and respects user-initiated cancellations.

## Fixes Issues

- Closes #6132

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
