### PR TITLE
feat: Add make commands for ios and android development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,6 +41,15 @@ else
 	@echo "Not macOS; skipping Rust target installation."
 endif
 
+# Install required Rust targets for Android builds
+install-android-rust-targets:
+	@echo "Checking and installing Android Rust targets..."
+	@rustup target list --installed | grep -q "aarch64-linux-android" || rustup target add aarch64-linux-android
+	@rustup target list --installed | grep -q "armv7-linux-androideabi" || rustup target add armv7-linux-androideabi
+	@rustup target list --installed | grep -q "i686-linux-android" || rustup target add i686-linux-android
+	@rustup target list --installed | grep -q "x86_64-linux-android" || rustup target add x86_64-linux-android
+	@echo "Android Rust targets ready!"
+
 dev: install-and-build
 	yarn download:bin
 	yarn download:lib
@@ -63,6 +72,18 @@ serve-web-app:
 
 build-serve-web-app: build-web-app
 	yarn serve:web-app
+
+# Mobile
+dev-android: install-and-build install-android-rust-targets
+	@echo "Setting up Android development environment..."
+	@if [ ! -d "src-tauri/gen/android" ]; then \
+		echo "Android app not initialized. Initializing..."; \
+		yarn tauri android init; \
+	fi
+	@echo "Sourcing Android environment setup..."
+	@bash autoqa/scripts/setup-android-env.sh echo "Android environment ready"
+	@echo "Starting Android development server..."
+	yarn dev:android
 
 # Linting
 lint: install-and-build

--- a/extensions/yarn.lock
+++ b/extensions/yarn.lock
@@ -517,41 +517,41 @@ __metadata:
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=63c6e9&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8d4ec2&locator=%40janhq%2Fassistant-extension%40workspace%3Aassistant-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/417ea9bd3e5b53264596d2ee816c3e24299f8b721f6ea951d078342555da457ebca4d5b1e116bf187ac77ec0a9e3341211d464f4ffdbd2a3915139523688d41d
+  checksum: 10c0/0d97a222894863621508d5a95d91bde17a370608d6f452b2335bcc336dab9ddd3c53f7458381909875324c61f3d63df041995d450744780ac6b57b53f5182551
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=63c6e9&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8d4ec2&locator=%40janhq%2Fconversational-extension%40workspace%3Aconversational-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/417ea9bd3e5b53264596d2ee816c3e24299f8b721f6ea951d078342555da457ebca4d5b1e116bf187ac77ec0a9e3341211d464f4ffdbd2a3915139523688d41d
+  checksum: 10c0/0d97a222894863621508d5a95d91bde17a370608d6f452b2335bcc336dab9ddd3c53f7458381909875324c61f3d63df041995d450744780ac6b57b53f5182551
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=63c6e9&locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8d4ec2&locator=%40janhq%2Fdownload-extension%40workspace%3Adownload-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/417ea9bd3e5b53264596d2ee816c3e24299f8b721f6ea951d078342555da457ebca4d5b1e116bf187ac77ec0a9e3341211d464f4ffdbd2a3915139523688d41d
+  checksum: 10c0/0d97a222894863621508d5a95d91bde17a370608d6f452b2335bcc336dab9ddd3c53f7458381909875324c61f3d63df041995d450744780ac6b57b53f5182551
   languageName: node
   linkType: hard
 
 "@janhq/core@file:../../core/package.tgz::locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension":
   version: 0.1.10
-  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=63c6e9&locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension"
+  resolution: "@janhq/core@file:../../core/package.tgz#../../core/package.tgz::hash=8d4ec2&locator=%40janhq%2Fllamacpp-extension%40workspace%3Allamacpp-extension"
   dependencies:
     rxjs: "npm:^7.8.1"
     ulidx: "npm:^2.3.0"
