### PR TITLE
fix: remove Jan prefix from blog post titles for better SEO

### DIFF
--- a/docs/theme.config.tsx
+++ b/docs/theme.config.tsx
@@ -107,14 +107,15 @@ const config: DocsThemeConfig = {
   head: function useHead() {
     const { title, frontMatter } = useConfig()
     const { asPath } = useRouter()
-    const titleTemplate =
-      (asPath.includes('/desktop')
+    const titleTemplate = asPath.includes('/post/')
+      ? (frontMatter?.title || title)
+      : (asPath.includes('/desktop')
         ? 'Jan Desktop'
         : asPath.includes('/server')
           ? 'Jan Server'
           : 'Jan') +
-      ' - ' +
-      (frontMatter?.title || title)
+        ' - ' +
+        (frontMatter?.title || title)
 
     return (
       <Fragment>


### PR DESCRIPTION
- Blog posts now use only frontmatter title without 'Jan -' prefix
- Other pages maintain existing branding (Jan Desktop, Jan Server, Jan)
- Improves SEO for blog content while preserving site branding

## Describe Your Changes

-

## Fixes Issues

- Closes #
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
