### PR TITLE
fix: chat completion usage - token speed

### DIFF
--- a/web-app/src/hooks/useAppState.ts
+++ b/web-app/src/hooks/useAppState.ts
@@ -38,6 +38,11 @@ type AppState = {
   updateTools: (tools: MCPTool[]) => void
   setAbortController: (threadId: string, controller: AbortController) => void
   updateTokenSpeed: (message: ThreadMessage, increment?: number) => void
+  setTokenSpeed: (
+    message: ThreadMessage,
+    speed: number,
+    completionTokens: number
+  ) => void
   resetTokenSpeed: () => void
   clearAppState: () => void
   setOutOfContextDialog: (show: boolean) => void
@@ -93,6 +98,17 @@ export const useAppState = create<AppState>()((set) => ({
       abortControllers: {
         ...state.abortControllers,
         [threadId]: controller,
+      },
+    }))
+  },
+  setTokenSpeed: (message, speed, completionTokens) => {
+    set((state) => ({
+      tokenSpeed: {
+        ...state.tokenSpeed,
+        lastTimestamp: new Date().getTime(),
+        tokenSpeed: speed,
+        tokenCount: completionTokens,
+        message: message.id,
       },
     }))
   },

--- a/web-app/src/hooks/useChat.ts
+++ b/web-app/src/hooks/useChat.ts
@@ -19,7 +19,10 @@ import {
 } from '@/lib/completion'
 import { CompletionMessagesBuilder } from '@/lib/messages'
 import { renderInstructions } from '@/lib/instructionTemplate'
-import { ChatCompletionMessageToolCall } from 'openai/resources'
+import {
+  ChatCompletionMessageToolCall,
+  CompletionUsage,
+} from 'openai/resources'
 
 import { useServiceHub } from '@/hooks/useServiceHub'
 import { useToolApproval } from '@/hooks/useToolApproval'
@@ -42,6 +45,7 @@ export const useChat = () => {
     updateStreamingContent,
     updateLoadingModel,
     setAbortController,
+    setTokenSpeed,
   ] = useAppState(
     useShallow((state) => [
       state.updateTokenSpeed,
@@ -49,6 +53,7 @@ export const useChat = () => {
       state.updateStreamingContent,
       state.updateLoadingModel,
       state.setAbortController,
+      state.setTokenSpeed,
     ])
   )
   const updatePromptProgress = useAppState(
@@ -333,6 +338,8 @@ export const useChat = () => {
           let accumulatedText = ''
           const currentCall: ChatCompletionMessageToolCall | null = null
           const toolCalls: ChatCompletionMessageToolCall[] = []
+          const timeToFirstToken = Date.now()
+          let tokenUsage: CompletionUsage | undefined = undefined
           try {
             if (isCompletionResponse(completion)) {
               const message = completion.choices[0]?.message
@@ -347,6 +354,9 @@ export const useChat = () => {
 
               if (message?.tool_calls) {
                 toolCalls.push(...message.tool_calls)
+              }
+              if ('usage' in completion) {
+                tokenUsage = completion.usage
               }
             } else {
               // High-throughput scheduler: batch UI updates on rAF (requestAnimationFrame)
@@ -384,7 +394,14 @@ export const useChat = () => {
                     }
                   )
                   updateStreamingContent(currentContent)
-                  if (pendingDeltaCount > 0) {
+                  if (tokenUsage) {
+                    setTokenSpeed(
+                      currentContent,
+                      tokenUsage.completion_tokens /
+                        Math.max((Date.now() - timeToFirstToken) / 1000, 1),
+                      tokenUsage.completion_tokens
+                    )
+                  } else if (pendingDeltaCount > 0) {
                     updateTokenSpeed(currentContent, pendingDeltaCount)
                   }
                   pendingDeltaCount = 0
@@ -413,7 +430,14 @@ export const useChat = () => {
                   }
                 )
                 updateStreamingContent(currentContent)
-                if (pendingDeltaCount > 0) {
+                if (tokenUsage) {
+                  setTokenSpeed(
+                    currentContent,
+                    tokenUsage.completion_tokens /
+                      Math.max((Date.now() - timeToFirstToken) / 1000, 1),
+                    tokenUsage.completion_tokens
+                  )
+                } else if (pendingDeltaCount > 0) {
                   updateTokenSpeed(currentContent, pendingDeltaCount)
                 }
                 pendingDeltaCount = 0
@@ -443,6 +467,10 @@ export const useChat = () => {
                         ? (part.message as string)
                         : (JSON.stringify(part) ?? '')
                     )
+                  }
+
+                  if ('usage' in part && part.usage) {
+                    tokenUsage = part.usage
                   }
 
                   if (part.choices[0]?.delta?.tool_calls) {


### PR DESCRIPTION
## Describe Your Changes

Some of remote providers stream chunked completion instead of token by token. This PR is to extract token usage at the end of the stream to display proper token speed. 

Formula: Total Completion Token / (Current Time - Time To First Token in seconds)

https://github.com/user-attachments/assets/45d85a6c-5490-439c-8f46-fea5650bc7eb

Note: 
I planned to add a tokenizer, but it's costly and incompatible with most models and providers, so I skipped it.

## Fixes Issues

- Closes #6289

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
