### PR TITLE
ci: update package version for tauri plugin

### DIFF
--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -79,8 +79,33 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
-          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/Cargo.toml---------"
+          cat ./src-tauri/Cargo.toml
+
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
 
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json

--- a/.github/workflows/template-tauri-build-linux-x64-external.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-external.yml
@@ -81,25 +81,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -102,25 +102,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
+++ b/.github/workflows/template-tauri-build-linux-x64-flatpak.yml
@@ -100,12 +100,35 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
-          # Temporarily enable devtool on prod build
-          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
-          cat ./src-tauri/Cargo.toml
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/Cargo.toml---------"
           cat ./src-tauri/Cargo.toml
+
+          # Temporarily enable devtool on prod build
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          cat ./src-tauri/Cargo.toml  
 
           # Change app name for beta and nightly builds
           if [ "${{ inputs.channel }}" != "stable" ]; then

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -119,25 +119,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-linux-x64.yml
+++ b/.github/workflows/template-tauri-build-linux-x64.yml
@@ -117,11 +117,34 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
-          # Temporarily enable devtool on prod build
-          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
-          cat ./src-tauri/Cargo.toml
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/Cargo.toml---------"
+          cat ./src-tauri/Cargo.toml
+
+          # Temporarily enable devtool on prod build
+          ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
           cat ./src-tauri/Cargo.toml
 
           # Change app name for beta and nightly builds

--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -42,31 +42,6 @@ jobs:
         run: |
           cargo install ctoml
 
-      - name: Create bun and uv universal
-        run: |
-          mkdir -p ./src-tauri/resources/bin/
-          cd ./src-tauri/resources/bin/
-          curl -L -o bun-darwin-x64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-x64.zip
-          curl -L -o bun-darwin-aarch64.zip https://github.com/oven-sh/bun/releases/download/bun-v1.2.10/bun-darwin-aarch64.zip
-          unzip bun-darwin-x64.zip
-          unzip bun-darwin-aarch64.zip
-          lipo -create -output bun-universal-apple-darwin bun-darwin-x64/bun bun-darwin-aarch64/bun
-          cp -f bun-darwin-aarch64/bun bun-aarch64-apple-darwin 
-          cp -f bun-darwin-x64/bun bun-x86_64-apple-darwin
-          cp -f bun-universal-apple-darwin bun
-
-          curl -L -o uv-x86_64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-x86_64-apple-darwin.tar.gz
-          curl -L -o uv-arm64.tar.gz https://github.com/astral-sh/uv/releases/download/0.6.17/uv-aarch64-apple-darwin.tar.gz
-          tar -xzf uv-x86_64.tar.gz
-          tar -xzf uv-arm64.tar.gz
-          mv uv-x86_64-apple-darwin uv-x86_64
-          mv uv-aarch64-apple-darwin uv-aarch64
-          lipo -create -output uv-universal-apple-darwin uv-x86_64/uv uv-aarch64/uv
-          cp -f uv-x86_64/uv uv-x86_64-apple-darwin
-          cp -f uv-aarch64/uv uv-aarch64-apple-darwin
-          cp -f uv-universal-apple-darwin uv
-          ls -la
-
       - name: Update app version
         run: |
           echo "Version: ${{ inputs.new_version }}"
@@ -74,8 +49,35 @@ jobs:
           mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
+          
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/Cargo.toml---------"
+          cat ./src-tauri/Cargo.toml
+          
           ctoml ./src-tauri/Cargo.toml dependencies.tauri.features[] "devtools"
+          
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
             mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json

--- a/.github/workflows/template-tauri-build-macos-external.yml
+++ b/.github/workflows/template-tauri-build-macos-external.yml
@@ -52,25 +52,25 @@ jobs:
           
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -103,25 +103,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-macos.yml
+++ b/.github/workflows/template-tauri-build-macos.yml
@@ -101,7 +101,30 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/Cargo.toml---------"
           cat ./src-tauri/Cargo.toml
 
           # Temporarily enable devtool on prod build

