### PR TITLE
ci: remove upload msi artifact

### DIFF
--- a/.github/workflows/template-tauri-build-windows-x64.yml
+++ b/.github/workflows/template-tauri-build-windows-x64.yml
@@ -273,8 +273,6 @@ jobs:
           # Upload for tauri updater
           aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}
           aws s3 cp ./${{ steps.metadata.outputs.FILE_NAME }}.sig s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.FILE_NAME }}.sig
-
-          aws s3 cp ./src-tauri/target/release/bundle/msi/${{ steps.metadata.outputs.MSI_FILE_NAME }} s3://${{ secrets.DELTA_AWS_S3_BUCKET_NAME }}/temp-${{ inputs.channel }}/${{ steps.metadata.outputs.MSI_FILE_NAME }}
         env:
           AWS_ACCESS_KEY_ID: ${{ secrets.DELTA_AWS_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.DELTA_AWS_SECRET_ACCESS_KEY }}


### PR DESCRIPTION
This pull request makes a minor update to the Windows x64 build workflow by removing an unnecessary step that uploaded the MSI installer file to the S3 bucket.

* Workflow update:
  * [`.github/workflows/template-tauri-build-windows-x64.yml`](diffhunk://#diff-c71636a16c635e7d32fdd0e3bebc3d7d5a2e90d1871995f8dc03f8d2a5bf63a8L276-L277): Removed the command that uploads the MSI file (`${{ steps.metadata.outputs.MSI_FILE_NAME }}`) to S3, streamlining the deployment process.