### PR TITLE
fix: font mono default from mcp json ediitor

### DIFF
--- a/web-app/src/containers/dialogs/AddEditMCPServer.tsx
+++ b/web-app/src/containers/dialogs/AddEditMCPServer.tsx
@@ -421,13 +421,12 @@ export default function AddEditMCPServer({
                   }}
                   onPaste={() => setError(null)}
                   style={{
-                    fontFamily: 'ui-monospace',
                     backgroundColor: 'transparent',
                     wordBreak: 'break-all',
                     overflowWrap: 'anywhere',
                     whiteSpace: 'pre-wrap',
                   }}
-                  className="w-full !text-sm min-h-[300px]"
+                  className="w-full !text-sm min-h-[300px] !font-mono"
                 />
               </div>
               {error && <div className="text-destructive text-sm">{error}</div>}

--- a/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
+++ b/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
@@ -98,7 +98,7 @@ export default function EditJsonMCPserver({
                 overflowWrap: 'anywhere',
                 whiteSpace: 'pre-wrap',
               }}
-              className="w-full !text-sm overflow-hidden !break-all font-mono"
+              className="w-full !text-sm overflow-hidden !break-all !font-mono"
             />
           </div>
           {error && <div className="text-destructive text-sm">{error}</div>}

--- a/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
+++ b/web-app/src/containers/dialogs/EditJsonMCPserver.tsx
@@ -93,13 +93,12 @@ export default function EditJsonMCPserver({
               onChange={(e) => setJsonContent(e.target.value)}
               onPaste={handlePaste}
               style={{
-                fontFamily: 'ui-monospace',
                 backgroundColor: 'transparent',
                 wordBreak: 'break-all',
                 overflowWrap: 'anywhere',
                 whiteSpace: 'pre-wrap',
               }}
-              className="w-full !text-sm overflow-hidden break-all"
+              className="w-full !text-sm overflow-hidden !break-all font-mono"
             />
           </div>
           {error && <div className="text-destructive text-sm">{error}</div>}


### PR DESCRIPTION
## Describe Your Changes

This pull request makes minor improvements to the styling of text areas in the `AddEditMCPServer` and `EditJsonMCPserver` dialog components. The main change is standardizing the monospace font usage by relying on the `font-mono` Tailwind CSS utility class instead of setting the font family inline.

Styling improvements:

* Replaced the inline `fontFamily: 'ui-monospace'` style with the Tailwind CSS `!font-mono` class for the text area in `AddEditMCPServer` (`AddEditMCPServer.tsx`) and added `!font-mono` to the class list.
* Replaced the inline `fontFamily: 'ui-monospace'` style with the Tailwind CSS `font-mono` class for the text area in `EditJsonMCPserver` (`EditJsonMCPserver.tsx`) and added `font-mono` to the class list.

## Fixes Issues

<img width="1070" height="870" alt="Screenshot 2025-10-07 220946" src="https://github.com/user-attachments/assets/2be0478a-9f04-4ee3-ad50-bfc643ab3c14" />


- Closes #6686 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