--- a/.github/workflows/template-tauri-build-windows-x64-external.yml
+++ b/.github/workflows/template-tauri-build-windows-x64-external.yml
@@ -54,9 +54,32 @@ jobs:
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
 
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------Cargo.toml---------"
+          echo "---------./src-tauri/Cargo.toml---------"
           cat ./src-tauri/Cargo.toml
+
           if [ "${{ inputs.channel }}" != "stable" ]; then
             jq '.plugins.updater.endpoints = ["https://delta.jan.ai/${{ inputs.channel }}/latest.json"]' ./src-tauri/tauri.conf.json > /tmp/tauri.conf.json
             mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json

--- a/.github/workflows/template-tauri-build-windows-x64-external.yml
+++ b/.github/workflows/template-tauri-build-windows-x64-external.yml
@@ -56,25 +56,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -97,9 +97,31 @@ jobs:
           mv /tmp/tauri.conf.json ./src-tauri/tauri.conf.json
           jq --arg version "${{ inputs.new_version }}" '.version = $version' web-app/package.json > /tmp/package.json
           mv /tmp/package.json web-app/package.json
+
+          # Update tauri plugin versions
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
           
+          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/tauri-plugin-hardware/package.json
+
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+
+          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          
+          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------Cargo.toml---------"
+          echo "---------./src-tauri/Cargo.toml---------"
           cat ./src-tauri/Cargo.toml
 
           # Add sign commands to tauri.windows.conf.json

--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -100,25 +100,25 @@ jobs:
 
           # Update tauri plugin versions
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-hardware/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-hardware/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-hardware/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-hardware/package.json
           
-          echo "---------./src-tauri/tauri-plugin-hardware/package.json---------"
-          cat ./src-tauri/tauri-plugin-hardware/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/package.json
 
-          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/tauri-plugin-llamacpp/package.json > /tmp/package.json
-          mv /tmp/package.json ./src-tauri/tauri-plugin-llamacpp/package.json
+          jq --arg version "${{ inputs.new_version }}" '.version = $version' ./src-tauri/plugins/tauri-plugin-llamacpp/package.json > /tmp/package.json
+          mv /tmp/package.json ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          echo "---------./src-tauri/tauri-plugin-llamacpp/package.json---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/package.json
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/package.json---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/package.json
 
-          ctoml ./src-tauri/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-hardware/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-hardware/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-hardware/Cargo.toml
           
-          ctoml ./src-tauri/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
-          echo "---------./src-tauri/tauri-plugin-llamacpp/Cargo.toml---------"
-          cat ./src-tauri/tauri-plugin-llamacpp/Cargo.toml
+          ctoml ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml package.version "${{ inputs.new_version }}"
+          echo "---------./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml---------"
+          cat ./src-tauri/plugins/tauri-plugin-llamacpp/Cargo.toml
 
           ctoml ./src-tauri/Cargo.toml package.version "${{ inputs.new_version }}"
           echo "---------./src-tauri/Cargo.toml---------"


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the build workflows for all platforms to ensure that the version numbers for the Tauri plugins (`tauri-plugin-hardware` and `tauri-plugin-llamacpp`) are consistently updated alongside the main application during the release process. It also adds extra logging for version files and removes an unused step from the macOS external workflow.

## Fixes Issues
- Closes #6580

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Updates Tauri plugin versioning in build workflows for consistency with main app version, adds logging, and removes unused macOS step.
> 
>   - **Versioning**:
>     - Updates Tauri plugin versions (`tauri-plugin-hardware`, `tauri-plugin-llamacpp`) in `package.json` and `Cargo.toml` files across all platform workflows.
>     - Ensures plugin versions are updated alongside the main application version during the release process.
>   - **Logging**:
>     - Adds logging for version files in `template-tauri-build-linux-x64-external.yml`, `template-tauri-build-linux-x64-flatpak.yml`, and `template-tauri-build-linux-x64.yml`.
>   - **Workflow Changes**:
>     - Removes unused step for creating universal binaries in `template-tauri-build-macos-external.yml`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for 45590e3188cdb8f72c26c6449cb267d2a750057d. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->