### PR TITLE
chore: update license path

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,8 +31,8 @@
     "build:android": "yarn build:icon && yarn copy:assets:mobile && cross-env IS_CLEAN=true yarn tauri android build -- --no-default-features --features mobile",
     "build:ios": "yarn build:icon && yarn copy:assets:mobile && cross-env IS_IOS=true yarn tauri ios build -- --no-default-features --features mobile",
     "build:ios:device": "yarn build:icon && yarn copy:assets:mobile && cross-env IS_IOS=true yarn tauri ios build -- --no-default-features --features mobile --export-method debugging",
-    "copy:assets:tauri": "cpx \"pre-install/*.tgz\" \"src-tauri/resources/pre-install/\" && cpx \"LICENSE\" \"src-tauri/resources/\"",
-    "copy:assets:mobile": "cpx \"pre-install/*.tgz\" \"src-tauri/resources/pre-install/\" && cpx \"LICENSE\" \"src-tauri/resources/\"",
+    "copy:assets:tauri": "cpx \"pre-install/*.tgz\" \"src-tauri/resources/pre-install/\"",
+    "copy:assets:mobile": "cpx \"pre-install/*.tgz\" \"src-tauri/resources/pre-install/\"",
     "download:lib": "node ./scripts/download-lib.mjs",
     "download:bin": "node ./scripts/download-bin.mjs",
     "build:tauri:win32": "yarn download:bin && yarn tauri build",
@@ -68,6 +68,5 @@
     "yallist": "4.0.0",
     "@types/react": "19.1.2",
     "@types/react-dom": "19.1.2"
-  },
-  "packageManager": "yarn@4.5.3"
+  }
 }

--- a/src-tauri/tauri.android.conf.json
+++ b/src-tauri/tauri.android.conf.json
@@ -15,8 +15,7 @@
   "bundle": {
     "active": true,
     "resources": [
-      "resources/pre-install/**/*",
-      "resources/LICENSE"
+      "resources/pre-install/**/*"
     ],
     "externalBin": [],
     "android": {

--- a/src-tauri/tauri.bundle.windows.nsis.template
+++ b/src-tauri/tauri.bundle.windows.nsis.template
@@ -697,7 +697,6 @@ Section Install
     CreateDirectory "$INSTDIR\resources"
     CreateDirectory "$INSTDIR\resources\pre-install"
     SetOutPath $INSTDIR
-    File /a "/oname=LICENSE" "D:\a\jan\jan\src-tauri\resources\LICENSE"
     SetOutPath "$INSTDIR\resources\pre-install"
     File /nonfatal /a /r "D:\a\jan\jan\src-tauri\resources\pre-install\"
     SetOutPath $INSTDIR
@@ -820,9 +819,6 @@ Section Uninstall
   ; Delete the app directory and its content from disk
   ; Copy main executable
   Delete "$INSTDIR\${MAINBINARYNAME}.exe"
-
-  ; Delete LICENSE file
-    Delete "$INSTDIR\LICENSE"
 
   ; Delete resources
     Delete "$INSTDIR\resources\pre-install\janhq-assistant-extension-1.0.2.tgz"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -76,6 +76,7 @@
     }
   },
   "bundle": {
+    "licenseFile": "../LICENSE",
     "publisher": "Menlo Research Pte. Ltd.",
     "active": true,
     "createUpdaterArtifacts": false,
@@ -85,7 +86,6 @@
       "icons/128x128@2x.png",
       "icons/icon.icns",
       "icons/icon.ico"
-    ],
-    "resources": ["resources/LICENSE"]
+    ]
   }
 }

--- a/src-tauri/tauri.ios.conf.json
+++ b/src-tauri/tauri.ios.conf.json
@@ -18,8 +18,7 @@
       "developmentTeam": "<DEVELOPMENT_TEAM_ID>"
     },
     "resources": [
-      "resources/pre-install/**/*",
-      "resources/LICENSE"
+      "resources/pre-install/**/*"
     ],
     "externalBin": []
   }

--- a/src-tauri/tauri.linux.conf.json
+++ b/src-tauri/tauri.linux.conf.json
@@ -11,7 +11,7 @@
   },
   "bundle": {
     "targets": ["deb", "appimage"],
-    "resources": ["resources/pre-install/**/*", "resources/LICENSE"],
+    "resources": ["resources/pre-install/**/*"],
     "externalBin": ["resources/bin/uv"],
     "linux": {
       "appimage": {

--- a/src-tauri/tauri.macos.conf.json
+++ b/src-tauri/tauri.macos.conf.json
@@ -11,7 +11,7 @@
   },
   "bundle": {
     "targets": ["app", "dmg"],
-    "resources": ["resources/pre-install/**/*", "resources/LICENSE"],
+    "resources": ["resources/pre-install/**/*"],
     "externalBin": ["resources/bin/bun", "resources/bin/uv"]
   }
 }

--- a/src-tauri/tauri.windows.conf.json
+++ b/src-tauri/tauri.windows.conf.json
@@ -13,8 +13,7 @@
   "bundle": {
     "targets": ["nsis", "msi"],
     "resources": [
-      "resources/pre-install/**/*",
-      "resources/LICENSE"
+      "resources/pre-install/**/*"
     ],
     "externalBin": ["resources/bin/bun", "resources/bin/uv"],
     "windows": {


### PR DESCRIPTION
This pull request removes the inclusion and installation of the `LICENSE` file from the build and packaging process for all platforms. Instead, the license file is now referenced via the `licenseFile` property in the main Tauri configuration, which is the recommended approach for distributing license information. The changes streamline asset copying scripts, update resource lists in platform-specific configuration files, and clean up installer templates.