### PR TITLE
docs: update redirects

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -1,3 +1,4 @@
+/about                                          /handbook  302
 /about/                                         /handbook  302
 /about/community                                /handbook  302
 /about/handbook                                 /handbook  302
@@ -73,6 +74,6 @@
 /local-server/settings                          /docs/desktop/server-settings 302
 /local-server/tabby                             /docs/desktop/server-examples/tabby 302
 /local-server/troubleshooting                   /docs/desktop/troubleshooting 302
-/mcp/                                           /docs/desktop/mcp 302
+/mcp                                            /docs/desktop/mcp 302
 /quickstart                                     /docs/desktop/quickstart 302
 /server-examples/continue-dev                   /docs/desktop/server-examples/continue-dev 302


### PR DESCRIPTION
This pull request updates the redirect rules in the `docs/_redirects` file to improve URL handling and ensure more consistent user navigation. The main changes involve adding a new redirect and refining an existing one.

Redirect improvements:

* Added a redirect from `/about` to `/handbook` with a 302 status to match the existing redirect from `/about/`, ensuring both URLs are handled consistently.
* Updated the `/mcp/` redirect to `/mcp` (removing the trailing slash) to standardize the URL format and prevent duplicate redirects.