### PR TITLE
fix: remove setup screen on project id to make same behavior with thread

### DIFF
--- a/web-app/src/routes/project/$projectId.tsx
+++ b/web-app/src/routes/project/$projectId.tsx
@@ -3,12 +3,10 @@ import { useMemo } from 'react'
 
 import { useThreadManagement } from '@/hooks/useThreadManagement'
 import { useThreads } from '@/hooks/useThreads'
-import { useModelProvider } from '@/hooks/useModelProvider'
 import { useTranslation } from '@/i18n/react-i18next-compat'
 
 import ChatInput from '@/containers/ChatInput'
 import HeaderPage from '@/containers/HeaderPage'
-import SetupScreen from '@/containers/SetupScreen'
 import ThreadList from '@/containers/ThreadList'
 import DropdownAssistant from '@/containers/DropdownAssistant'
 
@@ -26,7 +24,6 @@ export const Route = createFileRoute('/project/$projectId')({
 function ProjectPage() {
   const { t } = useTranslation()
   const { projectId } = useParams({ from: '/project/$projectId' })
-  const { providers } = useModelProvider()
   const { getFolderById } = useThreadManagement()
   const threads = useThreads((state) => state.threads)
 
@@ -42,18 +39,6 @@ function ProjectPage() {
       .filter((thread) => thread.metadata?.project?.id === projectId)
       .sort((a, b) => (b.updated || 0) - (a.updated || 0))
   }, [threads, projectId])
-
-  // Conditional to check if there are any valid providers
-  const hasValidProviders = providers.some(
-    (provider) =>
-      provider.api_key?.length ||
-      (provider.provider === 'llamacpp' && provider.models.length) ||
-      (provider.provider === 'jan' && provider.models.length)
-  )
-
-  if (!hasValidProviders) {
-    return <SetupScreen />
-  }
 
   if (!project) {
     return (
@@ -93,7 +78,9 @@ function ProjectPage() {
               {projectThreads.length > 0 && (
                 <>
                   <h2 className="text-xl font-semibold text-main-view-fg mb-2">
-                    {t('projects.conversationsIn', { projectName: project.name })}
+                    {t('projects.conversationsIn', {
+                      projectName: project.name,
+                    })}
                   </h2>
                   <p className="text-main-view-fg/70">
                     {t('projects.conversationsDescription')}
@@ -105,7 +92,11 @@ function ProjectPage() {
             {/* Thread List or Empty State */}
             <div className="mb-0">
               {projectThreads.length > 0 ? (
-                <ThreadList threads={projectThreads} variant="project" currentProjectId={projectId} />
+                <ThreadList
+                  threads={projectThreads}
+                  variant="project"
+                  currentProjectId={projectId}
+                />
               ) : (
                 <div className="flex flex-col items-center justify-center py-12 text-center">
                   <IconMessage
@@ -113,10 +104,14 @@ function ProjectPage() {
                     className="text-main-view-fg/30 mb-4"
                   />
                   <h3 className="text-lg font-medium text-main-view-fg/60 mb-2">
-                    {t('projects.noConversationsIn', { projectName: project.name })}
+                    {t('projects.noConversationsIn', {
+                      projectName: project.name,
+                    })}
                   </h3>
                   <p className="text-main-view-fg/50 text-sm">
-                    {t('projects.startNewConversation', { projectName: project.name })}
+                    {t('projects.startNewConversation', {
+                      projectName: project.name,
+                    })}
                   </p>
                 </div>
               )}


### PR DESCRIPTION
## Describe Your Changes

Issue 
<img width="1108" height="590" alt="Screenshot 2025-10-08 at 12 32 50" src="https://github.com/user-attachments/assets/1825f4d3-cbf0-4af9-bbbb-9ab31a8c7265" />

This pull request simplifies the `ProjectPage` component by removing the logic that checks for valid model providers and the related conditional rendering of the `SetupScreen`. It also makes minor formatting improvements to translation calls and component props for better readability.

Removed provider setup logic:

* Removed the import and usage of `useModelProvider`, as well as the conditional check for valid providers and the rendering of the `SetupScreen`. This means the page no longer blocks access if no valid model providers are configured. [[1]](diffhunk://#diff-c4becbb96b4eb40557e814e24de46f3616a7f9aabdec87cddcf9b4c97ff77a63L6-L11) [[2]](diffhunk://#diff-c4becbb96b4eb40557e814e24de46f3616a7f9aabdec87cddcf9b4c97ff77a63L29) [[3]](diffhunk://#diff-c4becbb96b4eb40557e814e24de46f3616a7f9aabdec87cddcf9b4c97ff77a63L46-L57)

Formatting and readability improvements:

* Reformatted translation (`t`) calls and the `ThreadList` component props to improve code readability and maintain consistency. [[1]](diffhunk://#diff-c4becbb96b4eb40557e814e24de46f3616a7f9aabdec87cddcf9b4c97ff77a63L96-R83) [[2]](diffhunk://#diff-c4becbb96b4eb40557e814e24de46f3616a7f9aabdec87cddcf9b4c97ff77a63L108-R114)

## Fixes Issues


<img width="1127" height="351" alt="Screenshot 2025-10-08 at 12 44 08" src="https://github.com/user-attachments/assets/836273bc-4bff-4d80-8928-912d35ced7a5" />


- Closes #6684 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
