### PR TITLE
docs: update redirect links

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -97,6 +97,23 @@
 /docs/server-examples/n8n	                    /docs/desktop/server-examples/n8n 302
 /docs/server-troubleshooting	                /docs/desktop/troubleshooting 302
 /docs/privacy-policy	                        /privacy 302
+/docs/server-settings 	                        /docs/desktop/server-settings 302
+/docs/settings	                                /docs/desktop/settings 302
+/docs/llama-cpp-server	                        /docs/desktop/llama-cpp-server 302
+/docs/server-settings 	                        /docs/desktop/server-settings 302
+/docs/install/linux	                            /docs/desktop/install/linux 302
+/docs/install/macos	                            /docs/desktop/install/mac 302
+/docs/install/windows	                        /docs/desktop/install/windows 302
+/docs/mcp-examples/browser/browserbase	        /docs/desktop/mcp-examples/browser/browserbase 302
+/docs/jan-models/jan-nano-128	                /docs/desktop/jan-models/jan-nano-128 302
+/docs/mcp-examples/search/serper	            /docs/desktop/mcp-examples/search/serper 302
+/docs/mcp-examples/data-analysis/jupyter	    /docs/desktop/mcp-examples/data-analysis/jupyter 302
+/docs/mcp-examples/productivity/todoist	        /docs/desktop/mcp-examples/productivity/todoist 302
+/docs/mcp-examples/search/serper	            /docs/desktop/mcp-examples/search/serper 302
+/docs/remote-models/anthropic	                /docs/desktop/remote-models/anthropic 302
+/docs/remote-models/openrouter	                /docs/desktop/remote-models/openrouter 302
+/docs/server-examples/llmcord	                /docs/desktop/server-examples/llmcord 302
+/docs/server-examples/tabby	                    /docs/desktop/server-examples/tabby 302
 
 /guides/integrations/continue/                  /docs/desktop/server-examples/continue-dev 302
 /continue-dev                                   /docs/desktop/server-examples/continue-dev 302

--- a/docs/_redirects
+++ b/docs/_redirects
@@ -100,7 +100,6 @@
 /docs/server-settings 	                        /docs/desktop/server-settings 302
 /docs/settings	                                /docs/desktop/settings 302
 /docs/llama-cpp-server	                        /docs/desktop/llama-cpp-server 302
-/docs/server-settings 	                        /docs/desktop/server-settings 302
 /docs/install/linux	                            /docs/desktop/install/linux 302
 /docs/install/macos	                            /docs/desktop/install/mac 302
 /docs/install/windows	                        /docs/desktop/install/windows 302
@@ -109,7 +108,6 @@
 /docs/mcp-examples/search/serper	            /docs/desktop/mcp-examples/search/serper 302
 /docs/mcp-examples/data-analysis/jupyter	    /docs/desktop/mcp-examples/data-analysis/jupyter 302
 /docs/mcp-examples/productivity/todoist	        /docs/desktop/mcp-examples/productivity/todoist 302
-/docs/mcp-examples/search/serper	            /docs/desktop/mcp-examples/search/serper 302
 /docs/remote-models/anthropic	                /docs/desktop/remote-models/anthropic 302
 /docs/remote-models/openrouter	                /docs/desktop/remote-models/openrouter 302
 /docs/server-examples/llmcord	                /docs/desktop/server-examples/llmcord 302


### PR DESCRIPTION
This pull request adds several new redirects to the `docs/_redirects` file to ensure that documentation links are correctly routed to their updated locations under the `/docs/desktop/` path. This helps users find the relevant documentation even if they use older URLs.

Documentation redirect updates:

* Added redirects for various documentation pages (such as `server-settings`, `settings`, `llama-cpp-server`, installation guides, and multiple example/model pages) to their new locations under `/docs/desktop/`, ensuring users are directed to the correct updated docs.
<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Adds new redirects in `docs/_redirects` to route old documentation URLs to updated paths under `/docs/desktop/`.
> 
>   - **Redirects**:
>     - Added new redirects in `docs/_redirects` for pages like `server-settings`, `settings`, `llama-cpp-server`, installation guides, and various example/model pages.
>     - Redirects point to updated paths under `/docs/desktop/`, ensuring users are directed to the correct documentation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=menloresearch%2Fjan&utm_source=github&utm_medium=referral)<sup> for eeaaf5ce0d033b5cef7f71b747aff4c66c2f79e7. You can [customize](https://app.ellipsis.dev/menloresearch/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->