### PR TITLE
enhancement: update statistic number jan web

### DIFF
--- a/docs/src/components/Home/index.tsx
+++ b/docs/src/components/Home/index.tsx
@@ -95,7 +95,7 @@ const Home = () => {
           <div className="container mx-auto relative z-10">
             <div className="flex justify-center items-center mt-14 lg:mt-20 px-4">
               <a
-                href=""
+                href={`https://github.com/menloresearch/jan/releases/tag/${lastVersion}`}
                 target="_blank"
                 rel="noopener noreferrer"
                 className="bg-black/40 px-3 lg:px-4 rounded-full h-10 inline-flex items-center max-w-full animate-fade-in delay-100"

--- a/docs/src/components/Home/index.tsx
+++ b/docs/src/components/Home/index.tsx
@@ -109,7 +109,7 @@ const Home = () => {
                 </span>
               </a>
             </div>
-            <div className="mt-10">
+            <div className="mt-4">
               <div className="text-center relative lg:w-1/2 mx-auto">
                 <div className="flex flex-col lg:flex-row items-center justify-center gap-4 animate-fade-in-up delay-300">
                   <span>
@@ -127,12 +127,17 @@ const Home = () => {
                   The best of open-source AI in an easy-to-use product.
                 </p>
               </div>
-              <div className="flex px-4 flex-col lg:flex-row items-center gap-4 w-full justify-center text-center animate-fade-in-up delay-600 mt-8 lg:mt-10">
-                <DropdownButton
-                  size="xxl"
-                  className="w-full !rounded-[20px] lg:w-auto"
-                  lastRelease={lastRelease}
-                />
+              <div className="flex px-4 flex-col lg:flex-row items-start gap-4 w-full justify-center text-center animate-fade-in-up delay-600 mt-8 lg:mt-10">
+                <div>
+                  <DropdownButton
+                    size="xxl"
+                    className="w-full !rounded-[20px] lg:w-auto"
+                    lastRelease={lastRelease}
+                  />
+                  <div className="font-medium text-center mt-2 text-white">
+                    +{totalDownload(release)} downloads
+                  </div>
+                </div>
                 <a
                   href="https://discord.com/invite/FTk2MvZwJH"
                   target="_blank"
@@ -189,7 +194,8 @@ const Home = () => {
                         </defs>
                       </svg>
                       <span className="text-sm">
-                        {formatCompactNumber(discordWidget.presence_count)}
+                        15k+
+                        {/* {formatCompactNumber(discordWidget.presence_count)} */}
                       </span>
                     </div>
                   </Button>
@@ -198,7 +204,7 @@ const Home = () => {
             </div>
           </div>
 
-          <div className="absolute w-full bottom-0 left-0 flex justify-center">
+          <div className="absolute w-full -bottom-10 left-0 flex justify-center">
             <img
               className="abs animate-float scale-[175%] md:scale-100"
               src={CuteRobotFlyingPNG.src}
@@ -448,9 +454,10 @@ const Home = () => {
                           <div className="flex items-center gap-1 ml-3">
                             <IoMdPeople className="size-5" />
                             <span className="text-sm">
-                              {formatCompactNumber(
+                              15k+
+                              {/* {formatCompactNumber(
                                 discordWidget.presence_count
-                              )}
+                              )} */}
                             </span>
                           </div>
                         </Button>
@@ -483,9 +490,10 @@ const Home = () => {
                           <div className="flex items-center gap-1 ml-3">
                             <IoMdPeople className="size-5" />
                             <span className="text-sm">
-                              {formatCompactNumber(
+                              15k+
+                              {/* {formatCompactNumber(
                                 discordWidget.presence_count
-                              )}
+                              )} */}
                             </span>
                           </div>
                         </Button>


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the homepage UI in `docs/src/components/Home/index.tsx` with minor layout adjustments and changes to how Discord presence and download statistics are displayed. The most important changes are grouped below:

**UI and Layout Improvements:**

* Reduced top margin in the main content section from `mt-10` to `mt-4` for a more compact look.
* Adjusted the layout of the button section to align items to the start instead of center, and wrapped the download stats with the dropdown button for better visual grouping.
* Moved the floating robot image lower by changing its position from `bottom-0` to `-bottom-10`.

**Statistics Display Changes:**

* Replaced the dynamic Discord presence count with a static `15k+` value in multiple places, commenting out the previous dynamic code for future reference. [[1]](diffhunk://#diff-4b089dcb809bb99abeebee60177aecb1ae460b95006e1cfdbd6093933cd4481aL192-R198) [[2]](diffhunk://#diff-4b089dcb809bb99abeebee60177aecb1ae460b95006e1cfdbd6093933cd4481aL451-R460) [[3]](diffhunk://#diff-4b089dcb809bb99abeebee60177aecb1ae460b95006e1cfdbd6093933cd4481aL486-R496)
* Added a new download count display below the dropdown button, showing the total downloads in a prominent font.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Update homepage UI in `index.tsx` with layout adjustments and static display of Discord presence and download statistics.
> 
>   - **UI and Layout**:
>     - Reduced top margin from `mt-10` to `mt-4` in `index.tsx` for compactness.
>     - Aligned button section items to start and wrapped download stats with dropdown button.
>     - Moved floating robot image lower by changing position from `bottom-0` to `-bottom-10`.
>   - **Statistics Display**:
>     - Replaced dynamic Discord presence count with static `15k+` in three places, commented out dynamic code.
>     - Added download count display below dropdown button, showing total downloads prominently.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for d1c8cd2dc9a0d953cf2c9bca773b1c4532970a95. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->