### PR TITLE
feat: Disable text selection on Toaster

### DIFF
--- a/web-app/src/providers/ToasterProvider.tsx
+++ b/web-app/src/providers/ToasterProvider.tsx
@@ -13,11 +13,15 @@ export function ToasterProvider() {
           alignItems: 'start',
           borderColor:
             'color-mix(in oklch, var(--app-main-view) 5%, transparent)',
+          userSelect: 'none',
+          WebkitUserSelect: 'none',
+          MozUserSelect: 'none',
+          msUserSelect: 'none',
         },
         classNames: {
-          toast: 'toast',
-          title: '!text-main-view/90',
-          description: '!text-main-view/70',
+          toast: 'toast select-none',
+          title: '!text-main-view/90 select-none',
+          description: '!text-main-view/70 select-none',
         },
       }}
     />


### PR DESCRIPTION
## Describe Your Changes

- Disable the option to select text on the Toaster to differentiate from the swiping action on the toast to dismiss it

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