-  checksum: 10c0/417ea9bd3e5b53264596d2ee816c3e24299f8b721f6ea951d078342555da457ebca4d5b1e116bf187ac77ec0a9e3341211d464f4ffdbd2a3915139523688d41d
+  checksum: 10c0/0d97a222894863621508d5a95d91bde17a370608d6f452b2335bcc336dab9ddd3c53f7458381909875324c61f3d63df041995d450744780ac6b57b53f5182551
   languageName: node
   linkType: hard
 

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -5333,6 +5333,7 @@ dependencies = [
  "sysinfo",
  "tauri",
  "tauri-plugin",
+ "tauri-plugin-hardware",
  "thiserror 2.0.12",
  "tokio",
 ]

--- a/src-tauri/capabilities/default.json
+++ b/src-tauri/capabilities/default.json
@@ -21,6 +21,7 @@
     "dialog:default",
     "core:webview:allow-create-webview-window",
     "opener:allow-open-url",
+    "store:default",
     {
       "identifier": "http:default",
       "allow": [
@@ -52,8 +53,6 @@
           "url": "http://0.0.0.0:*"
         }
       ]
-    },
-    "store:default",
-    "llamacpp:default"
+    }
   ]
 }

--- a/src-tauri/tauri.ios.conf.json
+++ b/src-tauri/tauri.ios.conf.json
@@ -3,7 +3,7 @@
     "devUrl": null,
     "frontendDist": "../web-app/dist"
   },
-  "identifier": "jan.ai.app.ios",
+  "identifier": "jan.ai.app",
   "app": {
     "security": {
       "capabilities": ["mobile"]

--- a/web-app/src/containers/RenderMarkdown.tsx
+++ b/web-app/src/containers/RenderMarkdown.tsx
@@ -7,7 +7,7 @@ import remarkBreaks from 'remark-breaks'
 import rehypeKatex from 'rehype-katex'
 import { Prism as SyntaxHighlighter } from 'react-syntax-highlighter'
 import * as prismStyles from 'react-syntax-highlighter/dist/cjs/styles/prism'
-import { memo, useState, useMemo, useCallback } from 'react'
+import React, { memo, useState, useMemo, useCallback } from 'react'
 import { getReadableLanguageName } from '@/lib/utils'
 import { cn } from '@/lib/utils'
 import { useCodeblock } from '@/hooks/useCodeblock'
@@ -154,8 +154,8 @@ const CodeComponent = memo(
             )}
           </button>
         </div>
-        <SyntaxHighlighter
-          style={
+        {React.createElement(SyntaxHighlighter as React.ComponentType<any>, {
+          style:
             prismStyles[
               codeBlockStyle
                 .split('-')
@@ -165,31 +165,27 @@ const CodeComponent = memo(
                     : part.charAt(0).toUpperCase() + part.slice(1)
                 )
                 .join('') as keyof typeof prismStyles
-            ] || prismStyles.oneLight
-          }
-          language={language}
-          showLineNumbers={showLineNumbers}
-          wrapLines={true}
-          lineProps={
-            isWrapping
-              ? {
-                  style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' },
-                }
-              : {}
-          }
-          customStyle={{
+            ] || prismStyles.oneLight,
+          language,
+          showLineNumbers,
+          wrapLines: true,
+          lineProps: isWrapping
+            ? {
+                style: { wordBreak: 'break-all', whiteSpace: 'pre-wrap' },
+              }
+            : {},
+          customStyle: {
             margin: 0,
             padding: '8px',
             borderRadius: '0 0 4px 4px',
             overflow: 'auto',
             border: 'none',
-          }}
-          PreTag="div"
-          CodeTag={'code'}
-          {...props}
-        >
-          {code}
-        </SyntaxHighlighter>
+          },
+          PreTag: 'div',
+          CodeTag: 'code',
+          ...props,
+          children: code
+        })}
       </div>
     )
   }

--- a/web-app/src/routeTree.gen.ts
+++ b/web-app/src/routeTree.gen.ts
@@ -8,329 +8,141 @@
 // You should NOT make any changes in this file as it will be overwritten.
 // Additionally, you should also exclude this file from your linter and/or formatter to prevent it from being checked or modified.
 
