### PR TITLE
ci: revert upload msi to github release

### DIFF
--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -252,13 +252,3 @@ jobs:
           asset_path: ./src-tauri/target/release/bundle/nsis/${{ steps.metadata.outputs.FILE_NAME }}
           asset_name: ${{ steps.metadata.outputs.FILE_NAME }}
           asset_content_type: application/octet-stream
-      - name: Upload release assert if public provider is github
-        if: inputs.public_provider == 'github'
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        uses: actions/upload-release-asset@v1.0.1
-        with:
-          upload_url: ${{ inputs.upload_url }}
-          asset_path: ./src-tauri/target/release/bundle/msi/${{ steps.metadata.outputs.MSI_FILE_NAME  }}
-          asset_name: ${{ steps.metadata.outputs.MSI_FILE_NAME  }}
-          asset_content_type: application/octet-stream


### PR DESCRIPTION
## Describe Your Changes

This pull request makes a small change to the Windows build workflow by removing a step that uploaded the MSI release asset to GitHub if the public provider was set to GitHub. This simplifies the release process and reduces unnecessary upload actions.
