### PR TITLE
docs: update missing redirect links

### DIFF
--- a/docs/_redirects
+++ b/docs/_redirects
@@ -112,6 +112,9 @@
 /docs/remote-models/openrouter	                /docs/desktop/remote-models/openrouter 302
 /docs/server-examples/llmcord	                /docs/desktop/server-examples/llmcord 302
 /docs/server-examples/tabby	                    /docs/desktop/server-examples/tabby 302
+/docs/built-in/tensorrt-llm                     /docs/desktop/llama-cpp 302
+/docs/desktop/docs/desktop/linux                /docs/desktop/install/linux 302
+/windows                                        /docs/desktop/install/windows 302
 
 /guides/integrations/continue/                  /docs/desktop/server-examples/continue-dev 302
 /continue-dev                                   /docs/desktop/server-examples/continue-dev 302


### PR DESCRIPTION
This pull request adds several new redirects to the documentation site to improve navigation and ensure users are directed to the correct pages.

Documentation redirects:

* Added a redirect from `/docs/built-in/tensorrt-llm` to `/docs/desktop/llama-cpp` to consolidate related documentation.
* Added a redirect from `/docs/desktop/docs/desktop/linux` to `/docs/desktop/install/linux` to point users to the correct Linux installation instructions.
* Added a redirect from `/windows` to `/docs/desktop/install/windows` to guide users to the Windows installation documentation.