-// Import Routes
+import { Route as rootRouteImport } from './routes/__root'
+import { Route as SystemMonitorRouteImport } from './routes/system-monitor'
+import { Route as LogsRouteImport } from './routes/logs'
+import { Route as AssistantRouteImport } from './routes/assistant'
+import { Route as IndexRouteImport } from './routes/index'
+import { Route as ProjectIndexRouteImport } from './routes/project/index'
+import { Route as HubIndexRouteImport } from './routes/hub/index'
+import { Route as ThreadsThreadIdRouteImport } from './routes/threads/$threadId'
+import { Route as SettingsShortcutsRouteImport } from './routes/settings/shortcuts'
+import { Route as SettingsPrivacyRouteImport } from './routes/settings/privacy'
+import { Route as SettingsMcpServersRouteImport } from './routes/settings/mcp-servers'
+import { Route as SettingsLocalApiServerRouteImport } from './routes/settings/local-api-server'
+import { Route as SettingsHttpsProxyRouteImport } from './routes/settings/https-proxy'
+import { Route as SettingsHardwareRouteImport } from './routes/settings/hardware'
+import { Route as SettingsGeneralRouteImport } from './routes/settings/general'
+import { Route as SettingsExtensionsRouteImport } from './routes/settings/extensions'
+import { Route as SettingsAppearanceRouteImport } from './routes/settings/appearance'
+import { Route as ProjectProjectIdRouteImport } from './routes/project/$projectId'
+import { Route as LocalApiServerLogsRouteImport } from './routes/local-api-server/logs'
+import { Route as HubModelIdRouteImport } from './routes/hub/$modelId'
+import { Route as SettingsProvidersIndexRouteImport } from './routes/settings/providers/index'
+import { Route as SettingsProvidersProviderNameRouteImport } from './routes/settings/providers/$providerName'
+import { Route as AuthGoogleCallbackRouteImport } from './routes/auth.google.callback'
 
