### PR TITLE
chore: turn off zoomHotkeysEnabled

### DIFF
--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -13,7 +13,6 @@
     "macOSPrivateApi": true,
     "windows": [
       {
-        "zoomHotkeysEnabled": true,
         "label": "main",
         "title": "Jan",
         "width": 1024,
@@ -40,7 +39,12 @@
       }
     ],
     "security": {
-      "capabilities": ["default", "logs-app-window", "logs-window", "system-monitor-window"],
+      "capabilities": [
+        "default",
+        "logs-app-window",
+        "logs-window",
+        "system-monitor-window"
+      ],
       "csp": {
         "default-src": "'self' customprotocol: asset: http://localhost:* http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:*",
         "connect-src": "ipc: http://ipc.localhost http://127.0.0.1:* ws://localhost:* ws://127.0.0.1:* https: http:",


### PR DESCRIPTION
## Describe Your Changes

This pull request contains minor configuration changes to the `src-tauri/tauri.conf.json` file. The most notable update is the removal of the `zoomHotkeysEnabled` property from the Windows window configuration.

Configuration updates:

* Removed the `zoomHotkeysEnabled` property from the Windows window configuration, which may affect zoom hotkey functionality on Windows builds.
* Reformatted the `capabilities` array in the `security` section for improved readability, without changing its contents.

## Fixes Issues

- Closes #6466 
- Closes #

## Self Checklist

- [ ] Added relevant comments, esp in complex areas
- [ ] Updated docs (for bug fixes / features)
- [ ] Created issues for follow-up changes or refactoring needed
