### PR TITLE
chore: fix new chat with update last selected model dropdown

### DIFF
--- a/web-app/src/containers/DropdownModelProvider.tsx
+++ b/web-app/src/containers/DropdownModelProvider.tsx
@@ -228,12 +228,11 @@ const DropdownModelProvider = ({
     selectModelProvider,
     updateCurrentThreadModel,
     providers,
-    useLastUsedModel,
     checkModelExists,
     updateProvider,
     getProviderByName,
     checkAndUpdateModelVisionCapability,
-    serviceHub,
+
     // selectedModel and selectedProvider intentionally excluded to prevent race conditions
   ])
 
@@ -326,7 +325,8 @@ const DropdownModelProvider = ({
   // Create Fzf instance for fuzzy search
   const fzfInstance = useMemo(() => {
     return new Fzf(searchableItems, {
-      selector: (item) => `${getModelDisplayName(item.model)} ${item.model.id}`.toLowerCase(),
+      selector: (item) =>
+        `${getModelDisplayName(item.model)} ${item.model.id}`.toLowerCase(),
     })
   }, [searchableItems])
 
@@ -404,12 +404,10 @@ const DropdownModelProvider = ({
       })
 
       // Store the selected model as last used
-      if (useLastUsedModel) {
-        setLastUsedModel(
-          searchableModel.provider.provider,
-          searchableModel.model.id
-        )
-      }
+      setLastUsedModel(
+        searchableModel.provider.provider,
+        searchableModel.model.id
+      )
 
       // Check mmproj existence for llamacpp models (async, don't block UI)
       if (searchableModel.provider.provider === 'llamacpp') {
@@ -443,7 +441,6 @@ const DropdownModelProvider = ({
     [
       selectModelProvider,
       updateCurrentThreadModel,
-      useLastUsedModel,
       updateProvider,
       getProviderByName,
       checkAndUpdateModelVisionCapability,


### PR DESCRIPTION
## Describe Your Changes

This pull request streamlines the logic for storing the last used model in the `DropdownModelProvider` component in `web-app/src/containers/DropdownModelProvider.tsx`. The main change is the removal of the `useLastUsedModel` flag, simplifying the code and ensuring the last used model is always updated without conditional checks.

### Logic simplification

* Removed the `useLastUsedModel` flag from the dependency arrays of several `useCallback` and `useEffect` hooks, reducing unnecessary complexity and potential for race conditions. [[1]](diffhunk://#diff-c2c9bb4171fbcfe7f094df2d1c84e275b36e6193bb6138e5dd30779eaf990facL231-R235) [[2]](diffhunk://#diff-c2c9bb4171fbcfe7f094df2d1c84e275b36e6193bb6138e5dd30779eaf990facL446)
* Updated the logic for storing the last used model: the model is now always stored when selected, without checking the `useLastUsedModel` flag. This makes the behavior more predictable and easier to maintain.

## Fixes Issues


https://github.com/user-attachments/assets/e12c83f6-f649-4edb-90f0-f5c3bdb5af28



- Closes #6542 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
