### PR TITLE
fix: title recent when no result found

### DIFF
--- a/web-app/src/containers/LeftPanel.tsx
+++ b/web-app/src/containers/LeftPanel.tsx
@@ -154,7 +154,6 @@ const LeftPanel = () => {
     }
   }, [setLeftPanel, open])
 
-
   const currentPath = useRouterState({
     select: (state) => state.location.pathname,
   })
@@ -581,6 +580,10 @@ const LeftPanel = () => {
 
                 {filteredThreads.length === 0 && searchTerm.length > 0 && (
                   <div className="px-1 mt-2">
+                    <span className="block text-xs text-left-panel-fg/50 px-1 font-semibold mb-2">
+                      {t('common:recents')}
+                    </span>
+
                     <div className="flex items-center gap-1 text-left-panel-fg/80">
                       <IconSearch size={18} />
                       <h6 className="font-medium text-base">


### PR DESCRIPTION
## Describe Your Changes

This pull request introduces a minor UI improvement to the `Left#6684 ` component in the web app. The main change is the addition of a "Recents" label to enhance the clarity of the recent threads section when no search results are found.

UI enhancements:

* Added a "Recents" label above the recent threads list when the search returns no results, improving the user experience and clarity in the `LeftPanel` component (`web-app/src/containers/LeftPanel.tsx`).

## Fixes Issues

<img width="248" height="400" alt="Screenshot 2025-10-06 at 11 36 09" src="https://github.com/user-attachments/assets/e581638f-bc31-43ff-8890-cdeed94f717d" />
<img width="256" height="330" alt="Screenshot 2025-10-06 at 11 35 59" src="https://github.com/user-attachments/assets/22fc09b1-8113-4be9-84d2-ab03a155a9ca" />
<img width="238" height="344" alt="Screenshot 2025-10-06 at 11 35 49" src="https://github.com/user-attachments/assets/ae589a7d-9ac3-419a-a4a1-61450d1dc01b" />


- Closes #6691 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
