### PR TITLE
chore: api change domain to menlo.ai

### DIFF
--- a/.github/workflows/jan-server-web-ci-dev.yml
+++ b/.github/workflows/jan-server-web-ci-dev.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
     env:
-      JAN_API_BASE: "https://api-dev.jan.ai/v1"
+      JAN_API_BASE: "https://api-dev.menlo.ai/v1"
     permissions:
       pull-requests: write
       contents: write

--- a/.github/workflows/jan-server-web-ci-prod.yml
+++ b/.github/workflows/jan-server-web-ci-prod.yml
@@ -13,7 +13,7 @@ jobs:
       deployments: write
       pull-requests: write
     env:
-      JAN_API_BASE: "https://api.jan.ai/v1"
+      JAN_API_BASE: "https://api.menlo.ai/v1"
       GA_MEASUREMENT_ID: "G-YK53MX8M8M"
       CLOUDFLARE_PROJECT_NAME: "jan-server-web"
     steps:

--- a/.github/workflows/jan-server-web-ci-stag.yml
+++ b/.github/workflows/jan-server-web-ci-stag.yml
@@ -12,7 +12,7 @@ jobs:
   build-and-preview:
     runs-on: [ubuntu-24-04-docker]
     env:
-      JAN_API_BASE: "https://api-stag.jan.ai/v1"
+      JAN_API_BASE: "https://api-stag.menlo.ai/v1"
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
This pull request updates the API base URLs in the CI workflow configuration files to use the new `menlo.ai` domain instead of `jan.ai`. This ensures that all development, staging, and production environments point to the correct API endpoints.

**CI Workflow Configuration Updates:**

* Updated the `JAN_API_BASE` environment variable in `.github/workflows/jan-server-web-ci-dev.yml` to use `https://api-dev.menlo.ai/v1` for development builds.
* Updated the `JAN_API_BASE` environment variable in `.github/workflows/jan-server-web-ci-stag.yml` to use `https://api-stag.menlo.ai/v1` for staging builds.
* Updated the `JAN_API_BASE` environment variable in `.github/workflows/jan-server-web-ci-prod.yml` to use `https://api.menlo.ai/v1` for production builds.