-import { Route as rootRoute } from './routes/__root'
-import { Route as SystemMonitorImport } from './routes/system-monitor'
-import { Route as LogsImport } from './routes/logs'
-import { Route as AssistantImport } from './routes/assistant'
-import { Route as IndexImport } from './routes/index'
-import { Route as ProjectIndexImport } from './routes/project/index'
-import { Route as HubIndexImport } from './routes/hub/index'
-import { Route as ThreadsThreadIdImport } from './routes/threads/$threadId'
-import { Route as SettingsShortcutsImport } from './routes/settings/shortcuts'
-import { Route as SettingsPrivacyImport } from './routes/settings/privacy'
-import { Route as SettingsMcpServersImport } from './routes/settings/mcp-servers'
-import { Route as SettingsLocalApiServerImport } from './routes/settings/local-api-server'
-import { Route as SettingsHttpsProxyImport } from './routes/settings/https-proxy'
-import { Route as SettingsHardwareImport } from './routes/settings/hardware'
-import { Route as SettingsGeneralImport } from './routes/settings/general'
-import { Route as SettingsExtensionsImport } from './routes/settings/extensions'
-import { Route as SettingsAppearanceImport } from './routes/settings/appearance'
-import { Route as ProjectProjectIdImport } from './routes/project/$projectId'
-import { Route as LocalApiServerLogsImport } from './routes/local-api-server/logs'
-import { Route as HubModelIdImport } from './routes/hub/$modelId'
-import { Route as SettingsProvidersIndexImport } from './routes/settings/providers/index'
-import { Route as SettingsProvidersProviderNameImport } from './routes/settings/providers/$providerName'
-import { Route as AuthGoogleCallbackImport } from './routes/auth.google.callback'
-
-// Create/Update Routes
-
-const SystemMonitorRoute = SystemMonitorImport.update({
+const SystemMonitorRoute = SystemMonitorRouteImport.update({
   id: '/system-monitor',
   path: '/system-monitor',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const LogsRoute = LogsImport.update({
+const LogsRoute = LogsRouteImport.update({
   id: '/logs',
   path: '/logs',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const AssistantRoute = AssistantImport.update({
+const AssistantRoute = AssistantRouteImport.update({
   id: '/assistant',
   path: '/assistant',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const IndexRoute = IndexImport.update({
+const IndexRoute = IndexRouteImport.update({
   id: '/',
   path: '/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const ProjectIndexRoute = ProjectIndexImport.update({
+const ProjectIndexRoute = ProjectIndexRouteImport.update({
   id: '/project/',
   path: '/project/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const HubIndexRoute = HubIndexImport.update({
+const HubIndexRoute = HubIndexRouteImport.update({
   id: '/hub/',
   path: '/hub/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const ThreadsThreadIdRoute = ThreadsThreadIdImport.update({
+const ThreadsThreadIdRoute = ThreadsThreadIdRouteImport.update({
   id: '/threads/$threadId',
   path: '/threads/$threadId',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsShortcutsRoute = SettingsShortcutsImport.update({
+const SettingsShortcutsRoute = SettingsShortcutsRouteImport.update({
   id: '/settings/shortcuts',
   path: '/settings/shortcuts',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsPrivacyRoute = SettingsPrivacyImport.update({
+const SettingsPrivacyRoute = SettingsPrivacyRouteImport.update({
   id: '/settings/privacy',
   path: '/settings/privacy',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsMcpServersRoute = SettingsMcpServersImport.update({
+const SettingsMcpServersRoute = SettingsMcpServersRouteImport.update({
   id: '/settings/mcp-servers',
   path: '/settings/mcp-servers',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsLocalApiServerRoute = SettingsLocalApiServerImport.update({
+const SettingsLocalApiServerRoute = SettingsLocalApiServerRouteImport.update({
   id: '/settings/local-api-server',
   path: '/settings/local-api-server',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsHttpsProxyRoute = SettingsHttpsProxyImport.update({
+const SettingsHttpsProxyRoute = SettingsHttpsProxyRouteImport.update({
   id: '/settings/https-proxy',
   path: '/settings/https-proxy',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsHardwareRoute = SettingsHardwareImport.update({
+const SettingsHardwareRoute = SettingsHardwareRouteImport.update({
   id: '/settings/hardware',
   path: '/settings/hardware',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsGeneralRoute = SettingsGeneralImport.update({
+const SettingsGeneralRoute = SettingsGeneralRouteImport.update({
   id: '/settings/general',
   path: '/settings/general',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsExtensionsRoute = SettingsExtensionsImport.update({
+const SettingsExtensionsRoute = SettingsExtensionsRouteImport.update({
   id: '/settings/extensions',
   path: '/settings/extensions',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsAppearanceRoute = SettingsAppearanceImport.update({
+const SettingsAppearanceRoute = SettingsAppearanceRouteImport.update({
   id: '/settings/appearance',
   path: '/settings/appearance',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const ProjectProjectIdRoute = ProjectProjectIdImport.update({
+const ProjectProjectIdRoute = ProjectProjectIdRouteImport.update({
   id: '/project/$projectId',
   path: '/project/$projectId',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const LocalApiServerLogsRoute = LocalApiServerLogsImport.update({
+const LocalApiServerLogsRoute = LocalApiServerLogsRouteImport.update({
   id: '/local-api-server/logs',
   path: '/local-api-server/logs',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const HubModelIdRoute = HubModelIdImport.update({
+const HubModelIdRoute = HubModelIdRouteImport.update({
   id: '/hub/$modelId',
   path: '/hub/$modelId',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-const SettingsProvidersIndexRoute = SettingsProvidersIndexImport.update({
+const SettingsProvidersIndexRoute = SettingsProvidersIndexRouteImport.update({
   id: '/settings/providers/',
   path: '/settings/providers/',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
 const SettingsProvidersProviderNameRoute =
-  SettingsProvidersProviderNameImport.update({
+  SettingsProvidersProviderNameRouteImport.update({
     id: '/settings/providers/$providerName',
     path: '/settings/providers/$providerName',
-    getParentRoute: () => rootRoute,
+    getParentRoute: () => rootRouteImport,
   } as any)
-
-const AuthGoogleCallbackRoute = AuthGoogleCallbackImport.update({
+const AuthGoogleCallbackRoute = AuthGoogleCallbackRouteImport.update({
   id: '/auth/google/callback',
   path: '/auth/google/callback',
-  getParentRoute: () => rootRoute,
+  getParentRoute: () => rootRouteImport,
 } as any)
-
-// Populate the FileRoutesByPath interface
-
-declare module '@tanstack/react-router' {
-  interface FileRoutesByPath {
-    '/': {
-      id: '/'
-      path: '/'
-      fullPath: '/'
-      preLoaderRoute: typeof IndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/assistant': {
-      id: '/assistant'
-      path: '/assistant'
-      fullPath: '/assistant'
-      preLoaderRoute: typeof AssistantImport
-      parentRoute: typeof rootRoute
-    }
-    '/logs': {
-      id: '/logs'
-      path: '/logs'
-      fullPath: '/logs'
-      preLoaderRoute: typeof LogsImport
-      parentRoute: typeof rootRoute
-    }
-    '/system-monitor': {
-      id: '/system-monitor'
-      path: '/system-monitor'
-      fullPath: '/system-monitor'
-      preLoaderRoute: typeof SystemMonitorImport
-      parentRoute: typeof rootRoute
-    }
-    '/hub/$modelId': {
-      id: '/hub/$modelId'
-      path: '/hub/$modelId'
-      fullPath: '/hub/$modelId'
-      preLoaderRoute: typeof HubModelIdImport
-      parentRoute: typeof rootRoute
-    }
-    '/local-api-server/logs': {
-      id: '/local-api-server/logs'
-      path: '/local-api-server/logs'
-      fullPath: '/local-api-server/logs'
-      preLoaderRoute: typeof LocalApiServerLogsImport
-      parentRoute: typeof rootRoute
-    }
-    '/project/$projectId': {
-      id: '/project/$projectId'
-      path: '/project/$projectId'
-      fullPath: '/project/$projectId'
-      preLoaderRoute: typeof ProjectProjectIdImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/appearance': {
-      id: '/settings/appearance'
-      path: '/settings/appearance'
-      fullPath: '/settings/appearance'
-      preLoaderRoute: typeof SettingsAppearanceImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/extensions': {
-      id: '/settings/extensions'
-      path: '/settings/extensions'
-      fullPath: '/settings/extensions'
-      preLoaderRoute: typeof SettingsExtensionsImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/general': {
-      id: '/settings/general'
-      path: '/settings/general'
-      fullPath: '/settings/general'
-      preLoaderRoute: typeof SettingsGeneralImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/hardware': {
-      id: '/settings/hardware'
-      path: '/settings/hardware'
-      fullPath: '/settings/hardware'
-      preLoaderRoute: typeof SettingsHardwareImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/https-proxy': {
-      id: '/settings/https-proxy'
-      path: '/settings/https-proxy'
-      fullPath: '/settings/https-proxy'
-      preLoaderRoute: typeof SettingsHttpsProxyImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/local-api-server': {
-      id: '/settings/local-api-server'
-      path: '/settings/local-api-server'
-      fullPath: '/settings/local-api-server'
-      preLoaderRoute: typeof SettingsLocalApiServerImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/mcp-servers': {
-      id: '/settings/mcp-servers'
-      path: '/settings/mcp-servers'
-      fullPath: '/settings/mcp-servers'
-      preLoaderRoute: typeof SettingsMcpServersImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/privacy': {
-      id: '/settings/privacy'
-      path: '/settings/privacy'
-      fullPath: '/settings/privacy'
-      preLoaderRoute: typeof SettingsPrivacyImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/shortcuts': {
-      id: '/settings/shortcuts'
-      path: '/settings/shortcuts'
-      fullPath: '/settings/shortcuts'
-      preLoaderRoute: typeof SettingsShortcutsImport
-      parentRoute: typeof rootRoute
-    }
-    '/threads/$threadId': {
-      id: '/threads/$threadId'
-      path: '/threads/$threadId'
-      fullPath: '/threads/$threadId'
-      preLoaderRoute: typeof ThreadsThreadIdImport
-      parentRoute: typeof rootRoute
-    }
-    '/hub/': {
-      id: '/hub/'
-      path: '/hub'
-      fullPath: '/hub'
-      preLoaderRoute: typeof HubIndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/project/': {
-      id: '/project/'
-      path: '/project'
-      fullPath: '/project'
-      preLoaderRoute: typeof ProjectIndexImport
-      parentRoute: typeof rootRoute
-    }
-    '/auth/google/callback': {
-      id: '/auth/google/callback'
-      path: '/auth/google/callback'
-      fullPath: '/auth/google/callback'
-      preLoaderRoute: typeof AuthGoogleCallbackImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/providers/$providerName': {
-      id: '/settings/providers/$providerName'
-      path: '/settings/providers/$providerName'
-      fullPath: '/settings/providers/$providerName'
-      preLoaderRoute: typeof SettingsProvidersProviderNameImport
-      parentRoute: typeof rootRoute
-    }
-    '/settings/providers/': {
-      id: '/settings/providers/'
-      path: '/settings/providers'
-      fullPath: '/settings/providers'
-      preLoaderRoute: typeof SettingsProvidersIndexImport
-      parentRoute: typeof rootRoute
-    }
-  }
-}
-
-// Create and export the route tree
 
 export interface FileRoutesByFullPath {
   '/': typeof IndexRoute
@@ -356,7 +168,6 @@ export interface FileRoutesByFullPath {
   '/settings/providers/$providerName': typeof SettingsProvidersProviderNameRoute
   '/settings/providers': typeof SettingsProvidersIndexRoute
 }
-
 export interface FileRoutesByTo {
   '/': typeof IndexRoute
   '/assistant': typeof AssistantRoute
@@ -381,9 +192,8 @@ export interface FileRoutesByTo {
   '/settings/providers/$providerName': typeof SettingsProvidersProviderNameRoute
   '/settings/providers': typeof SettingsProvidersIndexRoute
 }
-
 export interface FileRoutesById {
-  '__root__': typeof rootRoute
+  __root__: typeof rootRouteImport
   '/': typeof IndexRoute
   '/assistant': typeof AssistantRoute
   '/logs': typeof LogsRoute
@@ -407,7 +217,6 @@ export interface FileRoutesById {
   '/settings/providers/$providerName': typeof SettingsProvidersProviderNameRoute
   '/settings/providers/': typeof SettingsProvidersIndexRoute
 }
-
 export interface FileRouteTypes {
   fileRoutesByFullPath: FileRoutesByFullPath
   fullPaths:
@@ -483,7 +292,6 @@ export interface FileRouteTypes {
     | '/settings/providers/'
   fileRoutesById: FileRoutesById
 }
-
 export interface RootRouteChildren {
   IndexRoute: typeof IndexRoute
   AssistantRoute: typeof AssistantRoute
@@ -507,6 +315,165 @@ export interface RootRouteChildren {
   AuthGoogleCallbackRoute: typeof AuthGoogleCallbackRoute
   SettingsProvidersProviderNameRoute: typeof SettingsProvidersProviderNameRoute
   SettingsProvidersIndexRoute: typeof SettingsProvidersIndexRoute
+}
+
+declare module '@tanstack/react-router' {
+  interface FileRoutesByPath {
+    '/system-monitor': {
+      id: '/system-monitor'
+      path: '/system-monitor'
+      fullPath: '/system-monitor'
+      preLoaderRoute: typeof SystemMonitorRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/logs': {
+      id: '/logs'
+      path: '/logs'
+      fullPath: '/logs'
+      preLoaderRoute: typeof LogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/assistant': {
+      id: '/assistant'
+      path: '/assistant'
+      fullPath: '/assistant'
+      preLoaderRoute: typeof AssistantRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/': {
+      id: '/'
+      path: '/'
+      fullPath: '/'
+      preLoaderRoute: typeof IndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/project/': {
+      id: '/project/'
+      path: '/project'
+      fullPath: '/project'
+      preLoaderRoute: typeof ProjectIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hub/': {
+      id: '/hub/'
+      path: '/hub'
+      fullPath: '/hub'
+      preLoaderRoute: typeof HubIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/threads/$threadId': {
+      id: '/threads/$threadId'
+      path: '/threads/$threadId'
+      fullPath: '/threads/$threadId'
+      preLoaderRoute: typeof ThreadsThreadIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/shortcuts': {
+      id: '/settings/shortcuts'
+      path: '/settings/shortcuts'
+      fullPath: '/settings/shortcuts'
+      preLoaderRoute: typeof SettingsShortcutsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/privacy': {
+      id: '/settings/privacy'
+      path: '/settings/privacy'
+      fullPath: '/settings/privacy'
+      preLoaderRoute: typeof SettingsPrivacyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/mcp-servers': {
+      id: '/settings/mcp-servers'
+      path: '/settings/mcp-servers'
+      fullPath: '/settings/mcp-servers'
+      preLoaderRoute: typeof SettingsMcpServersRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/local-api-server': {
+      id: '/settings/local-api-server'
+      path: '/settings/local-api-server'
+      fullPath: '/settings/local-api-server'
+      preLoaderRoute: typeof SettingsLocalApiServerRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/https-proxy': {
+      id: '/settings/https-proxy'
+      path: '/settings/https-proxy'
+      fullPath: '/settings/https-proxy'
+      preLoaderRoute: typeof SettingsHttpsProxyRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/hardware': {
+      id: '/settings/hardware'
+      path: '/settings/hardware'
+      fullPath: '/settings/hardware'
+      preLoaderRoute: typeof SettingsHardwareRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/general': {
+      id: '/settings/general'
+      path: '/settings/general'
+      fullPath: '/settings/general'
+      preLoaderRoute: typeof SettingsGeneralRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/extensions': {
+      id: '/settings/extensions'
+      path: '/settings/extensions'
+      fullPath: '/settings/extensions'
+      preLoaderRoute: typeof SettingsExtensionsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/appearance': {
+      id: '/settings/appearance'
+      path: '/settings/appearance'
+      fullPath: '/settings/appearance'
+      preLoaderRoute: typeof SettingsAppearanceRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/project/$projectId': {
+      id: '/project/$projectId'
+      path: '/project/$projectId'
+      fullPath: '/project/$projectId'
+      preLoaderRoute: typeof ProjectProjectIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/local-api-server/logs': {
+      id: '/local-api-server/logs'
+      path: '/local-api-server/logs'
+      fullPath: '/local-api-server/logs'
+      preLoaderRoute: typeof LocalApiServerLogsRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/hub/$modelId': {
+      id: '/hub/$modelId'
+      path: '/hub/$modelId'
+      fullPath: '/hub/$modelId'
+      preLoaderRoute: typeof HubModelIdRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/providers/': {
+      id: '/settings/providers/'
+      path: '/settings/providers'
+      fullPath: '/settings/providers'
+      preLoaderRoute: typeof SettingsProvidersIndexRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/settings/providers/$providerName': {
+      id: '/settings/providers/$providerName'
+      path: '/settings/providers/$providerName'
+      fullPath: '/settings/providers/$providerName'
+      preLoaderRoute: typeof SettingsProvidersProviderNameRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+    '/auth/google/callback': {
+      id: '/auth/google/callback'
+      path: '/auth/google/callback'
+      fullPath: '/auth/google/callback'
+      preLoaderRoute: typeof AuthGoogleCallbackRouteImport
+      parentRoute: typeof rootRouteImport
+    }
+  }
 }
 
 const rootRouteChildren: RootRouteChildren = {
@@ -533,107 +500,6 @@ const rootRouteChildren: RootRouteChildren = {
   SettingsProvidersProviderNameRoute: SettingsProvidersProviderNameRoute,
   SettingsProvidersIndexRoute: SettingsProvidersIndexRoute,
 }
-
-export const routeTree = rootRoute
+export const routeTree = rootRouteImport
   ._addFileChildren(rootRouteChildren)
   ._addFileTypes<FileRouteTypes>()
-
-/* ROUTE_MANIFEST_START
-{
-  "routes": {
-    "__root__": {
-      "filePath": "__root.tsx",
-      "children": [
-        "/",
-        "/assistant",
-        "/logs",
-        "/system-monitor",
-        "/hub/$modelId",
-        "/local-api-server/logs",
-        "/project/$projectId",
-        "/settings/appearance",
-        "/settings/extensions",
-        "/settings/general",
-        "/settings/hardware",
-        "/settings/https-proxy",
-        "/settings/local-api-server",
-        "/settings/mcp-servers",
-        "/settings/privacy",
-        "/settings/shortcuts",
-        "/threads/$threadId",
-        "/hub/",
-        "/project/",
-        "/auth/google/callback",
-        "/settings/providers/$providerName",
-        "/settings/providers/"
-      ]
-    },
-    "/": {
-      "filePath": "index.tsx"
-    },
-    "/assistant": {
-      "filePath": "assistant.tsx"
-    },
-    "/logs": {
-      "filePath": "logs.tsx"
-    },
-    "/system-monitor": {
-      "filePath": "system-monitor.tsx"
-    },
-    "/hub/$modelId": {
-      "filePath": "hub/$modelId.tsx"
-    },
-    "/local-api-server/logs": {
-      "filePath": "local-api-server/logs.tsx"
-    },
-    "/project/$projectId": {
-      "filePath": "project/$projectId.tsx"
-    },
-    "/settings/appearance": {
-      "filePath": "settings/appearance.tsx"
-    },
-    "/settings/extensions": {
-      "filePath": "settings/extensions.tsx"
-    },
-    "/settings/general": {
-      "filePath": "settings/general.tsx"
-    },
-    "/settings/hardware": {
-      "filePath": "settings/hardware.tsx"
-    },
-    "/settings/https-proxy": {
-      "filePath": "settings/https-proxy.tsx"
-    },
-    "/settings/local-api-server": {
-      "filePath": "settings/local-api-server.tsx"
-    },
-    "/settings/mcp-servers": {
-      "filePath": "settings/mcp-servers.tsx"
-    },
-    "/settings/privacy": {
-      "filePath": "settings/privacy.tsx"
-    },
-    "/settings/shortcuts": {
-      "filePath": "settings/shortcuts.tsx"
-    },
-    "/threads/$threadId": {
-      "filePath": "threads/$threadId.tsx"
-    },
-    "/hub/": {
-      "filePath": "hub/index.tsx"
-    },
-    "/project/": {
-      "filePath": "project/index.tsx"
-    },
-    "/auth/google/callback": {
-      "filePath": "auth.google.callback.tsx"
-    },
-    "/settings/providers/$providerName": {
-      "filePath": "settings/providers/$providerName.tsx"
-    },
-    "/settings/providers/": {
-      "filePath": "settings/providers/index.tsx"
-    }
-  }
-}
-ROUTE_MANIFEST_END */


### PR DESCRIPTION
## Describe Your Changes

- Reconfig iOS build scheme
- Add make command for Android development
- Add make command for iOS development

### For iOS:
- Assuming you are running on MacOS, since iOS can only be built here
- Install XCode, iOS simulator, and XCode command line tools
- Just run `make dev-ios`

### For Android: (Experimented on MacOS)
- Install Android Studio, Android simulator, and Android NDK
- Just run `make dev-android`

### Multiple simulators and real device deployment:
- If you have many build destination options (simulators), select your desired machine
- If you want to build to your real device, turn up developer mode on your device first. 
  -  [Turn on iOS developer mode](https://developer.apple.com/documentation/xcode/enabling-developer-mode-on-a-device)
  - [Turn on Android developer mode](https://www.android.com/intl/en_uk/articles/enable-android-developer-settings/)

Then the `make` command will allow you to select your device from the destination options list.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [x] Added relevant comments, esp in complex areas
- [x] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
