### PR TITLE
fix: should not allow duplicating model

### DIFF
--- a/web-app/src/containers/dialogs/AddModel.tsx
+++ b/web-app/src/containers/dialogs/AddModel.tsx
@@ -17,6 +17,7 @@ import { getProviderTitle } from '@/lib/utils'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 import { ModelCapabilities } from '@/types/models'
 import { models as providerModels } from 'token.js'
+import { toast } from 'sonner'
 
 type DialogAddModelProps = {
   provider: ModelProvider
@@ -37,8 +38,13 @@ export const DialogAddModel = ({ provider, trigger }: DialogAddModelProps) => {
 
   // Handle form submission
   const handleSubmit = () => {
-    if (!modelId.trim()) {
-      return // Don't submit if model ID is empty
+    if (!modelId.trim()) return // Don't submit if model ID is empty
+
+    if (provider.models.some((e) => e.id === modelId)) {
+      toast.error(t('providers:addModel.modelExists'), {
+        description: t('providers:addModel.modelExistsDesc'),
+      })
+      return // Don't submit if model ID already exists
     }
 
     // Create the new model

--- a/web-app/src/locales/de-DE/providers.json
+++ b/web-app/src/locales/de-DE/providers.json
@@ -35,7 +35,9 @@
     "modelId": "Modell ID",
     "enterModelId": "Modell ID eingeben",
     "exploreModels": "Sehe Modellliste von {{provider}}",
-    "addModel": "Modell hinzufügen"
+    "addModel": "Modell hinzufügen",
+    "modelExists": "Modell bereits vorhanden",
+    "modelExistsDesc": "Bitte wähle eine andere Modell-ID."
   },
   "deleteModel": {
     "title": "Lösche Modell: {{modelId}}",

--- a/web-app/src/locales/en/providers.json
+++ b/web-app/src/locales/en/providers.json
@@ -35,7 +35,9 @@
     "modelId": "Model ID",
     "enterModelId": "Enter model ID",
     "exploreModels": "See model list from {{provider}}",
-    "addModel": "Add Model"
+    "addModel": "Add Model",
+    "modelExists": "Model already exists",
+    "modelExistsDesc": "Please choose a different model ID."
   },
   "deleteModel": {
     "title": "Delete Model: {{modelId}}",

--- a/web-app/src/locales/id/providers.json
+++ b/web-app/src/locales/id/providers.json
@@ -35,7 +35,9 @@
     "modelId": "ID Model",
     "enterModelId": "Masukkan ID model",
     "exploreModels": "Lihat daftar model dari {{provider}}",
-    "addModel": "Tambah Model"
+    "addModel": "Tambah Model",
+    "modelExists": "Model sudah ada",
+    "modelExistsDesc": "Silakan pilih ID model yang berbeda."
   },
   "deleteModel": {
     "title": "Hapus Model: {{modelId}}",

--- a/web-app/src/locales/pl/providers.json
+++ b/web-app/src/locales/pl/providers.json
@@ -35,7 +35,9 @@
     "modelId": "Identyfikator Modelu",
     "enterModelId": "Wprowadź identyfikator modelu",
     "exploreModels": "Zobacz listę modeli dostawcy {{provider}}",
-    "addModel": "Dodaj Model"
+    "addModel": "Dodaj Model",
+    "modelExists": "Model już istnieje",
+    "modelExistsDesc": "Wybierz inny identyfikator modelu."
   },
   "deleteModel": {
     "title": "Usuń Model: {{modelId}}",

--- a/web-app/src/locales/vn/providers.json
+++ b/web-app/src/locales/vn/providers.json
@@ -35,7 +35,9 @@
     "modelId": "ID mô hình",
     "enterModelId": "Nhập ID mô hình",
     "exploreModels": "Xem danh sách mô hình từ {{provider}}",
-    "addModel": "Thêm mô hình"
+    "addModel": "Thêm mô hình",
+    "modelExists": "Mô hình đã tồn tại",
+    "modelExistsDesc": "Vui lòng chọn một ID mô hình khác."
   },
   "deleteModel": {
     "title": "Xóa mô hình: {{modelId}}",

--- a/web-app/src/locales/zh-CN/providers.json
+++ b/web-app/src/locales/zh-CN/providers.json
@@ -35,7 +35,9 @@
     "modelId": "模型 ID",
     "enterModelId": "输入模型 ID",
     "exploreModels": "查看 {{provider}} 的模型列表",
-    "addModel": "添加模型"
+    "addModel": "添加模型",
+    "modelExists": "模型已存在",
+    "modelExistsDesc": "请选择不同的模型 ID。"
   },
   "deleteModel": {
     "title": "删除模型：{{modelId}}",

--- a/web-app/src/locales/zh-TW/providers.json
+++ b/web-app/src/locales/zh-TW/providers.json
@@ -35,7 +35,9 @@
     "modelId": "模型 ID",
     "enterModelId": "輸入模型 ID",
     "exploreModels": "查看 {{provider}} 的模型清單",
-    "addModel": "新增模型"
+    "addModel": "新增模型",
+    "modelExists": "模型已存在",
+    "modelExistsDesc": "請選擇不同的模型 ID。"
   },
   "deleteModel": {
     "title": "刪除模型：{{modelId}}",


### PR DESCRIPTION
This pull request improves the user experience when adding a new model by preventing duplicate model IDs and providing localized error messages. The main changes are an added check in the add model dialog to detect existing model IDs and new translations for the error message in multiple languages.

- Closes #6631
<img width="1728" height="1330" alt="CleanShot 2025-09-30 at 12 20 27@2x" src="https://github.com/user-attachments/assets/7eafa6b0-54a0-4fac-954c-6f9b543a2c84" />

**User experience improvements:**

* Added a check in `DialogAddModel` (`AddModel.tsx`) to prevent users from adding a model with an ID that already exists, displaying an error toast if a duplicate is detected.
* Integrated the `sonner` toast library to show error notifications in the add model dialog.

**Localization updates:**

* Added new translation keys for the duplicate model ID error (`modelExists`, `modelExistsDesc`) in English, German, Indonesian, Polish, Vietnamese, Simplified Chinese, and Traditional Chinese locale files. [[1]](diffhunk://#diff-e6998bc966825f098c29013565a7bc25cd0ad2d867cdc887ed805ebc1a424cb3L38-R40) [[2]](diffhunk://#diff-a307366d0694ae727d93e427a7afd7ee96daee4a8e07fe7016ad004674ec1eddL38-R40) [[3]](diffhunk://#diff-dc533f2bab318b10e1c2c54dc2ef5d1ac1ccfb44eaffbc5a5cef73c1d3820f87L38-R40) [[4]](diffhunk://#diff-7818e0f0aadba4d048ae67530de18bf0129bed96938c2002ff018efacea9aa38L38-R40) [[5]](diffhunk://#diff-e45e50930d2781a9da520c0dccb2a791215ab680e601396be66b3e9eeb3172f3L38-R40) [[6]](diffhunk://#diff-6ba7458d238ce09eb354b35b5904c6ae88330b8f0e9642fe5df7ad1166645804L38-R40) [[7]](diffhunk://#diff-cc04873b05524dbfeda39465f5870288cb9f99818becce248f343623cca7ce4bL38-R40)