### PR TITLE
fix: thread rerender due to thread scrolling padding subscription

### DIFF
--- a/web-app/src/containers/ThreadPadding.tsx
+++ b/web-app/src/containers/ThreadPadding.tsx
@@ -1,0 +1,19 @@
+import { useThreadScrolling } from '@/hooks/useThreadScrolling'
+
+export const ThreadPadding = ({
+  threadId,
+  scrollContainerRef,
+}: {
+  threadId: string
+  scrollContainerRef: React.RefObject<HTMLDivElement | null>
+}) => {
+  // Get padding height for ChatGPT-style message positioning
+  const { paddingHeight } = useThreadScrolling(threadId, scrollContainerRef)
+  return (
+    <div
+      style={{ height: paddingHeight }}
+      className="flex-shrink-0"
+      data-testid="chat-padding"
+    />
+  )
+}

--- a/web-app/src/routes/threads/$threadId.tsx
+++ b/web-app/src/routes/threads/$threadId.tsx
@@ -21,7 +21,7 @@ import { PlatformFeatures } from '@/lib/platform/const'
 import { PlatformFeature } from '@/lib/platform/types'
 import ScrollToBottom from '@/containers/ScrollToBottom'
 import { PromptProgress } from '@/components/PromptProgress'
-import { useThreadScrolling } from '@/hooks/useThreadScrolling'
+import { ThreadPadding } from '@/containers/ThreadPadding'
 
 // as route.threadsDetail
 export const Route = createFileRoute('/threads/$threadId')({
@@ -48,9 +48,6 @@ function ThreadDetail() {
   // Subscribe directly to the thread data to ensure updates when model changes
   const thread = useThreads(useShallow((state) => state.threads[threadId]))
   const scrollContainerRef = useRef<HTMLDivElement>(null)
-
-  // Get padding height for ChatGPT-style message positioning
-  const { paddingHeight } = useThreadScrolling(threadId, scrollContainerRef)
 
   useEffect(() => {
     setCurrentThreadId(threadId)
@@ -191,11 +188,7 @@ function ThreadDetail() {
               data-test-id="thread-content-text"
             />
             {/* Persistent padding element for ChatGPT-style message positioning */}
-            <div
-              style={{ height: paddingHeight }}
-              className="flex-shrink-0"
-              data-testid="chat-padding"
-            />
+           <ThreadPadding threadId={threadId} scrollContainerRef={scrollContainerRef} />
           </div>
         </div>
         <div


### PR DESCRIPTION
## Describe Your Changes

This pull request updates the handling of padding for ChatGPT-style message positioning in the thread detail view. The key change involves moving the padding logic into a separate `ThreadPadding` component, ensuring the Thread screen no longer subscribes to an expensive hook.

**Component extraction and usage:**

* Created a new `ThreadPadding` component in `web-app/src/containers/ThreadPadding.tsx` that encapsulates the logic for calculating and rendering padding height for thread messages.
* Replaced the inline padding element in the thread detail view with the new `ThreadPadding` component, simplifying the `ThreadDetail` function and removing direct usage of `useThreadScrolling`. [[1]](diffhunk://#diff-bfcfadc1ba1eb61eb68741d61cc9626423144789e607bf7d475dfe1a3a95d389L52-L54) [[2]](diffhunk://#diff-bfcfadc1ba1eb61eb68741d61cc9626423144789e607bf7d475dfe1a3a95d389L194-R191)

**Code cleanup:**

* Removed unnecessary imports and direct logic related to thread scrolling from `web-app/src/routes/threads/$threadId.tsx`, further streamlining the file.

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
